### PR TITLE
Clarify distinction between integration and native-integration commands

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -9,8 +9,8 @@ Key terms used across the Cargo CLI skills.
 **actionSlug**
 A string identifier for a specific action on a workflow node. Present on both `kind: "native"` and `kind: "connector"` nodes.
 
-- **Native nodes** — built-in actions discovered via `cargo-ai connection native-integration get` (keys of the `actions` object): `start`, `end`, `branch`, `filter`, `variables`, `agent`, `python`, `script`, etc.
-- **Connector nodes** — integration-specific actions discovered via `cargo-ai connection integration list` and the integration's action catalog. Examples: `company_enrich`, `create_contact`, `send_message`.
+- **Native nodes** — built-in Cargo actions discovered via `cargo-ai connection native-integration get` (keys of the `actions` object): `start`, `end`, `branch`, `filter`, `variables`, `agent`, `python`, `script`, etc. These are generic platform actions, not third-party service actions.
+- **Connector nodes** — third-party service-specific actions discovered via `cargo-ai connection integration get <slug>` (e.g. `integration get hubspot`). Examples: `company_enrich`, `create_contact`, `send_message`. **Do not use `native-integration get` for these** — it will not return HubSpot, Salesforce, or other connector-specific actions.
 
 **agent**
 An AI resource with configured instructions, a language model, and optional tools. Created and configured via `cargo-cli-ai`. Used in workflows as a `kind: "agent"` node, or messaged directly via `cargo-cli-orchestration`.

--- a/SKILL.md
+++ b/SKILL.md
@@ -198,7 +198,8 @@ cargo-ai storage relationship set --from-model-uuid <uuid> --to-model-uuid <uuid
 ```bash
 cargo-ai connection connector list
 cargo-ai connection integration list
-cargo-ai connection native-integration get       # discover available actions
+cargo-ai connection integration get <slug>          # third-party actions (HubSpot, Salesforce, etc.)
+cargo-ai connection native-integration get          # built-in Cargo actions only (NOT third-party)
 ```
 
 **Key concepts:**
@@ -299,7 +300,7 @@ Most `cargo-cli-orchestration` operations require UUIDs from other skills. This 
 | `segmentUuid`   | `segmentation segment list`                | `batch create --data '{"kind":"segment",...}'`                          |
 | `agentUuid`     | `ai agent list`                            | `ai chat create`, node graph (`kind: "agent"`)                          |
 | `connectorUuid` | `connection connector list`                | Node graph (`kind: "connector"`), `billing usage --connector-uuid`      |
-| `actionSlug`    | `connection native-integration get`        | Node graph (`kind: "connector"`)                                        |
+| `actionSlug`    | `connection integration get <slug>` (third-party) or `connection native-integration get` (built-in) | Node graph (`kind: "connector"` or `kind: "native"`) |
 | `releaseUuid`   | `orchestration batch get` → `.releaseUuid` | `orchestration release get`, `batch download`                           |
 | `batchUuid`     | `orchestration batch create`               | `batch get`, `batch download`, `run get-metrics --batch-uuid`           |
 | `folderUuid`    | `workspace folder list`                    | `play list --folder-uuid`, `tool list --folder-uuid`                    |
@@ -338,10 +339,10 @@ cargo-ai segmentation segment list
 **Skills needed:** `cargo-cli-storage`, `cargo-cli-connection`, `cargo-cli-orchestration`, `cargo-cli-analytics`
 
 ```
-1. storage model get-ddl          → get exact table name
-2. connection connector list       → get enrichment + CRM connector UUIDs
-3. connection native-integration get       → discover action slugs
-4. orchestration tool list         → find the enrichment tool
+1. storage model get-ddl                   → get exact table name
+2. connection connector list               → get enrichment + CRM connector UUIDs
+3. connection integration get <slug>       → discover third-party action slugs (e.g. HubSpot, Clearbit)
+4. orchestration tool list                 → find the enrichment tool
 5. orchestration batch create      → run on a segment of companies
 6. orchestration batch get         → poll until status is terminal
 7. analytics run download          → export results
@@ -366,7 +367,7 @@ cargo-ai segmentation segment list
 
 ```
 1. connection connector list               → get connector UUID
-2. connection native-integration get      → get actionSlug
+2. connection integration get <slug>       → get actionSlug for the third-party service
 3. orchestration node validate --nodes     → validate graph before running
 4. orchestration run create --nodes        → run with custom node graph
 5. orchestration run get                   → poll to terminal state

--- a/cargo-cli-connection/SKILL.md
+++ b/cargo-cli-connection/SKILL.md
@@ -120,7 +120,7 @@ cargo-ai connection integration list --has-actions true
 # Only integrations that have extractors (can sync data into models)
 cargo-ai connection integration list --has-extractors true
 
-# Get details for a native integration (includes available actions and extractors)
+# Get built-in Cargo actions and extractors (NOT third-party connector actions)
 cargo-ai connection native-integration get
 ```
 
@@ -141,7 +141,7 @@ cargo-ai connection connector list
 cargo-ai connection integration get <integration-slug>
 # → actions are keyed by actionSlug, with config.jsonSchema for each
 # → Or use get-documentation for a plain text overview
-# → Or use native-integration get for native actions
+# → Or use native-integration get for built-in Cargo actions (not third-party)
 
 # 3. Reference the connector and action in a node graph
 # See cargo-cli-orchestration references/nodes.md for the full node syntax

--- a/cargo-cli-connection/SKILL.md
+++ b/cargo-cli-connection/SKILL.md
@@ -42,8 +42,20 @@ Failed commands exit non-zero and return `{"errorMessage": "..."}`.
 cargo-ai connection connector list                        # all authenticated connectors
 cargo-ai connection integration list                      # all available integration types
 cargo-ai connection integration list --search "hubspot"   # search by name
-cargo-ai connection native-integration get                # native actions and extractors
+cargo-ai connection integration get <slug>                # third-party-specific actions (e.g. HubSpot)
+cargo-ai connection native-integration get                # built-in Cargo actions only (NOT third-party)
 ```
+
+### `integration get` vs `native-integration get`
+
+These two commands return **different sets of actions** and are not interchangeable:
+
+| Command | What it returns | When to use |
+|---|---|---|
+| `integration get <slug>` | Actions specific to a third-party service (e.g. HubSpot contact CRUD, deal management, Salesforce queries) | When you need service-specific actions to use in a connector node — **use this for HubSpot, Salesforce, Clearbit, etc.** |
+| `native-integration get` | Generic built-in Cargo actions (e.g. HTTP requests, data transforms, internal utilities) | When you need Cargo-native capabilities that don't belong to any specific third-party connector |
+
+**Example:** To find HubSpot-specific actions, use `integration get hubspot` — not `native-integration get`. The latter will only return generic actions unrelated to HubSpot.
 
 ## Quick reference
 
@@ -114,7 +126,7 @@ cargo-ai connection native-integration get
 
 **Integration categories:** `engagement`, `marketing`, `sales`, `finance`, `analytics`, `freeform`, `success`, `support`, `enrichment`, `storage`, `custom`.
 
-Use `native-integration get` to discover all native actions available in your workspace. Actions are referenced by `actionSlug` in workflow node graphs (see the `cargo-cli-orchestration` skill's `references/nodes.md`).
+Use `integration get <slug>` to discover all actions available for a specific third-party service (e.g. HubSpot, Salesforce). Use `native-integration get` only for built-in Cargo actions — it does **not** return HubSpot or other service-specific actions. Actions are referenced by `actionSlug` in workflow node graphs (see the `cargo-cli-orchestration` skill's `references/nodes.md`).
 
 ## Using connector actions in workflows
 

--- a/cargo-cli-connection/references/examples/integrations.md
+++ b/cargo-cli-connection/references/examples/integrations.md
@@ -55,13 +55,29 @@ cargo-ai connection integration get-documentation hubspot
 
 Returns plain text documentation for the integration, including available actions and their configuration.
 
-## Discover native actions and extractors
+## Discover actions for a specific integration (e.g. HubSpot)
+
+```bash
+cargo-ai connection integration get hubspot
+# → Returns HubSpot-specific actions (e.g. "create_contact", "update_deal") and extractors
+# → Each action includes its config.jsonSchema for building workflow nodes
+
+cargo-ai connection integration get-documentation hubspot
+# → Plain text overview of all HubSpot actions
+```
+
+**Use `integration get <slug>` when you need service-specific actions** — HubSpot, Salesforce, Clearbit, etc.
+
+## Discover native (built-in Cargo) actions and extractors
 
 ```bash
 cargo-ai connection native-integration get
-# → actions: keyed by actionSlug (e.g. "company_enrich", "send_email")
+# → Returns built-in Cargo actions ONLY — NOT HubSpot or other third-party actions
+# → actions: keyed by actionSlug (generic platform utilities)
 # → extractors: keyed by extractor slug
 ```
+
+**Important:** `native-integration get` does **not** return HubSpot-specific or other third-party connector actions. To get those, use `integration get <slug>` instead.
 
 Use `actionSlug` values in workflow node configs (see `cargo-cli-orchestration/references/nodes.md`).
 

--- a/cargo-cli-connection/references/response-shapes.md
+++ b/cargo-cli-connection/references/response-shapes.md
@@ -139,13 +139,15 @@ Returns the full integration object, including all actions and extractors with t
 
 ## cargo-ai connection native-integration get
 
+> **Note:** This command returns **built-in Cargo actions only** (e.g. `start`, `end`, `branch`, `filter`, `agent`, `python`). It does **not** return HubSpot, Salesforce, Clearbit, or other third-party connector actions. For those, use `cargo-ai connection integration get <slug>`.
+
 ```json
 {
   "nativeIntegration": {
     "actions": {
-      "company_enrich": {
-        "name": "Company Enrich",
-        "description": "Enrich a company record",
+      "send_email": {
+        "name": "Send Email",
+        "description": "Send an email via the native Cargo email action",
         "category": "enrichment",
         "icon": "https://...",
         "isSerialized": false,

--- a/cargo-cli-connection/references/troubleshooting.md
+++ b/cargo-cli-connection/references/troubleshooting.md
@@ -18,12 +18,12 @@ Common errors and recovery steps for `cargo-cli-connection` commands.
 | `connector create` fails                | Integration slug doesn't exist                   | Run `integration list` to find valid `integrationSlug` values                                    |
 | `connector remove` fails                | Connector is referenced by active plays or tools | Check `playsCount` and `toolsCount` on the connector; remove or update dependent resources first |
 | Workflow fails with connector not found | Connector UUID in node graph is wrong            | Re-run `connector list` to verify the UUID used in the node config                               |
-| Action not executing as expected        | Wrong `actionSlug`                               | Run `native-integration get` to see the correct `actions[].slug` values                   |
+| Action not executing as expected        | Wrong `actionSlug`                               | For third-party connector actions (HubSpot, Salesforce, etc.), run `integration get <slug>` to see correct `actionSlug` values. Only use `native-integration get` for built-in Cargo actions. |
 
 ## Integrations
 
 | Symptom                                                 | Cause                                                         | Fix                                                             |
 | ------------------------------------------------------- | ------------------------------------------------------------- | --------------------------------------------------------------- |
 | `integration list` doesn't show an expected integration | Integration may not be available in your region or plan       | Contact Cargo support or check the integrations page in the app |
-| `native-integration get` returns not found              | Wrong integration slug                                        | Use `integration list` to confirm the exact slug                |
+| Third-party actions (e.g. HubSpot) not found via `native-integration get` | `native-integration get` only returns built-in Cargo actions | Use `integration get <slug>` (e.g. `integration get hubspot`) to get service-specific actions |
 | OAuth flow incomplete                                   | `complete-oauth` not called after creating an OAuth connector | Complete the OAuth flow through the Cargo app UI or via the API |


### PR DESCRIPTION
## Summary
Updated documentation to clearly distinguish between `integration get <slug>` (third-party service-specific actions) and `native-integration get` (built-in Cargo actions only). This addresses potential confusion about which command to use when discovering actions for specific connectors like HubSpot or Salesforce.

## Key Changes
- **integrations.md**: 
  - Renamed "Discover native actions and extractors" section to "Discover native (built-in Cargo) actions and extractors" for clarity
  - Added new section "Discover actions for a specific integration (e.g. HubSpot)" with examples of `integration get <slug>` usage
  - Added explicit warning that `native-integration get` does NOT return third-party connector actions
  - Clarified that `integration get <slug>` should be used for service-specific actions (HubSpot, Salesforce, Clearbit, etc.)

- **SKILL.md**:
  - Updated command reference to include `integration get <slug>` example
  - Added new "integration get vs native-integration get" comparison table explaining when to use each command
  - Included concrete example: "To find HubSpot-specific actions, use `integration get hubspot` — not `native-integration get`"
  - Updated existing documentation note to emphasize the distinction and clarify that `native-integration get` does not return service-specific actions

## Notable Details
The changes use clear visual formatting (tables, bold text, code examples) to help users quickly understand the correct command to use based on their needs. The documentation now explicitly states that these commands return "different sets of actions" and are "not interchangeable."

https://claude.ai/code/session_01HwnBQbYmkMtCkC9kasEGnv