### PR TITLE
Add connector autocomplete documentation and glossary entries

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -15,6 +15,9 @@ A string identifier for a specific action on a workflow node. Present on both `k
 **agent**
 An AI resource with configured instructions, a language model, and optional tools. Created and configured via `cargo-cli-ai`. Used in workflows as a `kind: "agent"` node, or messaged directly via `cargo-cli-orchestration`.
 
+**autocomplete**
+A mechanism to fetch the list of allowed values for an action config field at runtime. When an action's `uiSchema` marks a field with `"ui:widget": "IntegrationAutocompleteWidget"`, its valid values must be retrieved via `cargo-ai connection connector autocomplete --connector-uuid <uuid> --slug <slug> --params '<json>'`. The autocomplete slug and params come from the field's `ui:options` in the `uiSchema`. Returns `{ "results": [{ "label": "...", "value": "..." }] }` — use the `value` in node configs.
+
 ---
 
 ## B
@@ -217,6 +220,13 @@ A float between `0.0` and `1.0` controlling how deterministic an agent's respons
 
 **tool**
 An on-demand workflow triggered manually, via API, or on a cron schedule. Listed via `orchestration tool list`. Supports both `run create` (single record) and `batch create` (multiple records).
+
+---
+
+## U
+
+**uiSchema**
+A companion object to `jsonSchema` in action and extractor configs. While `jsonSchema` defines the types and structure of fields, `uiSchema` provides UI rendering hints. The most important hint for CLI usage is `"ui:widget": "IntegrationAutocompleteWidget"` — this signals that the field's allowed values must be fetched dynamically using `connector autocomplete` rather than set to a freeform value. The `ui:options.slug` identifies which autocomplete endpoint to call, and `ui:options.params` (if present) specifies dependencies on other fields. See `cargo-cli-connection` for the full autocomplete workflow.
 
 ---
 

--- a/cargo-cli-connection/SKILL.md
+++ b/cargo-cli-connection/SKILL.md
@@ -65,6 +65,7 @@ cargo-ai connection connector create --integration-slug <slug> --slug <slug> --n
 cargo-ai connection connector update --uuid <uuid> --name <name>
 cargo-ai connection connector remove <connector-uuid>
 cargo-ai connection connector get <connector-uuid>
+cargo-ai connection connector autocomplete --connector-uuid <uuid> --slug <slug> --params '<json>'
 cargo-ai connection integration list
 cargo-ai connection integration get <slug>
 cargo-ai connection integration get-documentation <slug>
@@ -127,6 +128,128 @@ cargo-ai connection native-integration get
 **Integration categories:** `engagement`, `marketing`, `sales`, `finance`, `analytics`, `freeform`, `success`, `support`, `enrichment`, `storage`, `custom`.
 
 Use `integration get <slug>` to discover all actions available for a specific third-party service (e.g. HubSpot, Salesforce). Use `native-integration get` only for built-in Cargo actions — it does **not** return HubSpot or other service-specific actions. Actions are referenced by `actionSlug` in workflow node graphs (see the `cargo-cli-orchestration` skill's `references/nodes.md`).
+
+## Connector autocomplete — fetching available values for action fields
+
+Some action fields don't accept freeform input — their allowed values must be fetched dynamically from the connector. When you inspect an action's config (via `integration get <slug>` or `native-integration get`), look at the `uiSchema` alongside the `jsonSchema`. If a field's `uiSchema` contains `"ui:widget": "IntegrationAutocompleteWidget"`, the valid values for that field **must** be retrieved using `connector autocomplete`.
+
+### How to detect autocomplete fields
+
+When an action's config looks like this:
+
+```json
+{
+  "jsonSchema": {
+    "type": "object",
+    "properties": {
+      "objectType": { "type": "string", "description": "The object type" }
+    }
+  },
+  "uiSchema": {
+    "objectType": {
+      "ui:widget": "IntegrationAutocompleteWidget",
+      "ui:options": {
+        "slug": "listObjects",
+        "allowRefresh": true
+      }
+    }
+  }
+}
+```
+
+The `objectType` field requires autocomplete. The `ui:options.slug` (`"listObjects"`) is the autocomplete slug you pass to `connector autocomplete`.
+
+### How to call connector autocomplete
+
+```bash
+cargo-ai connection connector autocomplete \
+  --connector-uuid <connector-uuid> \
+  --slug <autocomplete-slug> \
+  --params '{}'
+```
+
+| Flag               | Required | Description                                                       |
+| ------------------ | -------- | ----------------------------------------------------------------- |
+| `--connector-uuid` | yes      | The UUID of the connector to autocomplete against                 |
+| `--slug`           | yes      | The autocomplete slug from `uiSchema[field]["ui:options"].slug`   |
+| `--params`         | yes      | JSON object of parameters (use `{}` when none are needed)         |
+| `--value`          | no       | Search string to filter results                                   |
+| `--refresh`        | no       | Bypass cache and fetch fresh results                              |
+
+### Autocomplete with parameters
+
+Some autocomplete fields depend on the value of another field. This is indicated by a `params` object in `ui:options`:
+
+```json
+{
+  "uiSchema": {
+    "objectType": {
+      "ui:widget": "IntegrationAutocompleteWidget",
+      "ui:options": { "slug": "listObjects" }
+    },
+    "propertyName": {
+      "ui:widget": "IntegrationAutocompleteWidget",
+      "ui:options": {
+        "slug": "listObjectProperties",
+        "params": { "objectType": "$this.$parent.objectType" }
+      }
+    }
+  }
+}
+```
+
+Here, `propertyName` depends on the selected `objectType`. Replace the `$this.$parent...` expression with the actual value you chose:
+
+```bash
+# 1. First, get the list of object types
+cargo-ai connection connector autocomplete \
+  --connector-uuid <uuid> --slug listObjects --params '{}'
+
+# 2. Then, get properties for the chosen object type
+cargo-ai connection connector autocomplete \
+  --connector-uuid <uuid> --slug listObjectProperties \
+  --params '{"objectType": "contacts"}'
+```
+
+### Response format
+
+```json
+{
+  "results": [
+    { "label": "Contacts", "value": "contacts" },
+    { "label": "Companies", "value": "companies" },
+    { "label": "Deals", "value": "deals" }
+  ]
+}
+```
+
+Use the `value` field in your node config. The `label` is the human-readable display name. Results may also include optional `description` and `parent` fields.
+
+### End-to-end example: configuring a HubSpot action
+
+```bash
+# 1. Find your HubSpot connector UUID
+cargo-ai connection connector list --integration-slug hubspot
+
+# 2. Get HubSpot actions and inspect their config + uiSchema
+cargo-ai connection integration get hubspot
+# → The "findRecords" action has objectType with autocomplete slug "listObjects"
+
+# 3. Fetch available object types
+cargo-ai connection connector autocomplete \
+  --connector-uuid <hubspot-connector-uuid> \
+  --slug listObjects --params '{}'
+# → Returns: contacts, companies, deals, tickets, etc.
+
+# 4. Fetch properties for the chosen object type
+cargo-ai connection connector autocomplete \
+  --connector-uuid <hubspot-connector-uuid> \
+  --slug listObjectProperties \
+  --params '{"objectType": "contacts"}'
+# → Returns: email, firstname, lastname, phone, etc.
+
+# 5. Use these values in your workflow node config
+```
 
 ## Using connector actions in workflows
 

--- a/cargo-cli-connection/references/examples/connectors.md
+++ b/cargo-cli-connection/references/examples/connectors.md
@@ -74,6 +74,57 @@ cargo-ai connection connector list
 # → Check playsCount and toolsCount fields for each connector
 ```
 
+## Autocomplete — fetch available values for an action field
+
+When an action's `uiSchema` marks a field with `"ui:widget": "IntegrationAutocompleteWidget"`, use `connector autocomplete` to get the allowed values.
+
+```bash
+# Basic autocomplete (no params needed)
+cargo-ai connection connector autocomplete \
+  --connector-uuid <connector-uuid> \
+  --slug listObjects \
+  --params '{}'
+# → { "results": [{ "label": "Contacts", "value": "contacts" }, ...] }
+```
+
+## Autocomplete with dependent parameters
+
+Some fields depend on another field's value. Pass the dependency in `--params`:
+
+```bash
+# Get properties for a specific object type
+cargo-ai connection connector autocomplete \
+  --connector-uuid <connector-uuid> \
+  --slug listObjectProperties \
+  --params '{"objectType": "contacts"}'
+# → { "results": [{ "label": "Email", "value": "email" }, ...] }
+```
+
+## Autocomplete with search filtering
+
+Use `--value` to filter results by a search string:
+
+```bash
+cargo-ai connection connector autocomplete \
+  --connector-uuid <connector-uuid> \
+  --slug listObjectProperties \
+  --params '{"objectType": "contacts"}' \
+  --value "email"
+# → Returns only properties matching "email"
+```
+
+## Autocomplete with cache refresh
+
+Results are cached (default 30 minutes). Use `--refresh` to bypass the cache:
+
+```bash
+cargo-ai connection connector autocomplete \
+  --connector-uuid <connector-uuid> \
+  --slug listObjects \
+  --params '{}' \
+  --refresh
+```
+
 ## Rate limit awareness
 
 Some connectors have rate limits (visible in the `rateLimit` field from `connector list`):

--- a/cargo-cli-connection/references/response-shapes.md
+++ b/cargo-cli-connection/references/response-shapes.md
@@ -127,6 +127,45 @@ Returns the full integration object, including all actions and extractors with t
           "costs": [{ "type": "fixed", "cost": 1 }]
         },
         "childrenCount": 0
+      },
+      "findRecords": {
+        "name": "Find records",
+        "description": "Find records matching the given criterias.",
+        "category": "enrichment",
+        "icon": "https://...",
+        "isSerialized": false,
+        "config": {
+          "jsonSchema": {
+            "type": "object",
+            "properties": {
+              "objectType": { "type": "string", "description": "The object type" },
+              "propertyName": { "type": "string", "description": "Property to search on" }
+            }
+          },
+          "uiSchema": {
+            "objectType": {
+              "ui:widget": "IntegrationAutocompleteWidget",
+              "ui:options": {
+                "slug": "listObjects",
+                "allowRefresh": true
+              }
+            },
+            "propertyName": {
+              "ui:widget": "IntegrationAutocompleteWidget",
+              "ui:options": {
+                "slug": "listObjectProperties",
+                "allowRefresh": true,
+                "params": {
+                  "objectType": "$this.$parent.objectType"
+                }
+              }
+            }
+          }
+        },
+        "credits": {
+          "costs": [{ "type": "fixed", "cost": 1 }]
+        },
+        "childrenCount": 0
       }
     },
     "extractors": {},
@@ -136,6 +175,8 @@ Returns the full integration object, including all actions and extractors with t
 ```
 
 **Key fields:** `actions` is keyed by `actionSlug` — use these in workflow connector nodes. `connector.config.jsonSchema` describes the credentials needed when creating a connector (for non-credit integrations). `extractors` is keyed by extractor slug — use these when creating models.
+
+**`uiSchema` and autocomplete:** Each action's `config` may include a `uiSchema` alongside `jsonSchema`. When a field in `uiSchema` has `"ui:widget": "IntegrationAutocompleteWidget"`, its allowed values must be fetched via `connector autocomplete`. The `ui:options.slug` tells you which autocomplete slug to use, and `ui:options.params` (if present) specifies dependent parameters — replace `$this.$parent...` expressions with actual values. See the main SKILL.md for the full autocomplete workflow.
 
 ## cargo-ai connection native-integration get
 
@@ -192,6 +233,7 @@ Returns the full integration object, including all actions and extractors with t
 | `category` | One of: `invisible`, `logic`, `storage`, `ai`, `sales`, `code` |
 | `icon` | Icon URL |
 | `config.jsonSchema` | JSON Schema describing the action's input parameters |
+| `config.uiSchema` | UI hints for each field — check for `IntegrationAutocompleteWidget` to detect autocomplete fields |
 | `childrenCount` | Number of child branches (0 for most actions) |
 | `credits.costs` | Credit cost per execution. Each cost has `type` (`fixed` or `unit`) and `cost` (number) |
 
@@ -205,3 +247,37 @@ Returns the full integration object, including all actions and extractors with t
 | `config.jsonSchema` | JSON Schema describing the extractor's configuration |
 | `mode.kind` | `"fetch"` (pull-based) or `"ingest"` (push-based) |
 | `mode.isIncremental` | Whether the extractor supports incremental sync (fetch mode only) |
+
+## cargo-ai connection connector autocomplete
+
+Fetches the allowed values for a field that uses `IntegrationAutocompleteWidget` in its `uiSchema`.
+
+```json
+{
+  "results": [
+    {
+      "label": "Contacts",
+      "value": "contacts",
+      "description": "HubSpot contacts object"
+    },
+    {
+      "label": "Companies",
+      "value": "companies"
+    },
+    {
+      "label": "Deals",
+      "value": "deals"
+    }
+  ]
+}
+```
+
+| Field | Required | Description |
+| ----- | -------- | ----------- |
+| `label` | yes | Human-readable display name |
+| `value` | yes | The value to use in node config |
+| `description` | no | Additional context about the option |
+| `parent` | no | Parent grouping identifier (for hierarchical options) |
+| `configOverride` | no | Additional config values that should be set when this option is selected |
+
+Use the `value` field when setting the corresponding property in a workflow node's `config`.

--- a/cargo-cli-connection/references/troubleshooting.md
+++ b/cargo-cli-connection/references/troubleshooting.md
@@ -20,6 +20,17 @@ Common errors and recovery steps for `cargo-cli-connection` commands.
 | Workflow fails with connector not found | Connector UUID in node graph is wrong            | Re-run `connector list` to verify the UUID used in the node config                               |
 | Action not executing as expected        | Wrong `actionSlug`                               | For third-party connector actions (HubSpot, Salesforce, etc.), run `integration get <slug>` to see correct `actionSlug` values. Only use `native-integration get` for built-in Cargo actions. |
 
+## Connector autocomplete
+
+| Symptom                                              | Cause                                                              | Fix                                                                                                                          |
+| ---------------------------------------------------- | ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
+| `connector autocomplete` returns empty results       | Wrong autocomplete slug or params                                  | Re-check the `uiSchema` from `integration get <slug>` — use the exact `ui:options.slug` and pass required `params`           |
+| `Invalid autocomplete params` error                  | Missing or wrong params keys                                       | Check `ui:options.params` in the `uiSchema` — each key listed there must be provided in `--params` with an actual value       |
+| `connectorNotFound` reason                           | Wrong connector UUID                                               | Re-run `connector list` to get the correct UUID                                                                               |
+| `failedToGetIntegration` reason                      | Integration doesn't support autocomplete for this slug             | Verify the autocomplete slug exists in the integration's `uiSchema` — not all fields use autocomplete                         |
+| Stale or outdated autocomplete results               | Results are cached (default 30 minutes)                            | Pass `--refresh` to bypass the cache                                                                                          |
+| Used a freeform value instead of autocomplete result  | Field requires a specific value from the autocomplete result set   | Always check `uiSchema` for `IntegrationAutocompleteWidget` — if present, fetch and use a `value` from the autocomplete results |
+
 ## Integrations
 
 | Symptom                                                 | Cause                                                         | Fix                                                             |

--- a/cargo-cli-orchestration/references/nodes.md
+++ b/cargo-cli-orchestration/references/nodes.md
@@ -69,6 +69,8 @@ cargo-ai connection connector list                       # → connectorUuid
 
 `childrenCount` for connector nodes equals the integration action's `children` array length if defined, otherwise defaults to **1**. Most connector actions have exactly 1 child.
 
+**Config values from autocomplete:** When you run `integration get <slug>`, some actions include a `uiSchema` alongside the `jsonSchema`. If a field has `"ui:widget": "IntegrationAutocompleteWidget"` in the `uiSchema`, you **must** fetch its allowed values using `connector autocomplete` rather than guessing or using freeform input. See `cargo-cli-connection/SKILL.md` for the full autocomplete workflow.
+
 ### `tool`
 
 Embeds another tool (sub-workflow) as a node. The tool's deployed release config fields become the node's `config`.


### PR DESCRIPTION
## Summary
This PR adds comprehensive documentation for the connector autocomplete feature, which allows fetching dynamic values for action fields marked with `IntegrationAutocompleteWidget` in their `uiSchema`.

## Key Changes

- **SKILL.md**: Added new "Connector autocomplete" section with:
  - How to detect autocomplete fields in `uiSchema`
  - Command syntax and flag reference for `connector autocomplete`
  - Handling of dependent parameters
  - Response format documentation
  - End-to-end HubSpot example workflow

- **response-shapes.md**: 
  - Added example `findRecords` action showing `uiSchema` with autocomplete widgets
  - Documented the `uiSchema` field in action response schema
  - Added new `cargo-ai connection connector autocomplete` response shape with field descriptions
  - Clarified how to interpret `ui:options.slug` and `ui:options.params`

- **examples/connectors.md**: Added practical examples for:
  - Basic autocomplete calls
  - Autocomplete with dependent parameters
  - Search filtering with `--value` flag
  - Cache refresh with `--refresh` flag

- **troubleshooting.md**: Added troubleshooting table for common autocomplete issues:
  - Empty results handling
  - Invalid params errors
  - Connector UUID validation
  - Integration support verification

- **GLOSSARY.md**: Added two new entries:
  - **autocomplete**: Explains the mechanism and how to use it
  - **uiSchema**: Describes its role alongside `jsonSchema` and the autocomplete widget indicator

## Notable Details

- Documentation emphasizes the relationship between `uiSchema` hints and the `connector autocomplete` command
- Examples show how to resolve `$this.$parent...` expressions in dependent parameters
- Response format clearly distinguishes between required (`label`, `value`) and optional fields (`description`, `parent`, `configOverride`)

https://claude.ai/code/session_01AG45dVCBz51bt92g95MYdA