### PR TITLE
Add template-first guidance throughout CLI documentation

### DIFF
--- a/cargo-cli-ai/SKILL.md
+++ b/cargo-cli-ai/SKILL.md
@@ -74,6 +74,13 @@ cargo-ai ai memory remove --mem0-id <id> --scope agent --agent-uuid <uuid>
 
 Agents are AI resources with configured instructions, a language model, tools, and optional resources.
 
+**Before creating an agent from scratch, check existing templates — they capture proven patterns for common use cases (lead research, classification, email drafting) and give you a ready-made system prompt, model, and temperature to start from:**
+
+```bash
+cargo-ai ai template list          # browse available patterns
+cargo-ai ai template get <slug>    # inspect system prompt, model, and tools
+```
+
 ```bash
 # List all agents
 cargo-ai ai agent list
@@ -136,24 +143,25 @@ cargo-ai ai release deploy-draft --agent-uuid <uuid> \
 
 **Agent configuration workflow:**
 
-1. Create the agent: `cargo-ai ai agent create --name "..." --icon-color blue --icon-face 🤖`
-2. Get the draft release: `cargo-ai ai release get-draft --agent-uuid <uuid>`
-3. Update the draft with tools, resources, prompt, model: `cargo-ai ai release update-draft --agent-uuid <uuid> ...`
-4. Deploy: `cargo-ai ai release deploy-draft --agent-uuid <uuid> ...`
+1. **Browse templates for inspiration**: `cargo-ai ai template list` — find a template close to your use case, then `cargo-ai ai template get <slug>` to see its system prompt, model, and temperature
+2. Create the agent: `cargo-ai ai agent create --name "..." --icon-color blue --icon-face 🤖`
+3. Get the draft release: `cargo-ai ai release get-draft --agent-uuid <uuid>`
+4. Update the draft with tools, resources, prompt, model: `cargo-ai ai release update-draft --agent-uuid <uuid> ...`
+5. Deploy: `cargo-ai ai release deploy-draft --agent-uuid <uuid> ...`
 
 ## Templates
 
-Templates are pre-built agent configurations. Use them to bootstrap agents with proven patterns.
+Templates are pre-built agent configurations that capture proven patterns for common use cases. **Always check templates before designing an agent from scratch** — they give you a ready-made system prompt, recommended language model, temperature, and tool configuration that you can adopt as-is or adapt.
 
 ```bash
 # List available agent templates
 cargo-ai ai template list
 
-# Get a template by slug
+# Get a template by slug — inspect its system prompt, model, and settings
 cargo-ai ai template get <slug>
 ```
 
-Templates include a system prompt, tools, resources, and recommended model settings. Use these as a starting point and customize via `release update-draft`.
+Templates include a system prompt, tools, resources, and recommended model settings. Use them as a starting point and customize via `release update-draft`. See `references/examples/templates.md` for the full guide including an end-to-end example of creating an agent from a template.
 
 ## Model and temperature guidance
 

--- a/cargo-cli-ai/references/examples/templates.md
+++ b/cargo-cli-ai/references/examples/templates.md
@@ -4,6 +4,11 @@
 
 An **AI template** is a pre-built agent configuration — a ready-to-use agent blueprint with instructions, model settings, and tool configuration already defined. Templates capture common agent patterns (lead research, company classification, email drafting) so you don't have to configure an agent from scratch.
 
+**Always check templates before creating an agent.** Even if no template is a perfect match, they provide:
+- A proven system prompt structure for the use case
+- A recommended language model and temperature setting
+- A list of tools and resources to consider attaching
+
 AI templates are read-only. You discover them by listing, then use their configuration as a starting point when creating or updating an agent.
 
 ## List all AI templates

--- a/cargo-cli-orchestration/SKILL.md
+++ b/cargo-cli-orchestration/SKILL.md
@@ -67,6 +67,8 @@ cargo-ai connection connector list         # all connectors
 
 **Plays vs tools:** Both are backed by a workflow. A **play** is a segment-driven automation — it reacts to data changes in a segment (records added, updated, removed). A **tool** is an on-demand workflow — triggered manually, via API, or on a cron schedule. Workflows don't have a `name` field; use `play list` or `tool list` to find names and extract the `workflowUuid`.
 
+**Designing a new tool or play?** Check templates first — they are pre-built node graphs for common automation patterns (enrichment pipelines, CRM syncs, lead scoring) and are an excellent starting point. List templates with `cargo-ai orchestration template list` and inspect a specific one with `cargo-ai orchestration template get <slug>`. Templates are tagged by `kind` so you can find ones suited for tools (`"kind":"tool"`) or plays (`"kind":"play"`) right away. See `references/templates.md` for the full guide.
+
 **Compatibility rules:**
 
 - **`run create`** — only works with **tool** workflows (or no `workflowUuid`). Play workflows return `playNotCompatible`.
@@ -245,7 +247,9 @@ cargo-ai segmentation segment remove <segment-uuid>
 
 ## Use a workflow template
 
-Templates are pre-built node graphs for common automation patterns. Use them to bootstrap a run without building nodes from scratch.
+Templates are pre-built node graphs for common automation patterns. They serve two purposes:
+- **Inspiration when building** — browse templates to understand how to structure a new tool or play, then copy and adapt the node graph into your draft release
+- **Bootstrap a run** — plug a template's nodes directly into `run create` or `batch create` without touching the tool's stored definition
 
 ```bash
 cargo-ai orchestration template list              # list available templates

--- a/cargo-cli-orchestration/references/plays.md
+++ b/cargo-cli-orchestration/references/plays.md
@@ -68,6 +68,8 @@ cargo-ai orchestration batch create \
 
 To change what a play does, update its draft release and deploy it. The draft release holds the unpublished node graph for the workflow.
 
+> **Looking for inspiration?** Before designing a node graph from scratch, check `cargo-ai orchestration template list` for pre-built patterns (lead scoring, enrichment pipelines, CRM syncs). Use `cargo-ai orchestration template get <slug>` to copy a ready-made node graph and adapt it instead of starting from zero. Templates tagged `"kind":"play"` are designed for segment-driven automations.
+
 ```bash
 # Step 1 — Find the play and its workflowUuid
 cargo-ai orchestration play list

--- a/cargo-cli-orchestration/references/templates.md
+++ b/cargo-cli-orchestration/references/templates.md
@@ -2,9 +2,12 @@
 
 ## What is a template?
 
-A **template** is a pre-built workflow blueprint — a ready-to-use node graph you can apply when creating a play or tool. Templates capture common automation patterns (enrichment pipelines, CRM syncs, AI research flows) so you don't have to build nodes from scratch.
+A **template** is a pre-built workflow blueprint — a ready-to-use node graph that captures common automation patterns (enrichment pipelines, CRM syncs, AI research flows, lead scoring). Templates serve two purposes:
 
-Templates are read-only. You discover them by slug, inspect their node graph and expected input schema, then use that graph as the `--nodes` value when creating a run or batch.
+1. **Design-time inspiration** — when building or updating a tool or play, browse templates to find one close to your use case, then copy its node graph into your draft release as a starting point instead of designing from scratch.
+2. **Runtime shortcut** — plug a template's nodes directly into `run create` or `batch create` via the `--nodes` flag without modifying the tool's stored definition.
+
+Templates are read-only. You discover them by slug, inspect their node graph and expected input schema, then either adapt the graph for a draft release or pass it directly as `--nodes` when creating a run or batch.
 
 ## List all templates
 
@@ -117,6 +120,41 @@ Response:
   }
 }
 ```
+
+## Use a template as inspiration when building a tool or play
+
+When creating or redesigning a tool or play, start with a template rather than building nodes from scratch. Copy the template's node graph into the draft release, replace any placeholders, then deploy.
+
+```bash
+# 1. Find a template that matches your use case
+cargo-ai orchestration template list
+# → Find "company-enrichment" (kind: "tool") or "lead-scoring" (kind: "play")
+
+# 2. Inspect the node graph — understand the structure and spot placeholders
+cargo-ai orchestration template get company-enrichment
+
+# 3. Fill in placeholders (connectorUuid, agentUuid, etc.) and validate
+cargo-ai orchestration node validate --nodes '[...modified nodes...]'
+# → { "outcome": "valid" }
+
+# 4. Find your tool's workflowUuid
+cargo-ai orchestration tool list
+# → Extract tool.workflowUuid
+
+# 5. Save the adapted nodes to the draft release
+cargo-ai orchestration draft-release update \
+  --workflow-uuid <tool.workflowUuid> \
+  --nodes '[...validated nodes...]'
+
+# 6. Deploy the draft release
+cargo-ai orchestration draft-release deploy \
+  --workflow-uuid <tool.workflowUuid> \
+  --nodes '[...validated nodes...]' \
+  --form-fields 'null' \
+  --description "Based on company-enrichment template"
+```
+
+> For plays, the same pattern applies — just use `play list` and replace `run create` with `batch create` in any test steps.
 
 ## Use a template to run a tool
 

--- a/cargo-cli-orchestration/references/tools.md
+++ b/cargo-cli-orchestration/references/tools.md
@@ -56,6 +56,8 @@ cargo-ai orchestration run create \
 
 To change what a tool does, update its draft release and deploy it. The draft release holds the unpublished node graph for the workflow.
 
+> **Looking for inspiration?** Before designing a node graph from scratch, check `cargo-ai orchestration template list` for pre-built patterns (enrichment pipelines, CRM syncs, AI research flows). Use `cargo-ai orchestration template get <slug>` to copy a ready-made node graph and adapt it instead of starting from zero. Templates tagged `"kind":"tool"` are designed for on-demand workflows.
+
 ```bash
 # Step 1 — Find the tool and its workflowUuid
 cargo-ai orchestration tool list


### PR DESCRIPTION
## Summary
This PR enhances documentation across the cargo-ai CLI to promote templates as a primary starting point for users building agents, tools, and plays. The changes emphasize that templates capture proven patterns and should be consulted before designing from scratch, rather than treating them as an afterthought.

## Key Changes

- **Orchestration templates guide** (`cargo-cli-orchestration/references/templates.md`):
  - Clarified the dual purpose of templates: design-time inspiration and runtime shortcuts
  - Added a new comprehensive section "Use a template as inspiration when building a tool or play" with step-by-step workflow for adapting templates into draft releases
  - Updated definition to highlight common patterns (enrichment pipelines, CRM syncs, AI research flows, lead scoring)

- **AI templates guide** (`cargo-cli-ai/references/examples/templates.md`):
  - Added emphasis that templates should always be checked before creating agents from scratch
  - Listed concrete benefits of templates even when not a perfect match (proven prompts, model recommendations, tool suggestions)

- **Orchestration skill documentation** (`cargo-cli-orchestration/SKILL.md`):
  - Added prominent guidance to check templates before designing new tools or plays
  - Clarified template discovery by `kind` tag (tool vs. play)
  - Updated "Use a workflow template" section to explain both inspiration and bootstrap use cases

- **AI skill documentation** (`cargo-cli-ai/SKILL.md`):
  - Added pre-creation template browsing step to agent configuration workflow
  - Inserted template discovery guidance before agent creation instructions
  - Enhanced Templates section to emphasize checking templates before designing from scratch
  - Added reference to full guide in examples

- **Tools and plays references** (`cargo-cli-orchestration/references/tools.md` and `plays.md`):
  - Added callout boxes suggesting template consultation before designing node graphs from scratch
  - Included template discovery commands and kind-based filtering hints

## Notable Details
- Changes maintain consistency across all documentation files
- Template-first messaging is positioned early in workflows, not as an afterthought
- Includes concrete command examples for discovering and inspecting templates
- Emphasizes that templates are useful even when not a perfect match

https://claude.ai/code/session_01PAWH33kjjB8d3doxfDvMw6