### PR TITLE
docs: add UI URL patterns for retrieving plays, tools, agents, and models

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -322,6 +322,19 @@ cargo-ai ai agent list
 cargo-ai segmentation segment list
 ```
 
+### Retrieve in the UI
+
+Each resource has a dedicated page in the Cargo app. Use these URL patterns to cross-reference a UUID returned by the CLI with the UI, or to extract a UUID from a URL the user pastes.
+
+| Resource | URL pattern                                                         |
+| -------- | ------------------------------------------------------------------- |
+| Play     | `app.getcargo.io/workspaces/<WORKSPACE_UUID>/plays/<PLAY_UUID>`     |
+| Tool     | `app.getcargo.io/workspaces/<WORKSPACE_UUID>/tools/<TOOL_UUID>`     |
+| Agent    | `app.getcargo.io/workspaces/<WORKSPACE_UUID>/agents/<AGENT_UUID>`   |
+| Model    | `app.getcargo.io/workspaces/<WORKSPACE_UUID>/models/<MODEL_UUID>`   |
+
+The workspace UUID is returned by `cargo-ai whoami` under `workspace.uuid`.
+
 ---
 
 ## End-to-end use cases

--- a/cargo-cli-ai/SKILL.md
+++ b/cargo-cli-ai/SKILL.md
@@ -42,6 +42,8 @@ cargo-ai ai mcp-server list                # all MCP servers (uuid, name)
 cargo-ai ai memory list --scope agent --agent-uuid <uuid>  # agent memories
 ```
 
+**Retrieve in the UI:** agents live at `app.getcargo.io/workspaces/<WORKSPACE_UUID>/agents/<AGENT_UUID>`. Get `<WORKSPACE_UUID>` from `cargo-ai whoami` under `workspace.uuid`.
+
 ## Quick reference
 
 ```bash

--- a/cargo-cli-orchestration/SKILL.md
+++ b/cargo-cli-orchestration/SKILL.md
@@ -75,6 +75,8 @@ cargo-ai connection connector list         # all connectors
 
 **Plays vs tools:** Both are backed by a workflow. A **play** is a segment-driven automation — it reacts to data changes in a segment (records added, updated, removed). A **tool** is an on-demand workflow — triggered manually, via API, or on a cron schedule. Workflows don't have a `name` field; use `play list` or `tool list` to find names and extract the `workflowUuid`.
 
+**Retrieve in the UI:** plays live at `app.getcargo.io/workspaces/<WORKSPACE_UUID>/plays/<PLAY_UUID>` and tools at `app.getcargo.io/workspaces/<WORKSPACE_UUID>/tools/<TOOL_UUID>`. Get `<WORKSPACE_UUID>` from `cargo-ai whoami` under `workspace.uuid`.
+
 **Designing a new tool or play?** Check templates first — they are pre-built node graphs for common automation patterns (enrichment pipelines, CRM syncs, lead scoring) and are an excellent starting point. List templates with `cargo-ai orchestration template list` and inspect a specific one with `cargo-ai orchestration template get <slug>`. Templates are tagged by `kind` so you can find ones suited for tools (`"kind":"tool"`) or plays (`"kind":"play"`) right away. See `references/templates.md` for the full guide.
 
 **Compatibility rules:**

--- a/cargo-cli-storage/SKILL.md
+++ b/cargo-cli-storage/SKILL.md
@@ -40,6 +40,8 @@ cargo-ai storage model list                # all models (uuid, name, slug, colum
 cargo-ai storage model list --dataset-uuid <uuid>   # models in a specific dataset
 ```
 
+**Retrieve in the UI:** models live at `app.getcargo.io/workspaces/<WORKSPACE_UUID>/models/<MODEL_UUID>`. Get `<WORKSPACE_UUID>` from `cargo-ai whoami` under `workspace.uuid`.
+
 ## Quick reference
 
 ```bash


### PR DESCRIPTION
## Summary
- Document the Cargo app URL patterns for plays, tools, agents, and models so a UUID returned by the CLI can be opened in the UI (and vice-versa).
- Add a "Retrieve in the UI" table to the main `SKILL.md` and one-line mentions in `cargo-cli-orchestration`, `cargo-cli-ai`, and `cargo-cli-storage` SKILL files.
- Point to `cargo-ai whoami` → `workspace.uuid` as the source of the workspace UUID.

## Test plan
- [ ] Skim the rendered diff on GitHub to confirm the table renders correctly in `SKILL.md`.
- [ ] Open a known play/tool/agent/model in the Cargo app and confirm each URL pattern matches what the app actually uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)