### PR TITLE
claude/update-skills-cli-oWGlk

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -6,6 +6,9 @@ Key terms used across the Cargo CLI skills.
 
 ## A
 
+**action**
+A discrete operation that an AI agent or workflow can perform. Actions come in four kinds: `tool` (orchestration tool), `connector` (third-party integration action), `agent` (AI agent), and `native` (built-in platform action). Actions replace the previous "tools" terminology in AI releases and messages. Execute a single action with `orchestration action execute`, or a single action across multiple records with `orchestration action execute-batch`. To chain multiple actions, use `run create` with `--nodes` or `batch create`.
+
 **actionSlug**
 A string identifier for a specific action on a workflow node. Present on both `kind: "native"` and `kind: "connector"` nodes.
 
@@ -13,7 +16,7 @@ A string identifier for a specific action on a workflow node. Present on both `k
 - **Connector nodes** — third-party service-specific actions discovered via `cargo-ai connection integration get <slug>` (e.g. `integration get hubspot`). Examples: `company_enrich`, `create_contact`, `send_message`. **Do not use `native-integration get` for these** — it will not return HubSpot, Salesforce, or other connector-specific actions.
 
 **agent**
-An AI resource with configured instructions, a language model, and optional tools. Created and configured via `cargo-cli-ai`. Used in workflows as a `kind: "agent"` node, or messaged directly via `cargo-cli-orchestration`.
+An AI resource with configured instructions, a language model, and optional actions. Created and configured via `cargo-cli-ai`. Used in workflows as a `kind: "agent"` node, or messaged directly via `cargo-cli-orchestration`.
 
 **autocomplete**
 A mechanism to fetch the list of allowed values for an action config field at runtime. When an action's `uiSchema` marks a field with `"ui:widget": "IntegrationAutocompleteWidget"`, its valid values must be retrieved via `cargo-ai connection connector autocomplete --connector-uuid <uuid> --slug <slug> --params '<json>'`. The autocomplete slug and params come from the field's `ui:options` in the `uiSchema`. Returns `{ "results": [{ "label": "...", "value": "..." }] }` — use the `value` in node configs.
@@ -133,7 +136,7 @@ The identifier for an LLM used by an agent or inline agent node. Examples: `gpt-
 ## M
 
 **MCP server**
-A Model Context Protocol server that exposes additional tools to agents. Connected via `cargo-cli-ai`. Once connected, agents can call MCP tools automatically during conversations or workflow runs.
+A Model Context Protocol server that exposes additional actions to agents. Connected via `cargo-cli-ai`. Once connected, agents can call MCP actions automatically during conversations or workflow runs.
 
 **memory**
 A piece of information an agent stores from a conversation for future reference. Listed via `ai memory list --agent-uuid <uuid>`. Can be cleared with `ai memory remove`.

--- a/README.md
+++ b/README.md
@@ -23,17 +23,24 @@ Works with Claude Code, Cursor, Windsurf, GitHub Copilot, and any agent that sup
 
 **Cargo** connects your data models (companies, contacts, deals) to external integrations (CRMs, enrichment providers, AI agents) and runs them as automated workflows. This skill covers the full CLI surface:
 
-| Domain            | What the agent learns                                                                                                                           |
-| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Orchestration** | Run tools on single records, trigger batches across segments, poll async operations, query the data warehouse with SQL, fetch live segment data |
-| **Storage**       | Inspect models and their DDL, create columns, navigate datasets, set relationships between models                                               |
-| **Connection**    | Authenticate connectors (HubSpot, Clearbit, Salesforce…), discover integration actions and their slugs                                          |
-| **AI**            | Create and configure agents, upload files for RAG, connect MCP servers, inspect agent memories                                                  |
-| **Analytics**     | Download run results, export segment data, monitor error rates and success metrics                                                              |
-| **Billing**       | Track credit consumption per workflow or connector, check subscription status, view invoices                                                    |
-| **Workspace**     | Invite users, create and rotate API tokens, organize resources into folders, manage roles                                                       |
+| Domain            | What the agent learns                                                                                                                                              |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Orchestration** | Execute single actions, chain actions into workflows, trigger batches across segments, poll async operations, query the data warehouse with SQL, fetch segment data |
+| **Storage**       | Inspect models and their DDL, create columns, navigate datasets, set relationships between models                                                                  |
+| **Connection**    | Authenticate connectors (HubSpot, Clearbit, Salesforce…), discover integration actions and their slugs                                                             |
+| **AI**            | Create and configure agents, upload files for RAG, connect MCP servers, inspect agent memories                                                                     |
+| **Analytics**     | Download run results, export segment data, monitor error rates and success metrics                                                                                 |
+| **Billing**       | Track credit consumption per workflow or connector, check subscription status, view invoices                                                                       |
+| **Workspace**     | Invite users, create and rotate API tokens, organize resources into folders, manage roles                                                                          |
 
 ## Use cases
+
+### Execute a single action
+
+Ask your agent to run one action on a record — it will pick the right action kind (connector, tool, or agent), execute it, and return the result.
+
+> "Enrich acme.com with Clearbit."
+> "Run the lead scorer on this contact."
 
 ### Run an existing workflow
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -103,7 +103,10 @@ All commands output JSON to stdout. Failed commands exit non-zero and return `{"
 **Key commands:**
 
 ```bash
+cargo-ai orchestration action execute --action '{"kind":"tool","toolUuid":"<uuid>","config":{}}' --data '{...}'
+cargo-ai orchestration action execute-batch --action '{"kind":"connector","integrationSlug":"clearbit","actionSlug":"company_enrich","config":{}}' --records '[{...},{...}]'
 cargo-ai orchestration run create --workflow-uuid <uuid> --data '{...}'
+cargo-ai orchestration run create --data '{...}' --nodes '[...]'
 cargo-ai orchestration batch create --workflow-uuid <uuid> --data '{"kind":"segment","segmentUuid":"..."}'
 cargo-ai ai message create --chat-uuid <uuid> --parts '[{"type":"text","text":"..."}]'
 cargo-ai system-of-record client query "SELECT * FROM <table> LIMIT 10"
@@ -112,6 +115,9 @@ cargo-ai segmentation segment fetch --model-uuid <uuid> --filter '{"conjonction"
 
 **Critical rules:**
 
+- Use `action execute` for a single action on one record — simplest path, no workflow needed.
+- Use `action execute-batch` for a single action on multiple records.
+- Use `run create` / `batch create` to chain multiple actions together via a node graph.
 - `run create` works only with **tool** workflows. For plays, use `batch create`.
 - Filter JSON uses `conjonction` (not `conjunction`) — this is intentional and will break silently if misspelled.
 - Always get DDL before querying the system-of-record: `cargo-ai storage model get-ddl <model-uuid>`.

--- a/SKILL.md
+++ b/SKILL.md
@@ -122,12 +122,10 @@ cargo-ai segmentation segment fetch --model-uuid <uuid> --filter '{"conjonction"
 
 **Critical rules:**
 
-- `action execute` for one action on one record. `action execute-batch` for one action on many records.
-- `run create` / `batch create` to chain actions via a node graph.
-- `run create` only works with **tool** workflows. For plays, use `batch create`.
+- See the decision flowchart at the top of `cargo-cli-orchestration/SKILL.md` for when to use `action execute` vs `run create` vs `batch create`.
 - Filter JSON uses `conjonction` (not `conjunction`) — breaks silently if misspelled.
 - Always get DDL before querying the system-of-record: `cargo-ai storage model get-ddl <model-uuid>`.
-- All operations are async — poll until terminal state or pass `--wait-until-finished`. See [Async polling](#async-polling).
+- All operations are async — poll or pass `--wait-until-finished`. See [Async polling](#async-polling).
 
 **References:** `cargo-cli-orchestration/SKILL.md`
 
@@ -239,16 +237,7 @@ cargo-ai ai mcp-server create --name "Internal Tools" --url "https://..."
 cargo-ai ai memory list --agent-uuid <uuid>
 ```
 
-**Model and temperature guidance:**
-
-| Use case                            | Recommended model                   | Temperature   |
-| ----------------------------------- | ----------------------------------- | ------------- |
-| Classification, extraction, scoring | `gpt-4o-mini` or `claude-3-5-haiku` | `0.0` – `0.2` |
-| Research, summarization, analysis   | `gpt-4o` or `claude-3-5-sonnet`     | `0.2` – `0.5` |
-| Copywriting, personalization        | `gpt-4o` or `claude-3-5-sonnet`     | `0.5` – `0.8` |
-| Brainstorming, creative ideation    | `gpt-4o` or `claude-opus`           | `0.7` – `1.0` |
-
-Low temperature (`0.0`–`0.2`) = deterministic, consistent outputs. High temperature (`0.7`+) = creative, varied outputs. For production workflows processing thousands of records, prefer low temperature.
+See `cargo-cli-ai/SKILL.md` for model and temperature guidance by use case.
 
 **References:** `cargo-cli-ai/SKILL.md`
 
@@ -278,7 +267,7 @@ cargo-ai workspace folder create --name "Q1 Campaigns" --emoji-slug "rocket" --k
 
 ## Async polling
 
-All operations are asynchronous. `action execute` returns a run; `action execute-batch` returns a batch. Poll until terminal state, or pass `--wait-until-finished` to block.
+All operations are asynchronous. Pass `--wait-until-finished` to block, or poll:
 
 | Result type   | Poll command                              | Interval | Terminal when                                  |
 | ------------- | ----------------------------------------- | -------- | ---------------------------------------------- |
@@ -286,16 +275,9 @@ All operations are asynchronous. `action execute` returns a run; `action execute
 | Batch         | `cargo-ai orchestration batch get <uuid>` | 5s       | `status` is `success`, `error`, or `cancelled` |
 | Agent message | `cargo-ai ai message get <uuid>`          | 2s       | `status` is `success` or `error`               |
 
-For large batches (1000+ records), increase the interval to 10-15s after the first minute.
+`action execute` returns a run; `action execute-batch` returns a batch — same polling applies.
 
-**When a run returns `error` status:**
-
-1. Read the run details: `cargo-ai orchestration run get <uuid>` — look at the node-level output for the specific node that failed.
-2. Check the error message from the connector or agent node to understand the root cause.
-3. Fix the input data or node config, then re-trigger.
-4. For transient errors (rate limits, timeouts), add a `retry` config to the node: `{"maximumAttempts": 3, "initialInterval": 1000, "backoffCoefficient": 2}`.
-
-See `cargo-cli-orchestration/references/troubleshooting.md` for a full list of error patterns.
+See `cargo-cli-orchestration/references/polling.md` for retry strategies, error handling, and large-batch guidance.
 
 ---
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -42,7 +42,7 @@ All commands output JSON to stdout. Failed commands exit non-zero and return `{"
 
 | Skill                                                 | Load when you need to…                                                                             |
 | ----------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| [`cargo-cli-orchestration`](#cargo-cli-orchestration) | Run workflows, trigger batches, chat with agents, query your data warehouse, fetch segment records |
+| [`cargo-cli-orchestration`](#cargo-cli-orchestration) | Execute actions, run workflows, trigger batches, chat with agents, query your data warehouse       |
 | [`cargo-cli-analytics`](#cargo-cli-analytics)         | Download run results, export segment data, monitor error rates and metrics                         |
 | [`cargo-cli-billing`](#cargo-cli-billing)             | Check credit usage, view subscription details, track costs per workflow or connector               |
 | [`cargo-cli-storage`](#cargo-cli-storage)             | Inspect or modify data models, columns, datasets, and relationships                                |
@@ -344,7 +344,17 @@ cargo-ai segmentation segment list
 
 ## End-to-end use cases
 
-### 1. Enrich a list of companies and push to CRM
+### 1. Enrich a single company (simplest path)
+
+**Skills needed:** `cargo-cli-orchestration`
+
+```
+1. orchestration action execute            → run a connector action on one record
+   --action '{"kind":"connector","integrationSlug":"clearbit","actionSlug":"company_enrich","config":{}}'
+   --data '{"domain":"acme.com"}' --wait-until-finished
+```
+
+### 2. Enrich a list of companies and push to CRM
 
 **Skills needed:** `cargo-cli-storage`, `cargo-cli-connection`, `cargo-cli-orchestration`, `cargo-cli-analytics`
 
@@ -358,7 +368,7 @@ cargo-ai segmentation segment list
 7. analytics run download          → export results
 ```
 
-### 2. Score leads with AI and update the model
+### 3. Score leads with AI and update the model
 
 **Skills needed:** `cargo-cli-ai`, `cargo-cli-orchestration`, `cargo-cli-billing`
 
@@ -371,7 +381,7 @@ cargo-ai segmentation segment list
 6. billing usage get-metrics       → check credit consumption
 ```
 
-### 3. Build a custom enrichment workflow from scratch
+### 4. Build a custom enrichment workflow from scratch
 
 **Skills needed:** `cargo-cli-connection`, `cargo-cli-orchestration`
 
@@ -383,7 +393,7 @@ cargo-ai segmentation segment list
 5. orchestration run get                   → poll to terminal state
 ```
 
-### 4. Monitor workflow health and alert on errors
+### 5. Monitor workflow health and alert on errors
 
 **Skills needed:** `cargo-cli-orchestration`, `cargo-cli-analytics`
 
@@ -394,7 +404,7 @@ cargo-ai segmentation segment list
 4. analytics run download --statuses error → download failed runs for inspection
 ```
 
-### 5. Bootstrap a fresh workspace
+### 6. Bootstrap a fresh workspace
 
 **Skills needed:** `cargo-cli-workspace`, `cargo-cli-storage`, `cargo-cli-connection`, `cargo-cli-ai`
 
@@ -410,7 +420,7 @@ cargo-ai segmentation segment list
 9. workspace folder create         → organize plays and tools into folders
 ```
 
-### 6. Export and analyze segment data
+### 7. Export and analyze segment data
 
 **Skills needed:** `cargo-cli-storage`, `cargo-cli-analytics`
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -98,30 +98,36 @@ All commands output JSON to stdout. Failed commands exit non-zero and return `{"
 
 ### cargo-cli-orchestration
 
-**The execution hub.** Use for everything runtime: running tools on single records, triggering batches across segments, chatting with AI agents, querying your data warehouse with SQL, and fetching live segment data.
+**The execution hub.** Execute actions, run workflows, chat with AI agents, query your data warehouse, and fetch segment records.
 
 **Key commands:**
 
 ```bash
+# Single actions (no workflow needed)
 cargo-ai orchestration action execute --action '{"kind":"tool","toolUuid":"<uuid>","config":{}}' --data '{...}'
-cargo-ai orchestration action execute-batch --action '{"kind":"connector","integrationSlug":"clearbit","actionSlug":"company_enrich","config":{}}' --records '[{...},{...}]'
+cargo-ai orchestration action execute-batch --action '{"kind":"connector","integrationSlug":"...","actionSlug":"...","config":{}}' --records '[{...},{...}]'
+
+# Workflows (chain multiple actions)
 cargo-ai orchestration run create --workflow-uuid <uuid> --data '{...}'
 cargo-ai orchestration run create --data '{...}' --nodes '[...]'
 cargo-ai orchestration batch create --workflow-uuid <uuid> --data '{"kind":"segment","segmentUuid":"..."}'
+
+# AI agents
 cargo-ai ai message create --chat-uuid <uuid> --parts '[{"type":"text","text":"..."}]'
+
+# Data
 cargo-ai system-of-record client query "SELECT * FROM <table> LIMIT 10"
 cargo-ai segmentation segment fetch --model-uuid <uuid> --filter '{"conjonction":"and","groups":[]}'
 ```
 
 **Critical rules:**
 
-- Use `action execute` for a single action on one record — simplest path, no workflow needed.
-- Use `action execute-batch` for a single action on multiple records.
-- Use `run create` / `batch create` to chain multiple actions together via a node graph.
-- `run create` works only with **tool** workflows. For plays, use `batch create`.
-- Filter JSON uses `conjonction` (not `conjunction`) — this is intentional and will break silently if misspelled.
+- `action execute` for one action on one record. `action execute-batch` for one action on many records.
+- `run create` / `batch create` to chain actions via a node graph.
+- `run create` only works with **tool** workflows. For plays, use `batch create`.
+- Filter JSON uses `conjonction` (not `conjunction`) — breaks silently if misspelled.
 - Always get DDL before querying the system-of-record: `cargo-ai storage model get-ddl <model-uuid>`.
-- Runs, batches, and agent messages are async — poll until terminal state. See [Async polling](#async-polling).
+- All operations are async — poll until terminal state or pass `--wait-until-finished`. See [Async polling](#async-polling).
 
 **References:** `cargo-cli-orchestration/SKILL.md`
 
@@ -272,17 +278,15 @@ cargo-ai workspace folder create --name "Q1 Campaigns" --emoji-slug "rocket" --k
 
 ## Async polling
 
-All runs, batches, and agent messages are asynchronous. Always poll until a terminal state is reached.
+All operations are asynchronous. `action execute` returns a run; `action execute-batch` returns a batch. Poll until terminal state, or pass `--wait-until-finished` to block.
 
-| Operation     | Poll command                              | Interval | Terminal when                                  |
+| Result type   | Poll command                              | Interval | Terminal when                                  |
 | ------------- | ----------------------------------------- | -------- | ---------------------------------------------- |
 | Run           | `cargo-ai orchestration run get <uuid>`   | 2s       | `status` is `success`, `error`, or `cancelled` |
 | Batch         | `cargo-ai orchestration batch get <uuid>` | 5s       | `status` is `success`, `error`, or `cancelled` |
 | Agent message | `cargo-ai ai message get <uuid>`          | 2s       | `status` is `success` or `error`               |
 
-For large batches (1000+ records), increase the interval to 10–15s after the first minute.
-
-Pass `--wait-until-finished` to `run create` or `batch create` to block until the operation reaches a terminal state and return the final result — no manual polling needed.
+For large batches (1000+ records), increase the interval to 10-15s after the first minute.
 
 **When a run returns `error` status:**
 

--- a/cargo-cli-ai/SKILL.md
+++ b/cargo-cli-ai/SKILL.md
@@ -72,13 +72,13 @@ cargo-ai ai memory remove --mem0-id <id> --scope agent --agent-uuid <uuid>
 
 ## Agents
 
-Agents are AI resources with configured instructions, a language model, tools, and optional resources.
+Agents are AI resources with configured instructions, a language model, actions, and optional resources.
 
 **Before creating an agent from scratch, check existing templates — they capture proven patterns for common use cases (lead research, classification, email drafting) and give you a ready-made system prompt, model, and temperature to start from:**
 
 ```bash
 cargo-ai ai template list          # browse available patterns
-cargo-ai ai template get <slug>    # inspect system prompt, model, and tools
+cargo-ai ai template get <slug>    # inspect system prompt, model, and actions
 ```
 
 ```bash
@@ -110,7 +110,7 @@ cargo-ai ai agent remove <agent-uuid>
 
 ## Releases
 
-Releases are versioned snapshots of an agent's configuration (system prompt, tools, resources, model, temperature). Agents execute against their deployed release.
+Releases are versioned snapshots of an agent's configuration (system prompt, actions, resources, model, temperature). Agents execute against their deployed release.
 
 ```bash
 # List releases for an agent
@@ -133,12 +133,12 @@ cargo-ai ai release update-draft --agent-uuid <uuid> \
 cargo-ai ai release deploy-draft --agent-uuid <uuid> \
   --integration-slug openai \
   --language-model-slug gpt-4o \
-  --tools '[]' \
+  --actions '[]' \
   --mcp-clients '[]' \
   --resources '[]' \
   --capabilities '[]' \
   --suggested-actions '[]' \
-  --description "Added research tools"
+  --description "Added research actions"
 ```
 
 **Agent configuration workflow:**
@@ -146,7 +146,7 @@ cargo-ai ai release deploy-draft --agent-uuid <uuid> \
 1. **Browse templates for inspiration**: `cargo-ai ai template list` — find a template close to your use case, then `cargo-ai ai template get <slug>` to see its system prompt, model, and temperature
 2. Create the agent: `cargo-ai ai agent create --name "..." --icon-color blue --icon-face 🤖`
 3. Get the draft release: `cargo-ai ai release get-draft --agent-uuid <uuid>`
-4. Update the draft with tools, resources, prompt, model: `cargo-ai ai release update-draft --agent-uuid <uuid> ...`
+4. Update the draft with actions, resources, prompt, model: `cargo-ai ai release update-draft --agent-uuid <uuid> ...`
 5. Deploy: `cargo-ai ai release deploy-draft --agent-uuid <uuid> ...`
 
 ## Templates
@@ -161,7 +161,7 @@ cargo-ai ai template list
 cargo-ai ai template get <slug>
 ```
 
-Templates include a system prompt, tools, resources, and recommended model settings. Use them as a starting point and customize via `release update-draft`. See `references/examples/templates.md` for the full guide including an end-to-end example of creating an agent from a template.
+Templates include a system prompt, actions, resources, and recommended model settings. Use them as a starting point and customize via `release update-draft`. See `references/examples/templates.md` for the full guide including an end-to-end example of creating an agent from a template.
 
 ## Model and temperature guidance
 
@@ -197,7 +197,7 @@ Uploaded files are attached to agents via the release's `resources` configuratio
 
 ## MCP servers
 
-MCP (Model Context Protocol) servers expose additional tools to agents. Once connected, agents can call MCP tools automatically during conversations or workflow runs.
+MCP (Model Context Protocol) servers expose additional actions to agents. Once connected, agents can call MCP actions automatically during conversations or workflow runs.
 
 ```bash
 # List all MCP servers

--- a/cargo-cli-ai/SKILL.md
+++ b/cargo-cli-ai/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo API token
 metadata:
   author: getcargo
-  version: "1.0"
+  version: "1.1"
 ---
 
 # Cargo CLI — AI

--- a/cargo-cli-ai/SKILL.md
+++ b/cargo-cli-ai/SKILL.md
@@ -146,7 +146,7 @@ cargo-ai ai release deploy-draft --agent-uuid <uuid> \
 1. **Browse templates for inspiration**: `cargo-ai ai template list` — find a template close to your use case, then `cargo-ai ai template get <slug>` to see its system prompt, model, and temperature
 2. Create the agent: `cargo-ai ai agent create --name "..." --icon-color blue --icon-face 🤖`
 3. Get the draft release: `cargo-ai ai release get-draft --agent-uuid <uuid>`
-4. Update the draft with actions, resources, prompt, model: `cargo-ai ai release update-draft --agent-uuid <uuid> ...`
+4. Update the draft with configured actions, resources, prompt, model: `cargo-ai ai release update-draft --agent-uuid <uuid> ...`
 5. Deploy: `cargo-ai ai release deploy-draft --agent-uuid <uuid> ...`
 
 ## Templates

--- a/cargo-cli-ai/references/examples/agents.md
+++ b/cargo-cli-ai/references/examples/agents.md
@@ -58,7 +58,7 @@ cargo-ai ai release update-draft --agent-uuid <agent-uuid> \
 cargo-ai ai release deploy-draft --agent-uuid <agent-uuid> \
   --integration-slug openai \
   --language-model-slug gpt-4o-mini \
-  --tools '[]' \
+  --actions '[]' \
   --mcp-clients '[]' \
   --resources '[]' \
   --capabilities '[]' \
@@ -94,7 +94,7 @@ cargo-ai ai template list
 
 # 2. Get the template
 cargo-ai ai template get <template-slug>
-# → Copy the systemPrompt, tools, resources, model settings
+# → Copy the systemPrompt, actions, resources, model settings
 
 # 3. Create the agent
 cargo-ai ai agent create \
@@ -111,7 +111,7 @@ cargo-ai ai release update-draft --agent-uuid <agent-uuid> \
 cargo-ai ai release deploy-draft --agent-uuid <agent-uuid> \
   --integration-slug <from template> \
   --language-model-slug <from template> \
-  --tools '[]' \
+  --actions '[]' \
   --mcp-clients '[]' \
   --resources '[]' \
   --capabilities '[]' \
@@ -128,5 +128,5 @@ cargo-ai ai release list --agent-uuid <agent-uuid>
 
 ```bash
 cargo-ai ai agent get <agent-uuid>
-# → .deployedRelease contains the full live config (prompt, model, tools, resources)
+# → .deployedRelease contains the full live config (prompt, model, actions, resources)
 ```

--- a/cargo-cli-ai/references/examples/mcp-servers.md
+++ b/cargo-cli-ai/references/examples/mcp-servers.md
@@ -53,9 +53,9 @@ cargo-ai ai release deploy-draft --agent-uuid <agent-uuid> \
   --integration-slug openai
 ```
 
-## Disable specific tools from an MCP server
+## Disable specific actions from an MCP server
 
-Use `disabledToolSlugs` to prevent the agent from using specific MCP tools:
+Use `disabledToolSlugs` to prevent the agent from using specific MCP actions:
 
 ```bash
 cargo-ai ai release update-draft --agent-uuid <agent-uuid> \

--- a/cargo-cli-ai/references/examples/templates.md
+++ b/cargo-cli-ai/references/examples/templates.md
@@ -2,12 +2,12 @@
 
 ## What is an AI template?
 
-An **AI template** is a pre-built agent configuration — a ready-to-use agent blueprint with instructions, model settings, and tool configuration already defined. Templates capture common agent patterns (lead research, company classification, email drafting) so you don't have to configure an agent from scratch.
+An **AI template** is a pre-built agent configuration — a ready-to-use agent blueprint with instructions, model settings, and action configuration already defined. Templates capture common agent patterns (lead research, company classification, email drafting) so you don't have to configure an agent from scratch.
 
 **Always check templates before creating an agent.** Even if no template is a perfect match, they provide:
 - A proven system prompt structure for the use case
 - A recommended language model and temperature setting
-- A list of tools and resources to consider attaching
+- A list of actions and resources to consider attaching
 
 AI templates are read-only. You discover them by listing, then use their configuration as a starting point when creating or updating an agent.
 

--- a/cargo-cli-ai/references/response-shapes.md
+++ b/cargo-cli-ai/references/response-shapes.md
@@ -23,7 +23,7 @@ JSON response structures returned by Cargo CLI commands used in the `cargo-cli-a
         "integrationSlug": "openai",
         "temperature": 0.3,
         "maxSteps": 10,
-        "tools": [],
+        "actions": [],
         "resources": [],
         "capabilities": [],
         "mcpClients": [],
@@ -70,14 +70,14 @@ Same structure as a single item from `agent list`, nested under `agent`:
       "agentUuid": "agent-uuid",
       "version": "3",
       "status": "deployed",
-      "description": "Added research tools",
+      "description": "Added research actions",
       "systemPrompt": "You are a sales research assistant...",
       "languageModelSlug": "gpt-4o",
       "integrationSlug": "openai",
       "temperature": 0.3,
       "maxSteps": 10,
       "withReasoning": false,
-      "tools": [],
+      "actions": [],
       "resources": [],
       "capabilities": [],
       "suggestedActions": [],
@@ -103,7 +103,7 @@ Supports `--agent-uuid`, `--limit`, `--offset`.
     "agentUuid": "agent-uuid",
     "version": "3",
     "status": "deployed",
-    "description": "Added research tools",
+    "description": "Added research actions",
     "systemPrompt": "You are a sales research assistant...",
     "languageModelSlug": "gpt-4o",
     "integrationSlug": "openai",
@@ -111,7 +111,7 @@ Supports `--agent-uuid`, `--limit`, `--offset`.
     "temperature": 0.3,
     "maxSteps": 10,
     "withReasoning": false,
-    "tools": [
+    "actions": [
       {
         "kind": "connector",
         "integrationSlug": "clearbit",
@@ -152,9 +152,9 @@ Supports `--agent-uuid`, `--limit`, `--offset`.
 }
 ```
 
-**Key fields:** `tools` (array of tool/connector/agent tools), `resources` (file or model resources), `mcpClients` (MCP server connections), `systemPrompt`, `languageModelSlug`, `temperature`, `maxSteps`.
+**Key fields:** `actions` (array of tool/connector/agent actions), `resources` (file or model resources), `mcpClients` (MCP server connections), `systemPrompt`, `languageModelSlug`, `temperature`, `maxSteps`.
 
-**Tool kinds:** `tool` (workflow tool), `connector` (integration action), `agent` (sub-agent).
+**Action kinds:** `tool` (workflow tool), `connector` (integration action), `agent` (sub-agent).
 
 **Resource kinds:** `file` (uploaded files/folders), `model` (data model reference).
 
@@ -207,7 +207,7 @@ Supports `--agent-uuid`, `--limit`, `--offset`.
     "temperature": 0.3,
     "maxSteps": 10,
     "withReasoning": false,
-    "tools": [...],
+    "actions": [...],
     "resources": [...],
     "capabilities": [],
     "suggestedActions": [],
@@ -255,7 +255,7 @@ Supports `--agent-uuid`, `--limit`, `--offset`.
       "uuid": "mcp-server-uuid",
       "workspaceUuid": "...",
       "name": "Internal Tools",
-      "tools": [
+      "actions": [
         {
           "kind": "tool",
           "slug": "search_docs",
@@ -272,7 +272,7 @@ Supports `--agent-uuid`, `--limit`, `--offset`.
 }
 ```
 
-**Key fields:** `uuid`, `name`, `tools` (discovered tools from the MCP server).
+**Key fields:** `uuid`, `name`, `actions` (discovered actions from the MCP server).
 
 ## cargo-ai ai memory list
 

--- a/cargo-cli-ai/references/troubleshooting.md
+++ b/cargo-cli-ai/references/troubleshooting.md
@@ -36,10 +36,10 @@ The `--parent-uuid` passed to `release update-draft` does not match a valid rele
 The version string is invalid. Version must be a non-empty string (not a number).
 
 **`invalidConnector`**
-A connector UUID referenced in the release tools or configuration does not exist. Verify connector UUIDs with `cargo-ai connection connector list`.
+A connector UUID referenced in the release actions or configuration does not exist. Verify connector UUIDs with `cargo-ai connection connector list`.
 
 **`failedToReconciliateAgentAiTools`**
-The tools configuration in the release is invalid — a referenced tool, agent, or connector UUID may not exist. Verify all UUIDs in the tools array.
+The actions configuration in the release is invalid — a referenced tool, agent, or connector UUID may not exist. Verify all UUIDs in the actions array.
 
 ## Templates
 
@@ -62,7 +62,7 @@ Large files may take longer to upload. Ensure the file path is correct and the f
 **`mcpServerNotFound`**
 The MCP server UUID does not exist or has been deleted. Run `cargo-ai ai mcp-server list` to get the current list.
 
-**MCP tools not appearing in agent**
+**MCP actions not appearing in agent**
 MCP servers are connected to agents via MCP clients on the release. After creating an MCP server, add it as an MCP client to the agent's draft release using `release update-draft`, then deploy.
 
 ## Memories

--- a/cargo-cli-orchestration/SKILL.md
+++ b/cargo-cli-orchestration/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: cargo-cli-orchestration
-description: Interact with the Cargo platform via CLI. Use when the user wants to run a workflow, trigger a batch, message an AI agent, query a data warehouse, fetch segment records, or inspect a model schema.
+description: Interact with the Cargo platform via CLI. Use when the user wants to execute an action, run a workflow, trigger a batch, message an AI agent, query a data warehouse, fetch segment records, or inspect a model schema.
 license: MIT
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo API token
 metadata:
   author: getcargo
-  version: "1.3"
+  version: "1.4"
 ---
 
 # Cargo CLI — Orchestration

--- a/cargo-cli-orchestration/SKILL.md
+++ b/cargo-cli-orchestration/SKILL.md
@@ -26,7 +26,7 @@ Need to run something?
 └── Conversational AI agent      → message create
 ```
 
-> **Terminology:** An orchestration **tool** is a saved workflow you trigger on demand. An **action** is a single step you execute — it can reference a tool (`kind: "tool"`), a connector (`kind: "connector"`), an agent (`kind: "agent"`), or a native operation (`kind: "native"`).
+> **Terminology:** An orchestration **tool** is a saved on-demand workflow (listed via `tool list`). An **action** is a single operation you execute without building a workflow — it can embed a saved orchestration tool (`kind: "tool"`), call a third-party connector (`kind: "connector"`), invoke an AI agent (`kind: "agent"`), or run a built-in platform operation (`kind: "native"`).
 
 **References:**
 
@@ -285,71 +285,25 @@ cargo-ai segmentation segment remove <segment-uuid>
 
 ## Use a workflow template
 
-Templates are pre-built node graphs for common automation patterns. They serve two purposes:
-- **Inspiration when building** — browse templates to understand how to structure a new tool or play, then copy and adapt the node graph into your draft release
-- **Bootstrap a run** — plug a template's nodes directly into `run create` or `batch create` without touching the tool's stored definition
+Templates are pre-built node graphs for common automation patterns (enrichment pipelines, CRM syncs, lead scoring). Browse with `template list`, inspect with `template get <slug>`, fill in placeholders, validate, and run.
 
 ```bash
 cargo-ai orchestration template list              # list available templates
 cargo-ai orchestration template get <slug>        # get template nodes + config
 ```
 
-**Pattern:**
-
-```bash
-# 1. Browse templates
-cargo-ai orchestration template list
-
-# 2. Get the node graph
-cargo-ai orchestration template get company-enrichment
-# → Copy "nodes" array, fill in __REPLACE_WITH_*__ placeholders
-
-# 3. Validate before running
-cargo-ai orchestration node validate --nodes '[...nodes...]'
-# → { "outcome": "valid" }
-
-# 4. Run
-cargo-ai orchestration run create \
-  --workflow-uuid <tool.workflowUuid> \
-  --data '{"domain":"acme.com"}' \
-  --nodes '[...validated nodes...]'
-```
-
-See `references/templates.md` for the full guide including play templates and placeholder conventions.
+See `references/templates.md` for the full guide including placeholder conventions and end-to-end examples.
 
 ## Validate and test nodes
 
-Before running a custom node graph, validate its structure. For debugging, compute (dry-run) or execute a single node in isolation.
+Always validate custom node graphs before running them.
 
 ```bash
-# Validate a node graph — catches structural errors before running
 cargo-ai orchestration node validate --nodes '[...]'
-# → { "outcome": "valid" }
-# → { "outcome": "notValid", "invalidNodes": [{ "node": {...}, "reason": "connectorNotFound" }] }
-
-# Compute a node — evaluate expressions without executing side effects
-cargo-ai orchestration node compute \
-  --node '{...node definition...}' \
-  --context '{"nodes":{"start":{"domain":"acme.com"}}}'
-
-# Execute a single node — run one node with its computed config (makes real API calls)
-cargo-ai orchestration node execute \
-  --workflow-uuid <uuid> \
-  --release-uuid <uuid> \
-  --node '{...node definition...}' \
-  --computed-config '{...}' \
-  --context '{"nodes":{"start":{"domain":"acme.com"}}}'
+# → { "outcome": "valid" } or { "outcome": "notValid", "invalidNodes": [...] }
 ```
 
-**When to use each:**
-
-| Command          | Use for                                                        |
-| ---------------- | -------------------------------------------------------------- |
-| `node validate`  | Structural check — missing start node, bad UUIDs, bad slugs   |
-| `node compute`   | Expression preview — see what a config resolves to from context|
-| `node execute`   | Live test — run one node against real services (costs credits) |
-
-See `references/nodes.md` for validation error codes and node graph construction.
+For debugging, use `node compute` (dry-run expressions) or `node execute` (live test, costs credits). See `references/nodes.md` for the full node creation guide, validation error codes, and examples.
 
 ## Help
 

--- a/cargo-cli-orchestration/SKILL.md
+++ b/cargo-cli-orchestration/SKILL.md
@@ -14,14 +14,23 @@ Runtime operations for the Cargo platform.
 
 **What do you want to do?**
 
-| Goal                              | Command                   | Section            | Workflow type |
-| --------------------------------- | ------------------------- | ------------------ | ------------- |
-| Process **one** record            | `run create`              | Create a run       | Tool only     |
-| Process **many** records          | `batch create`            | Create a batch     | Play or Tool  |
-| Chat with an **AI agent**         | `message create`          | Send a message     | —             |
-| **Query** your data warehouse     | `system-of-record client` | Query the SoR      | —             |
-| **Fetch** live segment records    | `segment fetch`           | Fetch segment data | —             |
-| **Inspect** a model's table shape | `storage model get-ddl`   | Quick reference    | —             |
+| Goal                                          | Command                    | Section                 |
+| --------------------------------------------- | -------------------------- | ----------------------- |
+| Run **one action** on **one** record           | `action execute`           | Execute a single action |
+| Run **one action** on **many** records         | `action execute-batch`     | Execute a batch action  |
+| **Chain actions** into a workflow on one record | `run create` (with nodes) | Create a run            |
+| **Chain actions** across many records          | `batch create`             | Create a batch          |
+| Chat with an **AI agent**                      | `message create`           | Send a message          |
+| **Query** your data warehouse                  | `system-of-record client`  | Query the SoR           |
+| **Fetch** live segment records                 | `segment fetch`            | Fetch segment data      |
+| **Inspect** a model's table shape              | `storage model get-ddl`    | Quick reference         |
+
+**Choosing the right approach:**
+
+- **`action execute`** — run a single action (connector, tool, or agent) on one record. Simplest path when you only need one step.
+- **`action execute-batch`** — run a single action on multiple records at once.
+- **`run create` / `batch create`** — chain multiple actions together into a workflow (pass `--nodes` with a node graph). Use when you need multi-step logic, branching, or data flowing between steps.
+- **Build a tool** — if you'll reuse the same workflow repeatedly, create a tool with a persisted node graph and deploy it. Then trigger it with `run create --workflow-uuid` or `batch create --workflow-uuid`.
 
 > See `references/response-shapes.md` for full JSON response structures.
 > See `references/filter-syntax.md` for the complete filter condition reference.
@@ -67,6 +76,8 @@ cargo-ai connection connector list         # all connectors
 
 **Plays vs tools:** Both are backed by a workflow. A **play** is a segment-driven automation — it reacts to data changes in a segment (records added, updated, removed). A **tool** is an on-demand workflow — triggered manually, via API, or on a cron schedule. Workflows don't have a `name` field; use `play list` or `tool list` to find names and extract the `workflowUuid`.
 
+**Actions vs workflows:** If you only need to run a **single action** (one connector call, one tool, one agent), use `action execute` — no workflow or node graph required. If you need to **chain multiple actions** together, use `run create` with `--nodes` or build a tool.
+
 **Designing a new tool or play?** Check templates first — they are pre-built node graphs for common automation patterns (enrichment pipelines, CRM syncs, lead scoring) and are an excellent starting point. List templates with `cargo-ai orchestration template list` and inspect a specific one with `cargo-ai orchestration template get <slug>`. Templates are tagged by `kind` so you can find ones suited for tools (`"kind":"tool"`) or plays (`"kind":"play"`) right away. See `references/templates.md` for the full guide.
 
 **Compatibility rules:**
@@ -79,7 +90,10 @@ cargo-ai connection connector list         # all connectors
 ## Quick reference
 
 ```bash
+cargo-ai orchestration action execute --action '{"kind":"tool","toolUuid":"<uuid>","config":{}}' --data '{"domain":"acme.com"}'
+cargo-ai orchestration action execute-batch --action '{"kind":"connector","integrationSlug":"clearbit","actionSlug":"company_enrich","config":{}}' --records '[{"domain":"acme.com"},{"domain":"globex.com"}]'
 cargo-ai orchestration run create --workflow-uuid <uuid> --data '{"company":"Acme","domain":"acme.com"}'
+cargo-ai orchestration run create --data '{"domain":"acme.com"}' --nodes '[...]'
 cargo-ai orchestration run create --workflow-uuid <uuid> --data '{"company":"Acme","domain":"acme.com"}' --wait-until-finished
 cargo-ai orchestration batch create --workflow-uuid <uuid> --data '{"kind":"segment","segmentUuid":"..."}'
 cargo-ai orchestration batch create --workflow-uuid <uuid> --data '{"kind":"segment","segmentUuid":"..."}' --wait-until-finished
@@ -93,19 +107,77 @@ cargo-ai storage model get-ddl <model-uuid>
 
 Runs, batches, and agent messages are asynchronous. Either poll until they reach a terminal state, or pass `--wait-until-finished` to `run create` or `batch create` to block and return the final result in one command.
 
-| Operation     | Poll command         | Interval | Done when                                      |
-| ------------- | -------------------- | -------- | ---------------------------------------------- |
-| Run           | `run get <uuid>`     | 2s       | `status` is `success`, `error`, or `cancelled` |
-| Batch         | `batch get <uuid>`   | 5s       | `status` is `success`, `error`, or `cancelled` |
-| Agent message | `message get <uuid>` | 2s       | `status` is `success` or `error`               |
+| Operation       | Poll command         | Interval | Done when                                      |
+| --------------- | -------------------- | -------- | ---------------------------------------------- |
+| Action execute  | `run get <uuid>`     | 2s       | `status` is `success`, `error`, or `cancelled` |
+| Action batch    | `batch get <uuid>`   | 5s       | `status` is `success`, `error`, or `cancelled` |
+| Run             | `run get <uuid>`     | 2s       | `status` is `success`, `error`, or `cancelled` |
+| Batch           | `batch get <uuid>`   | 5s       | `status` is `success`, `error`, or `cancelled` |
+| Agent message   | `message get <uuid>` | 2s       | `status` is `success` or `error`               |
 
 For long-running batches (1000+ records), increase the interval to 10-15s after the first minute.
 
 Pass `--wait-until-finished` to `run create` or `batch create` to block until the operation reaches a terminal state and return the final result — no manual polling needed.
 
+## Execute a single action
+
+Use `action execute` when you want to run **one action** on **one record** — no workflow or node graph needed. This is the simplest way to trigger a connector, tool, or agent action.
+
+```bash
+# Execute a tool action
+cargo-ai orchestration action execute \
+  --action '{"kind":"tool","toolUuid":"<tool-uuid>","config":{}}' \
+  --data '{"email":"user@example.com"}'
+
+# Execute a connector action
+cargo-ai orchestration action execute \
+  --action '{"kind":"connector","integrationSlug":"clearbit","actionSlug":"company_enrich","config":{}}' \
+  --data '{"domain":"acme.com"}' \
+  --wait-until-finished
+
+# Execute an agent action
+cargo-ai orchestration action execute \
+  --action '{"kind":"agent","agentUuid":"<agent-uuid>","config":{}}' \
+  --data '{"company":"Acme Corp"}'
+```
+
+Returns a `run` object. Poll with `run get <uuid>` or pass `--wait-until-finished` to block.
+
+**Action kinds:**
+
+| Kind          | Required fields                                      | Description                          |
+| ------------- | ---------------------------------------------------- | ------------------------------------ |
+| `tool`        | `toolUuid` or `templateSlug` or `releaseUuid`        | Execute an orchestration tool        |
+| `connector`   | `integrationSlug` + `actionSlug`                     | Execute a third-party service action |
+| `agent`       | `agentUuid` or `templateSlug` or `releaseUuid`       | Execute an AI agent                  |
+| `native`      | `actionSlug`                                         | Execute a built-in platform action   |
+
+Optional `retry` config: `{"maximumAttempts": 3, "initialInterval": 1000, "backoffCoefficient": 2}`.
+
+## Execute a batch action
+
+Use `action execute-batch` when you want to run **one action** on **multiple records**. Same action kinds as `action execute`.
+
+```bash
+cargo-ai orchestration action execute-batch \
+  --action '{"kind":"tool","toolUuid":"<tool-uuid>","config":{}}' \
+  --records '[{"email":"a@b.com"},{"email":"c@d.com"}]'
+
+# With webhook notification
+cargo-ai orchestration action execute-batch \
+  --action '{"kind":"connector","integrationSlug":"clearbit","actionSlug":"company_enrich","config":{}}' \
+  --records '[{"domain":"acme.com"},{"domain":"globex.com"}]' \
+  --webhook-url "https://hooks.example.com/done" \
+  --wait-until-finished
+```
+
+Returns a `batch` object. Poll with `batch get <uuid>` or pass `--wait-until-finished`.
+
 ## Create a run
 
-A run processes a single record through a workflow. **Runs only work with tool workflows.** Play workflows return `playNotCompatible` — use `batch create` instead.
+A run processes a single record through a workflow. Use `run create` when you need to **chain multiple actions** together via a node graph, or when running an existing tool workflow.
+
+**Runs only work with tool workflows.** Play workflows return `playNotCompatible` — use `batch create` instead.
 
 ```bash
 cargo-ai orchestration run create \
@@ -180,7 +252,7 @@ cargo-ai ai message create \                              # 3. Send a message
 #   Done when .message.status is "success" (read .parts) or "error" (read .errorMessage)
 ```
 
-Also supports `--tools`, `--resources`, `--language-model-slug`, `--temperature`, `--max-steps`, and `--wait-until-finished` (blocks until the assistant message reaches a terminal status). See `references/agents.md` for multi-turn conversations, tool/resource injection, and model selection.
+Also supports `--actions`, `--resources`, `--language-model-slug`, `--temperature`, `--max-steps`, and `--wait-until-finished` (blocks until the assistant message reaches a terminal status). See `references/agents.md` for multi-turn conversations, action/resource injection, and model selection.
 
 ## Inspect records
 

--- a/cargo-cli-orchestration/SKILL.md
+++ b/cargo-cli-orchestration/SKILL.md
@@ -12,37 +12,36 @@ metadata:
 
 Runtime operations for the Cargo platform.
 
-**What do you want to do?**
+**What do you want to run?**
 
-| Goal                                          | Command                    | Section                 |
-| --------------------------------------------- | -------------------------- | ----------------------- |
-| Run **one action** on **one** record           | `action execute`           | Execute a single action |
-| Run **one action** on **many** records         | `action execute-batch`     | Execute a batch action  |
-| **Chain actions** into a workflow on one record | `run create` (with nodes) | Create a run            |
-| **Chain actions** across many records          | `batch create`             | Create a batch          |
-| Chat with an **AI agent**                      | `message create`           | Send a message          |
-| **Query** your data warehouse                  | `system-of-record client`  | Query the SoR           |
-| **Fetch** live segment records                 | `segment fetch`            | Fetch segment data      |
-| **Inspect** a model's table shape              | `storage model get-ddl`    | Quick reference         |
+```
+Need to run something?
+├── One action, one record       → action execute
+├── One action, many records     → action execute-batch
+├── Multiple actions chained
+│   ├── One-off / ad-hoc         → run create --nodes (one record)
+│   │                              batch create --nodes (many records)
+│   └── Reusable workflow        → build a tool, then run create --workflow-uuid
+│                                  or batch create --workflow-uuid
+└── Conversational AI agent      → message create
+```
 
-**Choosing the right approach:**
+> **Terminology:** An orchestration **tool** is a saved workflow you trigger on demand. An **action** is a single step you execute — it can reference a tool (`kind: "tool"`), a connector (`kind: "connector"`), an agent (`kind: "agent"`), or a native operation (`kind: "native"`).
 
-- **`action execute`** — run a single action (connector, tool, or agent) on one record. Simplest path when you only need one step.
-- **`action execute-batch`** — run a single action on multiple records at once.
-- **`run create` / `batch create`** — chain multiple actions together into a workflow (pass `--nodes` with a node graph). Use when you need multi-step logic, branching, or data flowing between steps.
-- **Build a tool** — if you'll reuse the same workflow repeatedly, create a tool with a persisted node graph and deploy it. Then trigger it with `run create --workflow-uuid` or `batch create --workflow-uuid`.
+**References:**
 
-> See `references/response-shapes.md` for full JSON response structures.
-> See `references/filter-syntax.md` for the complete filter condition reference.
-> See `references/polling.md` for all async polling patterns, error handling, and retry strategies.
-> See `references/troubleshooting.md` for common errors and how to fix them.
-> See `references/nodes.md` for the full node creation guide (kinds, native actions, expressions, validation, routing, and examples).
-> See `references/templates.md` for using pre-built workflow templates.
-> See `references/plays.md` for play (segment-driven automation) examples.
-> See `references/tools.md` for tool (on-demand workflow) examples.
-> See `references/agents.md` for AI agent chat examples.
-> See `references/queries.md` for system of record query examples.
-> See `references/segments.md` for segment fetch and filter examples.
+> `references/actions.md` — action execute and execute-batch examples
+> `references/tools.md` — tool (on-demand workflow) examples
+> `references/plays.md` — play (segment-driven automation) examples
+> `references/agents.md` — AI agent chat examples
+> `references/nodes.md` — full node creation guide (kinds, native actions, expressions, validation, routing)
+> `references/templates.md` — pre-built workflow templates
+> `references/queries.md` — system of record query examples
+> `references/segments.md` — segment fetch and filter examples
+> `references/response-shapes.md` — full JSON response structures
+> `references/filter-syntax.md` — complete filter condition reference
+> `references/polling.md` — async polling patterns, error handling, retry strategies
+> `references/troubleshooting.md` — common errors and how to fix them
 
 ## Prerequisites
 
@@ -76,8 +75,6 @@ cargo-ai connection connector list         # all connectors
 
 **Plays vs tools:** Both are backed by a workflow. A **play** is a segment-driven automation — it reacts to data changes in a segment (records added, updated, removed). A **tool** is an on-demand workflow — triggered manually, via API, or on a cron schedule. Workflows don't have a `name` field; use `play list` or `tool list` to find names and extract the `workflowUuid`.
 
-**Actions vs workflows:** If you only need to run a **single action** (one connector call, one tool, one agent), use `action execute` — no workflow or node graph required. If you need to **chain multiple actions** together, use `run create` with `--nodes` or build a tool.
-
 **Designing a new tool or play?** Check templates first — they are pre-built node graphs for common automation patterns (enrichment pipelines, CRM syncs, lead scoring) and are an excellent starting point. List templates with `cargo-ai orchestration template list` and inspect a specific one with `cargo-ai orchestration template get <slug>`. Templates are tagged by `kind` so you can find ones suited for tools (`"kind":"tool"`) or plays (`"kind":"play"`) right away. See `references/templates.md` for the full guide.
 
 **Compatibility rules:**
@@ -90,14 +87,19 @@ cargo-ai connection connector list         # all connectors
 ## Quick reference
 
 ```bash
+# Single actions
 cargo-ai orchestration action execute --action '{"kind":"tool","toolUuid":"<uuid>","config":{}}' --data '{"domain":"acme.com"}'
-cargo-ai orchestration action execute-batch --action '{"kind":"connector","integrationSlug":"clearbit","actionSlug":"company_enrich","config":{}}' --records '[{"domain":"acme.com"},{"domain":"globex.com"}]'
+cargo-ai orchestration action execute-batch --action '{"kind":"connector","integrationSlug":"clearbit","actionSlug":"company_enrich","config":{}}' --records '[{...},{...}]'
+
+# Workflows (chain multiple actions)
 cargo-ai orchestration run create --workflow-uuid <uuid> --data '{"company":"Acme","domain":"acme.com"}'
 cargo-ai orchestration run create --data '{"domain":"acme.com"}' --nodes '[...]'
-cargo-ai orchestration run create --workflow-uuid <uuid> --data '{"company":"Acme","domain":"acme.com"}' --wait-until-finished
 cargo-ai orchestration batch create --workflow-uuid <uuid> --data '{"kind":"segment","segmentUuid":"..."}'
-cargo-ai orchestration batch create --workflow-uuid <uuid> --data '{"kind":"segment","segmentUuid":"..."}' --wait-until-finished
+
+# AI agents
 cargo-ai ai message create --chat-uuid <uuid> --parts '[{"type":"text","text":"..."}]'
+
+# Data
 cargo-ai system-of-record client query "SELECT * FROM companies LIMIT 10"
 cargo-ai segmentation segment fetch --model-uuid <uuid> --filter '{"conjonction":"and","groups":[]}' --fetching-limit 100
 cargo-ai storage model get-ddl <model-uuid>
@@ -105,73 +107,37 @@ cargo-ai storage model get-ddl <model-uuid>
 
 ## Polling async operations
 
-Runs, batches, and agent messages are asynchronous. Either poll until they reach a terminal state, or pass `--wait-until-finished` to `run create` or `batch create` to block and return the final result in one command.
+All operations are asynchronous. Either poll until terminal state, or pass `--wait-until-finished` to block.
 
-| Operation       | Poll command         | Interval | Done when                                      |
+`action execute` returns a run. `action execute-batch` returns a batch. They poll the same way:
+
+| Result type     | Poll command         | Interval | Done when                                      |
 | --------------- | -------------------- | -------- | ---------------------------------------------- |
-| Action execute  | `run get <uuid>`     | 2s       | `status` is `success`, `error`, or `cancelled` |
-| Action batch    | `batch get <uuid>`   | 5s       | `status` is `success`, `error`, or `cancelled` |
 | Run             | `run get <uuid>`     | 2s       | `status` is `success`, `error`, or `cancelled` |
 | Batch           | `batch get <uuid>`   | 5s       | `status` is `success`, `error`, or `cancelled` |
 | Agent message   | `message get <uuid>` | 2s       | `status` is `success` or `error`               |
 
 For long-running batches (1000+ records), increase the interval to 10-15s after the first minute.
 
-Pass `--wait-until-finished` to `run create` or `batch create` to block until the operation reaches a terminal state and return the final result — no manual polling needed.
+## Execute actions
 
-## Execute a single action
-
-Use `action execute` when you want to run **one action** on **one record** — no workflow or node graph needed. This is the simplest way to trigger a connector, tool, or agent action.
+Run a single action — no workflow or node graph needed.
 
 ```bash
-# Execute a tool action
-cargo-ai orchestration action execute \
-  --action '{"kind":"tool","toolUuid":"<tool-uuid>","config":{}}' \
-  --data '{"email":"user@example.com"}'
-
-# Execute a connector action
+# One action, one record → returns a run
 cargo-ai orchestration action execute \
   --action '{"kind":"connector","integrationSlug":"clearbit","actionSlug":"company_enrich","config":{}}' \
   --data '{"domain":"acme.com"}' \
   --wait-until-finished
 
-# Execute an agent action
-cargo-ai orchestration action execute \
-  --action '{"kind":"agent","agentUuid":"<agent-uuid>","config":{}}' \
-  --data '{"company":"Acme Corp"}'
-```
-
-Returns a `run` object. Poll with `run get <uuid>` or pass `--wait-until-finished` to block.
-
-**Action kinds:**
-
-| Kind          | Required fields                                      | Description                          |
-| ------------- | ---------------------------------------------------- | ------------------------------------ |
-| `tool`        | `toolUuid` or `templateSlug` or `releaseUuid`        | Execute an orchestration tool        |
-| `connector`   | `integrationSlug` + `actionSlug`                     | Execute a third-party service action |
-| `agent`       | `agentUuid` or `templateSlug` or `releaseUuid`       | Execute an AI agent                  |
-| `native`      | `actionSlug`                                         | Execute a built-in platform action   |
-
-Optional `retry` config: `{"maximumAttempts": 3, "initialInterval": 1000, "backoffCoefficient": 2}`.
-
-## Execute a batch action
-
-Use `action execute-batch` when you want to run **one action** on **multiple records**. Same action kinds as `action execute`.
-
-```bash
+# One action, many records → returns a batch
 cargo-ai orchestration action execute-batch \
   --action '{"kind":"tool","toolUuid":"<tool-uuid>","config":{}}' \
-  --records '[{"email":"a@b.com"},{"email":"c@d.com"}]'
-
-# With webhook notification
-cargo-ai orchestration action execute-batch \
-  --action '{"kind":"connector","integrationSlug":"clearbit","actionSlug":"company_enrich","config":{}}' \
   --records '[{"domain":"acme.com"},{"domain":"globex.com"}]' \
-  --webhook-url "https://hooks.example.com/done" \
   --wait-until-finished
 ```
 
-Returns a `batch` object. Poll with `batch get <uuid>` or pass `--wait-until-finished`.
+Action kinds: `tool`, `connector`, `agent`, `native`. See `references/actions.md` for all action kinds, parameters, retry config, response shapes, and end-to-end examples.
 
 ## Create a run
 

--- a/cargo-cli-orchestration/references/actions.md
+++ b/cargo-cli-orchestration/references/actions.md
@@ -15,7 +15,7 @@ Actions come in four kinds:
 
 Every action object also requires a `config` field (use `{}` for defaults).
 
-> **When to use actions vs workflows:** Actions are for running a **single step**. If you need to chain multiple steps together (enrichment → scoring → CRM push), use `run create --nodes` or `batch create --nodes` instead. See `tools.md` for workflow examples.
+> **When to use actions vs workflows:** Actions are for running a **single operation** without building a workflow graph. If you need to **chain multiple operations** together (enrichment → scoring → CRM push), use `run create --nodes` or `batch create --nodes` instead. See `tools.md` for workflow examples.
 
 ---
 

--- a/cargo-cli-orchestration/references/actions.md
+++ b/cargo-cli-orchestration/references/actions.md
@@ -1,0 +1,224 @@
+# Action examples
+
+## What is an action?
+
+An **action** is a single operation you can execute without building a workflow. Use `action execute` for one record, or `action execute-batch` for multiple records.
+
+Actions come in four kinds:
+
+| Kind        | What it does                         | Required fields                                |
+| ----------- | ------------------------------------ | ---------------------------------------------- |
+| `tool`      | Run an orchestration tool            | `toolUuid` or `templateSlug` or `releaseUuid`  |
+| `connector` | Call a third-party service           | `integrationSlug` + `actionSlug`               |
+| `agent`     | Invoke an AI agent                   | `agentUuid` or `templateSlug` or `releaseUuid` |
+| `native`    | Run a built-in platform action       | `actionSlug`                                   |
+
+Every action object also requires a `config` field (use `{}` for defaults).
+
+> **When to use actions vs workflows:** Actions are for running a **single step**. If you need to chain multiple steps together (enrichment → scoring → CRM push), use `run create --nodes` or `batch create --nodes` instead. See `tools.md` for workflow examples.
+
+---
+
+## Execute one action on one record
+
+```bash
+# Tool action
+cargo-ai orchestration action execute \
+  --action '{"kind":"tool","toolUuid":"<tool-uuid>","config":{}}' \
+  --data '{"domain":"acme.com"}'
+
+# Connector action
+cargo-ai orchestration action execute \
+  --action '{"kind":"connector","integrationSlug":"clearbit","actionSlug":"company_enrich","config":{}}' \
+  --data '{"domain":"acme.com"}'
+
+# Agent action
+cargo-ai orchestration action execute \
+  --action '{"kind":"agent","agentUuid":"<agent-uuid>","config":{}}' \
+  --data '{"company":"Acme Corp"}'
+```
+
+Returns a `run` object. Poll with `run get <uuid>` until terminal, or pass `--wait-until-finished`:
+
+```bash
+cargo-ai orchestration action execute \
+  --action '{"kind":"connector","integrationSlug":"clearbit","actionSlug":"company_enrich","config":{}}' \
+  --data '{"domain":"acme.com"}' \
+  --wait-until-finished
+```
+
+Custom polling interval (default 5000ms):
+
+```bash
+cargo-ai orchestration action execute \
+  --action '{"kind":"tool","toolUuid":"<tool-uuid>","config":{}}' \
+  --data '{"domain":"acme.com"}' \
+  --wait-until-finished --polling-interval 2000
+```
+
+### Response
+
+```json
+{
+  "run": {
+    "uuid": "run-uuid",
+    "status": "pending",
+    "createdAt": "2025-01-15T10:00:00Z"
+  }
+}
+```
+
+With `--wait-until-finished`, the response contains the terminal run state:
+
+```json
+{
+  "run": {
+    "uuid": "run-uuid",
+    "status": "success",
+    "createdAt": "2025-01-15T10:00:00Z",
+    "finishedAt": "2025-01-15T10:00:05Z"
+  }
+}
+```
+
+**Status values:** `pending`, `running`, `success`, `error`, `cancelled`.
+
+---
+
+## Execute one action on many records
+
+```bash
+cargo-ai orchestration action execute-batch \
+  --action '{"kind":"tool","toolUuid":"<tool-uuid>","config":{}}' \
+  --records '[{"domain":"acme.com"},{"domain":"globex.com"},{"domain":"initech.com"}]'
+```
+
+Returns a `batch` object. Poll with `batch get <uuid>` until terminal, or pass `--wait-until-finished`:
+
+```bash
+cargo-ai orchestration action execute-batch \
+  --action '{"kind":"connector","integrationSlug":"clearbit","actionSlug":"company_enrich","config":{}}' \
+  --records '[{"domain":"acme.com"},{"domain":"globex.com"}]' \
+  --wait-until-finished
+```
+
+### Webhook notification
+
+Get notified when the batch completes instead of polling:
+
+```bash
+cargo-ai orchestration action execute-batch \
+  --action '{"kind":"tool","toolUuid":"<tool-uuid>","config":{}}' \
+  --records '[{"domain":"acme.com"},{"domain":"globex.com"}]' \
+  --webhook-url "https://hooks.example.com/done" \
+  --webhook-secret "my-secret"
+```
+
+### Response
+
+```json
+{
+  "batch": {
+    "uuid": "batch-uuid",
+    "status": "pending",
+    "createdAt": "2025-01-15T10:00:00Z"
+  }
+}
+```
+
+With `--wait-until-finished`:
+
+```json
+{
+  "batch": {
+    "uuid": "batch-uuid",
+    "status": "success",
+    "runsCount": 3,
+    "executedRunsCount": 3,
+    "failedRunsCount": 0,
+    "creditsUsedCount": 3,
+    "createdAt": "2025-01-15T10:00:00Z",
+    "finishedAt": "2025-01-15T10:00:15Z"
+  }
+}
+```
+
+---
+
+## Retry configuration
+
+Add a `retry` object to the action for automatic retries on transient failures:
+
+```bash
+cargo-ai orchestration action execute \
+  --action '{
+    "kind":"connector",
+    "integrationSlug":"clearbit",
+    "actionSlug":"company_enrich",
+    "config":{},
+    "retry":{"maximumAttempts":3,"initialInterval":1000,"backoffCoefficient":2}
+  }' \
+  --data '{"domain":"acme.com"}' \
+  --wait-until-finished
+```
+
+---
+
+## Discovering action parameters
+
+To find the right values for each action kind:
+
+```bash
+# Tool actions — find toolUuid
+cargo-ai orchestration tool list
+# → Extract .tools[].uuid
+
+# Connector actions — find integrationSlug + actionSlug
+cargo-ai connection integration list
+cargo-ai connection integration get <slug>
+# → Extract actions from the integration
+
+# Agent actions — find agentUuid
+cargo-ai ai agent list
+# → Extract .agents[].uuid
+
+# Connector actions — find connectorUuid (optional, for authenticated connectors)
+cargo-ai connection connector list
+# → Extract .connectors[].uuid
+```
+
+---
+
+## End-to-end: enrich a company with a connector action
+
+```bash
+# 1. Find the integration and action
+cargo-ai connection integration get clearbit
+# → Find actionSlug: "company_enrich"
+
+# 2. Execute
+cargo-ai orchestration action execute \
+  --action '{"kind":"connector","integrationSlug":"clearbit","actionSlug":"company_enrich","config":{}}' \
+  --data '{"domain":"acme.com"}' \
+  --wait-until-finished
+# → Done. Check run.status for success/error.
+```
+
+## End-to-end: run a tool action on multiple leads
+
+```bash
+# 1. Find the tool
+cargo-ai orchestration tool list
+# → Find "Lead Enrichment", extract uuid
+
+# 2. Execute batch
+cargo-ai orchestration action execute-batch \
+  --action '{"kind":"tool","toolUuid":"<tool-uuid>","config":{}}' \
+  --records '[
+    {"email":"alice@acme.com","company":"Acme"},
+    {"email":"bob@globex.com","company":"Globex"},
+    {"email":"carol@initech.com","company":"Initech"}
+  ]' \
+  --wait-until-finished
+# → Check batch.status, batch.failedRunsCount
+```

--- a/cargo-cli-orchestration/references/agents.md
+++ b/cargo-cli-orchestration/references/agents.md
@@ -98,16 +98,16 @@ cargo-ai ai message create \
 # → Poll for response
 ```
 
-## Send a message with tools
+## Send a message with actions
 
-Give the agent access to specific tools for enrichment, CRM actions, etc.
+Give the agent access to specific actions for enrichment, CRM actions, etc.
 
 ```bash
 cargo-ai ai message create \
   --chat-uuid <chat-uuid> \
   --parts '[{"type":"text","text":"Enrich this lead and add to Salesforce"}]' \
-  --tools '[{"slug":"clearbit","kind":"tool","toolUuid": "<tool-uuid>","config":{}},{"slug":"salesforce","kind":"tool","config":{}}]'
-# → The agent can use these tools during its response
+  --actions '[{"slug":"clearbit","kind":"tool","toolUuid": "<tool-uuid>","config":{}},{"slug":"salesforce","kind":"tool","config":{}}]'
+# → The agent can use these actions during its response
 ```
 
 ## Send a message with model resources
@@ -137,7 +137,7 @@ cargo-ai ai message create \
 
 Lower temperature (0.0–0.3) for factual/structured tasks, higher (0.7–1.0) for creative tasks.
 
-## Send a message with tools, resources, and custom model
+## Send a message with actions, resources, and custom model
 
 Full example combining all options.
 
@@ -145,7 +145,7 @@ Full example combining all options.
 cargo-ai ai message create \
   --chat-uuid <chat-uuid> \
   --parts '[{"type":"text","text":"Research Acme Corp, enrich their data, and update our CRM"}]' \
-  --tools '[{"slug":"clearbit","kind":"tool","config":{}},{"slug":"salesforce","kind":"tool","config":{}}]' \
+  --actions '[{"slug":"clearbit","kind":"tool","config":{}},{"slug":"salesforce","kind":"tool","config":{}}]' \
   --resources '[{"slug":"companies","kind":"model","integrationSlug":"salesforce","modelUuid":"<model-uuid>"}]' \
   --language-model-slug gpt-4o \
   --temperature 0.3 \
@@ -195,7 +195,7 @@ cargo-ai ai release update-draft --agent-uuid agent-abc \
 cargo-ai ai file upload --file-path ./icp-criteria.pdf
 # → Extract file.uuid
 
-# Step 5 — Give the agent access to tools (optional — connectors as tools)
+# Step 5 — Give the agent access to actions (optional — connectors as actions)
 cargo-ai orchestration tool list
 # → Find a "Find Email" tool, extract uuid
 
@@ -210,7 +210,7 @@ cargo-ai ai chat create \
 cargo-ai ai message create \
   --chat-uuid <chat-uuid> \
   --parts '[{"type":"text","text":"Research the VP of Sales at acme.com. Find their name, LinkedIn URL, and email address."}]' \
-  --tools '[{"slug":"find_email","kind":"tool","toolUuid":"<email-finder-tool-uuid>","config":{}}]' \
+  --actions '[{"slug":"find_email","kind":"tool","toolUuid":"<email-finder-tool-uuid>","config":{}}]' \
   --max-steps 10
 # → Extract assistantMessage.uuid
 

--- a/cargo-cli-orchestration/references/nodes.md
+++ b/cargo-cli-orchestration/references/nodes.md
@@ -264,7 +264,7 @@ The `group` node iterates over `items`, running the child subgraph once per item
 | `python`   | Run Python code     | 1        | `{"script": "..."}`                                                                                    |
 | `script`   | Run JavaScript code | 1        | `{"script": "..."}`                                                                                    |
 
-The `agent` action requires `advancedSettings.connectorUuid` (an AI provider connector — get it from `connector list`). Optional fields: `tools`, `resources`, `capabilities`, `output` (structured output with `{"type": "jsonSchema", "jsonSchema": {...}}`), `advancedSettings.temperature`, `advancedSettings.maxSteps`, `advancedSettings.systemPrompt`.
+The `agent` action requires `advancedSettings.connectorUuid` (an AI provider connector — get it from `connector list`). Optional fields: `actions`, `resources`, `capabilities`, `output` (structured output with `{"type": "jsonSchema", "jsonSchema": {...}}`), `advancedSettings.temperature`, `advancedSettings.maxSteps`, `advancedSettings.systemPrompt`.
 
 The `python` and `script` nodes receive `nodes` and `parentNodes` as context variables. The return value of the script becomes the node's output under `{{nodes.<slug>.result}}`.
 

--- a/cargo-cli-orchestration/references/polling.md
+++ b/cargo-cli-orchestration/references/polling.md
@@ -169,5 +169,5 @@ Use `fallbackOnFailure: true` if you want execution to continue to the next node
 |---|---|---|
 | Run stuck in `pending` for >30s | Workflow not enabled, no deployed release | Check `isEnabled` on the tool/play; verify a release exists with `release list --workflow-uuid <uuid>` |
 | Batch never reaches a terminal `status` | Individual runs are stuck or erroring | Run `run list --workflow-uuid <uuid> --batch-uuid <uuid>` to inspect per-record status |
-| Agent message stuck in `generating` for >60s | Agent running multi-step tools | Wait up to 120s for complex agents; check `message get` for partial progress |
+| Agent message stuck in `generating` for >60s | Agent running multi-step actions | Wait up to 120s for complex agents; check `message get` for partial progress |
 | Batch shows `executedRunsCount` less than `runsCount` after a long time | Some records are stuck | Check `run list` for `pending` or `generating` statuses; contact support if persistent |

--- a/cargo-cli-orchestration/references/response-shapes.md
+++ b/cargo-cli-orchestration/references/response-shapes.md
@@ -169,6 +169,36 @@ JSON response structures returned by Cargo CLI commands used in the `cargo-cli-o
 
 **IMPORTANT:** `segment fetch` requires `--model-uuid`, not `--segment-uuid`. Get `modelUuid` from the segment list response.
 
+## cargo-ai orchestration action execute
+
+```json
+{
+  "run": {
+    "uuid": "run-uuid",
+    "status": "pending",
+    "createdAt": "2025-01-15T10:00:00Z"
+  }
+}
+```
+
+With `--wait-until-finished`, returns the terminal run state (same shape as `run get`).
+
+**Status values:** `pending`, `running`, `success`, `error`, `cancelled`.
+
+## cargo-ai orchestration action execute-batch
+
+```json
+{
+  "batch": {
+    "uuid": "batch-uuid",
+    "status": "pending",
+    "createdAt": "2025-01-15T10:00:00Z"
+  }
+}
+```
+
+With `--wait-until-finished`, returns the terminal batch state (same shape as `batch get`).
+
 ## cargo-ai orchestration run create
 
 ```json

--- a/cargo-cli-orchestration/references/tools.md
+++ b/cargo-cli-orchestration/references/tools.md
@@ -88,9 +88,45 @@ cargo-ai orchestration draft-release deploy \
 
 ---
 
+## Execute a single action (without a workflow)
+
+If you only need to run **one action** (e.g. a single enrichment call, one agent invocation), use `action execute` instead of building a full workflow. No `workflowUuid` or node graph required.
+
+```bash
+# Execute a tool action directly
+cargo-ai orchestration action execute \
+  --action '{"kind":"tool","toolUuid":"<tool-uuid>","config":{}}' \
+  --data '{"domain":"acme.com"}' \
+  --wait-until-finished
+
+# Execute a connector action directly
+cargo-ai orchestration action execute \
+  --action '{"kind":"connector","integrationSlug":"clearbit","actionSlug":"company_enrich","config":{}}' \
+  --data '{"domain":"acme.com"}' \
+  --wait-until-finished
+```
+
+For multiple records with a single action, use `action execute-batch`:
+
+```bash
+cargo-ai orchestration action execute-batch \
+  --action '{"kind":"tool","toolUuid":"<tool-uuid>","config":{}}' \
+  --records '[{"domain":"acme.com"},{"domain":"globex.com"},{"domain":"initech.com"}]' \
+  --wait-until-finished
+```
+
+**When to use `action execute` vs `run create`:**
+
+- **`action execute`** — one action, one record. No workflow needed.
+- **`action execute-batch`** — one action, many records. No workflow needed.
+- **`run create` with `--nodes`** — chain multiple actions together into a workflow (multi-step logic).
+- **`run create` with `--workflow-uuid`** — run an existing tool's persisted workflow.
+
+---
+
 ## Run a tool on a single record
 
-The most common use case — run the tool on one record. Tools support both `run create` (single record) and `batch create` (multiple records). Allowed batch data kinds for tools: `file`, `records`.
+The most common use case — run an existing tool workflow on one record. Tools support both `run create` (single record) and `batch create` (multiple records). Allowed batch data kinds for tools: `file`, `records`.
 
 ```bash
 # 1. Find the tool

--- a/cargo-cli-orchestration/references/tools.md
+++ b/cargo-cli-orchestration/references/tools.md
@@ -88,42 +88,6 @@ cargo-ai orchestration draft-release deploy \
 
 ---
 
-## Execute a single action (without a workflow)
-
-If you only need to run **one action** (e.g. a single enrichment call, one agent invocation), use `action execute` instead of building a full workflow. No `workflowUuid` or node graph required.
-
-```bash
-# Execute a tool action directly
-cargo-ai orchestration action execute \
-  --action '{"kind":"tool","toolUuid":"<tool-uuid>","config":{}}' \
-  --data '{"domain":"acme.com"}' \
-  --wait-until-finished
-
-# Execute a connector action directly
-cargo-ai orchestration action execute \
-  --action '{"kind":"connector","integrationSlug":"clearbit","actionSlug":"company_enrich","config":{}}' \
-  --data '{"domain":"acme.com"}' \
-  --wait-until-finished
-```
-
-For multiple records with a single action, use `action execute-batch`:
-
-```bash
-cargo-ai orchestration action execute-batch \
-  --action '{"kind":"tool","toolUuid":"<tool-uuid>","config":{}}' \
-  --records '[{"domain":"acme.com"},{"domain":"globex.com"},{"domain":"initech.com"}]' \
-  --wait-until-finished
-```
-
-**When to use `action execute` vs `run create`:**
-
-- **`action execute`** — one action, one record. No workflow needed.
-- **`action execute-batch`** — one action, many records. No workflow needed.
-- **`run create` with `--nodes`** — chain multiple actions together into a workflow (multi-step logic).
-- **`run create` with `--workflow-uuid`** — run an existing tool's persisted workflow.
-
----
-
 ## Run a tool on a single record
 
 The most common use case — run an existing tool workflow on one record. Tools support both `run create` (single record) and `batch create` (multiple records). Allowed batch data kinds for tools: `file`, `records`.

--- a/cargo-cli-orchestration/references/troubleshooting.md
+++ b/cargo-cli-orchestration/references/troubleshooting.md
@@ -27,8 +27,8 @@ Common errors and recovery steps for `cargo-cli-orchestration` commands.
 
 | Symptom                                                              | Cause                                    | Fix                                                                        |
 | -------------------------------------------------------------------- | ---------------------------------------- | -------------------------------------------------------------------------- |
-| Assistant message stuck in `pending` or `generating` for a long time | Agent may be running multi-step tools    | Wait longer (up to 60s for complex tasks); check with `message get <uuid>` |
-| Message returns `error` status                                       | Agent encountered an unrecoverable error | Read `.message.errorMessage`; try again with simpler input or fewer tools  |
+| Assistant message stuck in `pending` or `generating` for a long time | Agent may be running multi-step actions   | Wait longer (up to 60s for complex tasks); check with `message get <uuid>` |
+| Message returns `error` status                                       | Agent encountered an unrecoverable error | Read `.message.errorMessage`; try again with simpler input or fewer actions |
 | `Chat not found`                                                     | Wrong UUID or chat was deleted           | Re-create with `chat create`                                               |
 | `Agent not found`                                                    | Wrong UUID                               | Re-run `agent list` to get current UUIDs                                   |
 


### PR DESCRIPTION
Aligns skill documentation with CLI changes:
- Rename --tools to --actions in AI release deploy/update and message create
- Rename "tools" to "actions" in response shapes (releases, templates, MCP servers)
- Add action execute and action execute-batch documentation for single-action runs
- Add decision table: action.execute for one action, run.create/batch.create for chaining
- Update glossary with new "action" entry

https://claude.ai/code/session_01BFtdCQiK6YE6WLimLzPhz6