### PR TITLE
docs: fix SQL connector config, integration get command, and deploy --version gotcha

### DIFF
--- a/cargo-cli-connection/references/examples/integrations.md
+++ b/cargo-cli-connection/references/examples/integrations.md
@@ -37,36 +37,43 @@ cargo-ai connection integration list --search "hubspot"
 # → Use slug when creating connectors: --integration-slug <slug>
 ```
 
-## Get full integration details
+## Get full integration details (actions + config schemas)
 
 ```bash
-cargo-ai connection integration get clearbit
-# → Returns the full integration object with actions, extractors, and configuration schemas
+cargo-ai connection integration list --slug clearbit
+# → Returns the full integration object including .manifest.actions and their config.jsonSchema
 ```
 
-Use this to discover all available actions and extractors for an integration, including their `config.jsonSchema` for building workflow nodes.
+Use this to discover all available actions for an integration and the exact config fields each action expects. This is the authoritative source before building a connector node — field names vary between integrations and are not validated by `node validate`.
 
-## Get integration documentation
+```bash
+# Extract the config schema for a specific action
+cargo-ai connection integration list --slug sql | \
+  jq '.integrations[0].manifest.actions.upsertRecords.config.jsonSchema'
+```
+
+## Get integration documentation (plain text)
 
 ```bash
 cargo-ai connection integration get-documentation clearbit
 cargo-ai connection integration get-documentation hubspot
 ```
 
-Returns plain text documentation for the integration, including available actions and their configuration.
+Returns plain text documentation for the integration. Useful for a quick overview, but does not include machine-readable config schemas — use `integration list --slug <slug>` when you need the exact field names for node configs.
 
 ## Discover actions for a specific integration (e.g. HubSpot)
 
 ```bash
-cargo-ai connection integration get hubspot
-# → Returns HubSpot-specific actions (e.g. "create_contact", "update_deal") and extractors
-# → Each action includes its config.jsonSchema for building workflow nodes
+# Full manifest with action schemas
+cargo-ai connection integration list --slug hubspot
+# → .integrations[0].manifest.actions — keyed by actionSlug
+# → Each action includes .config.jsonSchema for building workflow nodes
 
+# Plain text overview
 cargo-ai connection integration get-documentation hubspot
-# → Plain text overview of all HubSpot actions
 ```
 
-**Use `integration get <slug>` when you need service-specific actions** — HubSpot, Salesforce, Clearbit, etc.
+**Use `integration list --slug <slug>` when you need service-specific action config schemas** — HubSpot, Salesforce, SQL, Clearbit, etc.
 
 ## Discover native (built-in Cargo) actions and extractors
 
@@ -114,5 +121,57 @@ cargo-ai connection integration get hubspot
 | HTTP (custom) | `http`         |
 | Slack         | `slack`        |
 | Google Sheets | `googleSheets` |
+| SQL (BigQuery, Snowflake, etc.) | `sql` |
 
 Run `integration list` for the complete current list.
+
+---
+
+## SQL integration — action config reference
+
+The SQL integration uses different field names from CRM connectors like Salesforce. Always use `integration list --slug sql` to confirm schemas, but the key actions are documented below.
+
+### `upsertRecords` — MERGE a row by matching column
+
+```json
+{
+  "kind": "connector",
+  "integrationSlug": "sql",
+  "actionSlug": "upsertRecords",
+  "connectorUuid": "<your-sql-connector-uuid>",
+  "config": {
+    "database": "my-bq-project",
+    "schema": "my_dataset",
+    "table": "my_table",
+    "matchingColumnSlug": "domain",
+    "matchingValue": {
+      "kind": "templateExpression",
+      "expression": "{{ nodes.start.domain }}",
+      "instructTo": "none",
+      "fromRecipe": false
+    },
+    "mappings": [
+      {
+        "columnSlug": "domain",
+        "value": {
+          "kind": "templateExpression",
+          "expression": "{{ nodes.start.domain }}",
+          "instructTo": "none",
+          "fromRecipe": false
+        }
+      },
+      {
+        "columnSlug": "parent_domain",
+        "value": {
+          "kind": "templateExpression",
+          "expression": "{{ nodes.start.parent_domain }}",
+          "instructTo": "none",
+          "fromRecipe": false
+        }
+      }
+    ]
+  }
+}
+```
+
+> **Note:** The target table is specified as three separate fields (`database`, `schema`, `table`) — not as a single `objectType` string. Using `objectType` passes `node validate` but leaves all three fields empty in the UI and fails at runtime.

--- a/cargo-cli-orchestration/references/tools.md
+++ b/cargo-cli-orchestration/references/tools.md
@@ -86,6 +86,8 @@ cargo-ai orchestration draft-release deploy \
 
 > **Do not skip validation.** Deploying an invalid node graph will cause runs to fail. Always run `node validate` before `draft-release deploy`.
 
+> **Do not pass `--version` to `draft-release deploy`.** Passing `--version` causes the command to exit 0 and print `"1.0.0"` without deploying anything — no error, no warning. Omit the flag entirely; the platform auto-assigns the next semantic version.
+
 ---
 
 ## Run a tool on a single record

--- a/cargo-cli-orchestration/references/troubleshooting.md
+++ b/cargo-cli-orchestration/references/troubleshooting.md
@@ -16,6 +16,7 @@ Common errors and recovery steps for `cargo-cli-orchestration` commands.
 
 | Symptom                             | Cause                                              | Fix                                                                                                         |
 | ----------------------------------- | -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `draft-release deploy` exits 0 but nothing deploys | `--version` flag was passed | Omit `--version` entirely — passing it causes a silent no-op. The platform assigns the version automatically. |
 | Run stuck in `pending`              | Workflow may be paused or have no deployed release | Check that the play/tool `isEnabled` is `true`; verify a release exists with `release list --workflow-uuid` |
 | Batch never finishes                | Individual runs may be erroring or stuck           | List runs for the batch: `run list --workflow-uuid <uuid> --batch-uuid <uuid>` and check for errors         |
 | `Workflow not found`                | Wrong UUID                                         | Re-run `play list` or `tool list` and double-check the `workflowUuid`                                       |
@@ -60,6 +61,31 @@ When a run reaches `status: "error"`, follow this sequence:
 
 4. **Re-trigger after fixing:** Create a new run with the corrected data or node config.
 5. **For systematic failures:** Use `run download --statuses error` to export all failed records, fix the data, then re-batch with `batch create --data '{"kind":"recordIds",...}'`.
+
+## Connector config field mismatches
+
+`node validate` only checks graph structure (node kinds, UUID links, required top-level fields). It does **not** validate the contents of each node's `config` object against the integration's JSON schema. A node can return `{ "outcome": "valid" }` while using entirely wrong field names — the misconfiguration only surfaces at runtime or in the UI.
+
+**The most common source of this:** copying config field names from one integration (e.g. Salesforce) into a different integration (e.g. SQL). Each integration has its own schema.
+
+**How to get the correct config schema before building a node:**
+
+```bash
+# Get the full integration manifest including action schemas
+cargo-ai connection integration list --slug <integration-slug>
+# → Look at .manifest.actions.<actionSlug>.config.jsonSchema for the exact fields
+```
+
+**Example — SQL vs Salesforce field name differences:**
+
+| Concept         | Salesforce (`upsertRecords`) | SQL (`upsertRecords`) |
+| --------------- | ---------------------------- | --------------------- |
+| Target table    | `objectType` (e.g. `"Account"`) | `database` + `schema` + `table` (separate fields) |
+| Match key name  | `matchingPropertyName`       | `matchingColumnSlug`  |
+| Match key value | `matchingValue`              | `matchingValue`       |
+| Column mappings | `mappings[].propertyName`    | `mappings[].columnSlug` |
+
+Using Salesforce-style fields on a SQL node passes validation but leaves the database, schema, and table empty in the UI — the upsert will fail at runtime.
 
 ## Batch sizing and third-party connector rate limits
 


### PR DESCRIPTION
## Summary

Three issues discovered while building Cargo tools in production (connecting a domain hierarchy workflow to BigQuery via the SQL connector).

### 1. SQL `upsertRecords` config schema was undocumented

The SQL connector uses different field names from CRM connectors. An agent building a SQL node from the existing docs will copy Salesforce-style field names, which pass `node validate` but silently misconfigure the node — the database, schema, and table appear empty in the UI and the upsert fails at runtime.

**Changes:**
- Add full `upsertRecords` node example with correct field names to `integrations.md`
- Add SQL to the common integration slugs table
- Add a "Connector config field mismatches" section to `troubleshooting.md` with a Salesforce vs SQL comparison table

### 2. `integration get <slug>` does not exist as a command

`integrations.md` referenced `cargo-ai connection integration get <slug>` in two places. That subcommand does not exist — the CLI returns `error: unknown command 'get'`. The correct way to get action config schemas is `integration list --slug <slug>`, which returns the full manifest including `manifest.actions.<actionSlug>.config.jsonSchema`.

**Changes:**
- Replace `integration get <slug>` with `integration list --slug <slug>` throughout
- Clarify that `get-documentation` returns plain text only, not machine-readable schemas

### 3. `draft-release deploy --version` is a silent no-op

Passing `--version` to `draft-release deploy` causes the command to exit 0 and print `"1.0.0"` without deploying anything. No error, no warning. The version should be omitted — the platform assigns it automatically.

**Changes:**
- Add a warning callout in the deploy step in `tools.md`
- Add a row to the troubleshooting table in `troubleshooting.md`

## Test plan

- [ ] Verify `cargo-ai connection integration list --slug sql` returns the manifest with `upsertRecords` config schema
- [ ] Verify `cargo-ai connection integration get <slug>` fails with "unknown command" (confirming the doc fix is accurate)
- [ ] Verify `draft-release deploy` without `--version` deploys correctly and auto-assigns version
- [ ] Verify `draft-release deploy --version x.y.z` exits 0 without deploying (confirming the gotcha is real)

🤖 Generated with [Claude Code](https://claude.com/claude-code)