### PR TITLE
Use runContext (not title) as source of truth for debugging runs

### DIFF
--- a/cargo-cli-orchestration/SKILL.md
+++ b/cargo-cli-orchestration/SKILL.md
@@ -41,7 +41,7 @@ Need to run something?
 > `references/response-shapes.md` — full JSON response structures
 > `references/filter-syntax.md` — complete filter condition reference
 > `references/polling.md` — async polling patterns, error handling, retry strategies
-> `references/troubleshooting.md` — common errors and how to fix them
+> `references/troubleshooting.md` — common errors, plus a "Debugging a workflow run" section for runs that succeed but produce wrong output (wrong-branch routing, empty downstream values)
 
 ## Prerequisites
 
@@ -305,7 +305,7 @@ cargo-ai orchestration node validate --nodes '[...]'
 # → { "outcome": "valid" } or { "outcome": "notValid", "invalidNodes": [...] }
 ```
 
-For debugging, use `node compute` (dry-run expressions) or `node execute` (live test, costs credits). See `references/nodes.md` for the full node creation guide, validation error codes, and examples.
+For debugging, use `node compute` (dry-run expressions) or `node execute` (live test, costs credits). For runs that complete with `status: success` but produce wrong output (wrong branch taken, empty downstream values), use `run.executions[].title` from `run get` only as a quick summary — it may be truncated — and read `runContext.<nodeSlug>` (returned at the top level of the same `run get <run-uuid>` response) to verify field-level data. See `references/troubleshooting.md` → "Debugging a workflow run" and `references/nodes.md` for the full node creation guide, validation error codes, and examples.
 
 ## Help
 

--- a/cargo-cli-orchestration/references/nodes.md
+++ b/cargo-cli-orchestration/references/nodes.md
@@ -155,6 +155,8 @@ The `config` for an `agent` node takes two fields:
 }
 ```
 
+> **Reading agent output downstream — the `.answer` wrapper.** The parsed JSON is exposed under `.answer`, not directly on the node. Use `{{nodes.<slug>.answer.<field>}}` (e.g. `{{nodes.classify.answer.category}}`). Referencing `{{nodes.classify.category}}` resolves to undefined silently — branch conditions evaluate to false, end-node variables come out empty, and the run still reports `success`. This bites hard because nothing errors. Same path applies to `output.type: "text"` results — read them via `{{nodes.<slug>.answer}}`.
+
 ## Config values and expressions
 
 Config fields that need dynamic data use **expression objects**:
@@ -491,8 +493,8 @@ cargo-ai orchestration run create \
       "uuid":"f3f3f3f3-f3f3-4f3f-af3f-f3f3f3f3f3f3","slug":"end","kind":"native","actionSlug":"end",
       "config":{
         "variables":[
-          {"name":"category","type":"string","value":{"kind":"templateExpression","expression":"{{nodes.classify.category}}","instructTo":"none","fromRecipe":false}},
-          {"name":"reasoning","type":"string","value":{"kind":"templateExpression","expression":"{{nodes.classify.reasoning}}","instructTo":"none","fromRecipe":false}}
+          {"name":"category","type":"string","value":{"kind":"templateExpression","expression":"{{nodes.classify.answer.category}}","instructTo":"none","fromRecipe":false}},
+          {"name":"reasoning","type":"string","value":{"kind":"templateExpression","expression":"{{nodes.classify.answer.reasoning}}","instructTo":"none","fromRecipe":false}}
         ]
       },
       "childrenUuids":[],"fallbackOnFailure":false,
@@ -683,6 +685,8 @@ cargo-ai orchestration node compute \
 The `--context` object mirrors what nodes receive at runtime — `nodes.<slug>.<field>` for data from previous nodes. Inside a `group` loop, also pass `groupContext`.
 
 Response shows the resolved config values that would be sent to the connector or action.
+
+> **Don't use `node compute` to debug branch/condition logic.** The local evaluator does not reliably resolve `templateExpression` references against `--context` for boolean conditions — literals (`{{true}}`) work, but `{{nodes.qualify.answer.qualified}}` may return `false` even when the context has `qualified: true`. For branch debugging, prefer running the full graph with a single record (`batch create --data '{"kind":"recordIds",...}'`) and inspecting `run get <run-uuid>` — read `run.executions[].nodeChildIndex` / `nextNodeUuid` to see which branch was taken, and read `runContext.<upstreamSlug>` (returned at the top level of the same response) to verify the field the condition reads. `executions[].title` is only a truncated summary. See `references/troubleshooting.md` → "Debugging a workflow run".
 
 ## Node execute
 

--- a/cargo-cli-orchestration/references/plays.md
+++ b/cargo-cli-orchestration/references/plays.md
@@ -98,6 +98,8 @@ cargo-ai orchestration draft-release deploy \
 
 > **Do not skip validation.** Deploying an invalid node graph will cause runs to fail. Always run `node validate` before `draft-release deploy`.
 
+> **Do not pass `--version` to `draft-release deploy`.** The deploy-specific `--version` flag is shadowed by the global `--version` flag — passing it causes the command to print the CLI version (e.g. `1.0.11`) and exit 0 **without deploying**. Omit it and let the server auto-assign (first deploy → `1.0.0`, then `1.0.1`, etc.). Always confirm the deploy worked with `release get-deployed --workflow-uuid <uuid>` — the response should show `status: "deployed"`, not `draft`.
+
 ---
 
 ## Run a play's workflow on specific records

--- a/cargo-cli-orchestration/references/response-shapes.md
+++ b/cargo-cli-orchestration/references/response-shapes.md
@@ -226,11 +226,47 @@ With `--wait-until-finished`, returns the terminal batch state (same shape as `b
     "status": "success",
     "batchUuid": null,
     "releaseUuid": "...",
+    "recordId": "...",
+    "recordTitle": "...",
+    "contextS3Filename": "...",
+    "computedConfigsS3Filename": "...",
+    "executions": [
+      {
+        "nodeUuid": "...",
+        "nodeSlug": "qualify",
+        "nodeKind": "agent",
+        "nodeActionSlug": "...",
+        "nodeChildIndex": 0,
+        "nextNodeUuid": "...",
+        "status": "success",
+        "title": "✅ {\"qualified\":true,\"score\":8,...}",
+        "creditsUsedCount": 1,
+        "startedAt": "...",
+        "updatedAt": "...",
+        "finishedAt": "..."
+      }
+    ],
     "createdAt": "2025-01-15T10:00:00Z",
     "finishedAt": "2025-01-15T10:00:05Z"
+  },
+  "runContext": {
+    "start":   { "_id": "...", "domain": "acme.com" },
+    "qualify": { "answer": { "qualified": true, "score": 8, "reasoning": "..." } },
+    "is_qualified": { "condition": true },
+    "post_slack": { "ok": true, "channel": "C123", "ts": "..." },
+    "end": { "qualified": true, "score": 8, "slack_message_ts": "..." }
+  },
+  "runComputedConfigs": {
+    "qualify": { "...resolved config that was sent to the node..." }
   }
 }
 ```
+
+**Key fields for debugging:**
+
+- `run.executions[].title` — quick human-readable summary of each node's output; **may be truncated**, do not treat as the full output.
+- `runContext.<nodeSlug>` — the actual per-node output, keyed by `nodeSlug`. This is the canonical source for what `{{nodes.<slug>...}}` resolves to downstream. Agent nodes wrap their structured output under `.answer` (e.g. `runContext.qualify.answer.qualified`).
+- `runComputedConfigs.<nodeSlug>` — the resolved config values each node was actually called with (after template expression evaluation).
 
 ## cargo-ai orchestration batch create
 

--- a/cargo-cli-orchestration/references/troubleshooting.md
+++ b/cargo-cli-orchestration/references/troubleshooting.md
@@ -41,6 +41,76 @@ Common errors and recovery steps for `cargo-cli-orchestration` commands.
 | `outcome: "notQueried"` with permission error  | SoR connection issue                   | Verify the connection is active in Cargo; try `sor list` to check status          |
 | Query returns empty rows                       | Filter too restrictive, or wrong table | Verify table name with DDL; try a broader query first (`SELECT * ... LIMIT 5`)    |
 
+## Debugging a workflow run
+
+A run can finish with `status: "success"` and still be wrong — wrong branch taken, empty downstream values, no Slack message sent. Use this checklist when behavior doesn't match expectations.
+
+### 1. Pull the per-node executions and context
+
+```bash
+cargo-ai orchestration run get <run-uuid>
+```
+
+The response has three top-level fields:
+
+| Field                | What it gives you                                                                                |
+| -------------------- | ------------------------------------------------------------------------------------------------ |
+| `run.executions[]`   | Node-by-node trace (which node ran, status, routing)                                             |
+| `runContext`         | Full per-node output, keyed by `nodeSlug` — the actual data referenced as `{{nodes.<slug>...}}`  |
+| `runComputedConfigs` | Per-node resolved config values (what each node was actually called with), also keyed by `nodeSlug` |
+
+Each `executions[]` item has:
+
+| Field            | What it tells you                                                                                |
+| ---------------- | ------------------------------------------------------------------------------------------------ |
+| `nodeSlug`       | Which node ran                                                                                   |
+| `status`         | `success` / `error` for this node                                                                |
+| `nextNodeUuid`   | Where execution went next — for a `branch`, this reveals which child was taken                   |
+| `nodeChildIndex` | Index into `childrenUuids` that was followed (`0` = matched/yes, `1` = not matched/no for branch)|
+| `title`          | Human-readable **summary only** — may be truncated; do not treat as the full output              |
+| `creditsUsedCount` | Per-node cost; agent and connector nodes are non-zero, native nodes are zero                  |
+
+`title` is a quick sanity check, not a source of truth — it can be truncated. To verify the exact data a node produced, read `runContext.<nodeSlug>` from the same response. Deep-dive into it to confirm the path you're referencing in `{{nodes.<slug>....}}` actually exists (for example, an agent's structured output is nested under `.answer`, so the right path is `{{nodes.<slug>.answer.<field>}}` and not `{{nodes.<slug>.<field>}}`).
+
+### 2. Spot wrong-branch routing
+
+If a `branch` node's `title` says "❌ Condition is not matched" but you expected the yes-path, the condition expression resolved to falsy. Most common causes:
+
+| Cause | Fix |
+|---|---|
+| Path in the expression doesn't exist | Read `runContext.<upstreamSlug>` from `run get <run-uuid>` and check the actual shape — common case: an agent's output is nested under `.answer`, so `{{nodes.qualify.qualified}}` resolves to undefined while `{{nodes.qualify.answer.qualified}}` works |
+| Stringified boolean comparison | `{{nodes.qualify.answer.qualified === true}}` may evaluate the inner expression as a string template — prefer the truthy form `{{nodes.qualify.answer.qualified}}` |
+| Field actually missing from the output | The upstream node didn't produce it — `runContext.<upstreamSlug>` will confirm. For agents, this usually means revisiting the prompt + `jsonSchema` |
+| Typo in slug or field | Slugs are case-sensitive; `nodes.Qualify.answer.qualified` won't resolve |
+
+### 3. Re-run a single record after fixing
+
+```bash
+# Stage the fix without deploying (per workflow safety)
+cargo-ai orchestration draft-release update \
+  --workflow-uuid <play.workflowUuid> --nodes '[...]'
+
+# After approval, deploy (do NOT pass --version — it collides with the global flag)
+cargo-ai orchestration draft-release deploy \
+  --workflow-uuid <play.workflowUuid> --nodes '[...]' \
+  --form-fields 'null' --description "Fix branch condition"
+
+# Re-test against the same record IDs that exposed the bug
+cargo-ai orchestration batch create \
+  --workflow-uuid <play.workflowUuid> \
+  --data '{"kind":"recordIds","modelUuid":"<model>","ids":["id1","id2","id3"]}'
+```
+
+### 4. Common silent-failure modes
+
+| Symptom in `run get` | Likely cause |
+|---|---|
+| Run is `success` but nothing downstream of a node fired | Downstream expression resolved to undefined — open `runContext.<upstreamSlug>` from `run get` and compare against the path you wrote |
+| Branch always takes the same child | Condition references a non-existent path; `{{...}}` resolved to undefined which is falsy — verify against `runContext.<upstreamSlug>` |
+| `find_email`/connector node ran but downstream values are empty | Connector returned a partial response — read `runContext.<nodeSlug>` from `run get` to see the exact shape, then use the actual field names (e.g. `nodes.find_email.email` may be `nodes.find_email.contact.email` for some integrations) |
+| Slack post succeeded but message body has `{{...}}` literals | Template syntax error — a stray space or a missing closing `}}` makes the template engine treat the segment as plain text |
+| End-node variables are all empty in a successful run | The `value` expressions reference paths that don't exist; cross-check each upstream node's `runContext.<slug>` from `run get` (don't rely on `title` — it may be truncated) |
+
 ## Run error recovery
 
 When a run reaches `status: "error"`, follow this sequence:


### PR DESCRIPTION
## Summary
The troubleshooting guidance previously told readers to read `executions[].title`
to inspect a node's output when debugging a workflow run. `title` is a
human-readable summary that can be truncated, so it's unsafe as the source of
truth — readers verifying a `{{nodes.<slug>....}}` expression against `title`
could be misled into thinking a field is missing when it's actually present in
the node's real output.
`cargo-ai orchestration run get <run-uuid>` already returns three top-level
fields — `run` (metadata + `executions[]`), `runContext` (full per-node output
keyed by `nodeSlug`), and `runComputedConfigs` (resolved per-node configs). This
PR updates the docs to point debugging workflows at `runContext.<nodeSlug>`
instead of `title`, and documents the actual response shape (which
`response-shapes.md` was missing entirely — it only showed the `run` envelope).
It also softens prescriptive "always use `.answer`" guidance into the more
general principle "inspect the context to verify the path you're referencing",
with `.answer` kept as one illustrative example.
### Files changed
- `cargo-cli-orchestration/references/troubleshooting.md` — new top-level table
  documenting the three `run get` response fields; rewrote the "inspect agent
  output" paragraph to point at `runContext.<nodeSlug>`; updated branch-routing
  and silent-failure tables so every row that previously relied on `title` now
  references `runContext.<slug>`.
- `cargo-cli-orchestration/references/response-shapes.md` — expanded the
  `run get` example from a bare `run` envelope to a realistic three-key payload
  (including `executions[]`, `runContext`, `runComputedConfigs`) with a "Key
  fields for debugging" note.
- `cargo-cli-orchestration/references/nodes.md` — updated the branch-debugging
  callout to name `runContext.<upstreamSlug>` explicitly.
- `cargo-cli-orchestration/SKILL.md` — same update in the top-level debugging
  paragraph.
- `cargo-cli-orchestration/references/plays.md` — [pre-existing staged change,
  unrelated; include or split out as appropriate].
### Verified against
Ran `cargo-ai orchestration run get <uuid>` against a live run to confirm the
response actually has `run`, `runContext`, and `runComputedConfigs` at the top
level, and that agent nodes surface their structured output as
`runContext.<slug>.answer.<field>`.
## Test plan
- [ ] Manually open `troubleshooting.md` and confirm every reference to `title`
      as a source of truth has been replaced or qualified.
- [ ] Confirm the `response-shapes.md` example matches a real `run get`
      response for a workflow that includes an agent, a branch, and a
      connector node.
- [ ] Grep the skill for any remaining "inspect `executions[].title`"
      recommendations that should be updated.