### PR TITLE
Add workspace management report feature and guidance

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -36,6 +36,25 @@ Without a global install, prefix every command with `npx @cargo-ai/cli` instead 
 
 All commands output JSON to stdout. Failed commands exit non-zero and return `{"errorMessage": "..."}`.
 
+## When the CLI fails or you're stuck — send a workspace management report
+
+Whenever the CLI is failing in a way the skill references and `--help` cannot resolve, the user or agent is repeatedly retrying the same command without progress, the syntax for a flag / JSON payload is unclear, or a needed capability seems missing — escalate by submitting a report to **workspace management**:
+
+```bash
+cargo-ai workspace report create \
+  --title "<one-line summary of the problem>" \
+  --description "<exact command(s) tried, errorMessage, expected vs actual, UUIDs involved>"
+```
+
+Trigger conditions (any one is enough):
+
+- A command failed ≥ 2 times in a row on the same task and the cause is not obvious.
+- The CLI is being misused and the correct usage is not discoverable from the skills, examples, or `--help`.
+- A documented behavior contradicts what you observe.
+- A feature appears to be missing entirely.
+
+This is the official feedback channel — every report is reviewed by the Cargo team and used to improve the CLI and these skills. **Do not give up silently — file a report.** See `cargo-cli-workspace/SKILL.md` (Reports section) and `cargo-cli-workspace/references/examples/reports.md` for templates.
+
 ---
 
 ## Skills at a glance
@@ -48,7 +67,7 @@ All commands output JSON to stdout. Failed commands exit non-zero and return `{"
 | [`cargo-cli-storage`](#cargo-cli-storage)             | Inspect or modify data models, columns, datasets, and relationships                                |
 | [`cargo-cli-connection`](#cargo-cli-connection)       | Manage connector authentication, discover available integrations and their actions                 |
 | [`cargo-cli-ai`](#cargo-cli-ai)                       | Create and configure agents, upload files for RAG, manage MCP servers                              |
-| [`cargo-cli-workspace`](#cargo-cli-workspace)         | Invite users, create API tokens, organize folders, manage roles                                    |
+| [`cargo-cli-workspace`](#cargo-cli-workspace)         | Invite users, create API tokens, organize folders, manage roles, report CLI issues to management   |
 
 ---
 
@@ -245,7 +264,7 @@ See `cargo-cli-ai/SKILL.md` for model and temperature guidance by use case.
 
 ### cargo-cli-workspace
 
-**Workspace administration.** Use to invite users, create and rotate API tokens, organize plays/tools/agents into folders, and manage roles.
+**Workspace administration.** Use to invite users, create and rotate API tokens, organize plays/tools/agents into folders, manage roles, and **submit reports to workspace management when the CLI fails or is being misused**.
 
 **Key commands:**
 
@@ -254,12 +273,14 @@ cargo-ai whoami
 cargo-ai workspace user create --user-email user@example.com --role-slug <slug>
 cargo-ai workspace token create --from-user
 cargo-ai workspace folder create --name "Q1 Campaigns" --emoji-slug "rocket" --kind "play"
+cargo-ai workspace report create --title "<summary>" --description "<details>"
 ```
 
 **Critical rules:**
 
 - Most commands require a token with **admin access**.
 - Token values are only shown **once** at creation — store immediately in a secrets manager (GitHub Secrets, AWS Secrets Manager, etc.).
+- **Always send a `workspace report create`** when the CLI errors, is being used incorrectly, or you (user or agent) are struggling to make progress on a CLI task — see the section at the top of this file and `cargo-cli-workspace/references/examples/reports.md`.
 
 **References:** `cargo-cli-workspace/SKILL.md`
 

--- a/cargo-cli-workspace/SKILL.md
+++ b/cargo-cli-workspace/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cargo-cli-workspace
-description: Manage workspace users, API tokens, folders, and roles using the Cargo CLI. Use when the user wants to invite or manage workspace members, create or rotate API tokens, organize resources into folders, or inspect workspace roles and permissions.
+description: Manage workspace users, API tokens, folders, roles, and submit reports to workspace management using the Cargo CLI. Use when the user wants to invite or manage workspace members, create or rotate API tokens, organize resources into folders, inspect workspace roles and permissions, or submit a report to workspace management when the CLI fails or is misused.
 license: MIT
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo API token
 metadata:
@@ -10,13 +10,14 @@ metadata:
 
 # Cargo CLI — Workspace
 
-Workspace administration: managing users, API tokens, folders, roles, and workspace-level files.
+Workspace administration: managing users, API tokens, folders, roles, workspace-level files, and submitting reports to workspace management.
 
 > See `references/response-shapes.md` for full JSON response structures.
 > See `references/troubleshooting.md` for common errors and how to fix them.
 > See `references/examples/users.md` for user invite and management examples.
 > See `references/examples/tokens.md` for API token creation and rotation examples.
 > See `references/examples/folders.md` for organizing resources into folders.
+> See `references/examples/reports.md` for examples of submitting workspace management reports.
 
 ## Prerequisites
 
@@ -53,6 +54,7 @@ cargo-ai workspace token create --from-user
 cargo-ai workspace token remove <token-uuid>
 cargo-ai workspace folder list
 cargo-ai workspace folder create --name <name> --emoji-slug <slug> --kind <kind>
+cargo-ai workspace report create --title <title> --description <description>
 ```
 
 ## Current user and workspace
@@ -128,6 +130,40 @@ cargo-ai workspace folder update --uuid <folder-uuid> --name "Q1 2025 Campaigns"
 # Remove a folder
 cargo-ai workspace folder remove <folder-uuid>
 ```
+
+## Reports
+
+Submit a report to workspace management. **Use this whenever the CLI is failing, behaving unexpectedly, lacks a capability you need, or whenever you (user or agent) are struggling to accomplish a task with the CLI.** This is the official feedback channel — every report is reviewed by the Cargo team and used to improve the CLI, its skills, and the underlying APIs.
+
+```bash
+# Submit a report to workspace management
+cargo-ai workspace report create \
+  --title "<short summary>" \
+  --description "<detailed description, including the command(s) tried and the error(s) seen>"
+```
+
+**When to send a report (non-exhaustive):**
+
+- A command exits non-zero with an `errorMessage` you cannot resolve from `--help` or `references/troubleshooting.md`.
+- The CLI is being misused or the syntax is unclear (e.g. you can't figure out which flag to pass, or the JSON schema for `--filter` / `--nodes` / `--action` is ambiguous).
+- A user or AI agent is repeatedly retrying the same command without progress (≥ 2 failed attempts on the same task).
+- A documented command does not behave as the skill describes, or a response shape differs from what `references/response-shapes.md` documents.
+- A capability appears to be missing entirely (no command exists for what you need to do).
+- An async operation never reaches a terminal status, or returns inconsistent results across runs.
+
+**What to put in the report:**
+
+- `--title`: one-line summary of the problem (e.g. `"batch create fails with 'playNotCompatible' on tool workflow"`).
+- `--description`: include the exact command(s) executed (with sensitive values redacted), the JSON `errorMessage`, what you expected, what you tried, and any relevant UUIDs (run, batch, workflow, model). The more context you provide, the faster it can be triaged.
+
+```bash
+# Example: report a CLI struggle after multiple failed attempts
+cargo-ai workspace report create \
+  --title "segment fetch returns empty results despite matching records in UI" \
+  --description "Ran: cargo-ai segmentation segment fetch --model-uuid <uuid> --filter '{\"conjunction\":\"and\",\"groups\":[...]}'. Got 0 records. The same filter shows 1,200 matches in the app UI. Tried both --filter and --segment-uuid; both return empty. Expected: the same records as the UI."
+```
+
+> Do not silently give up on a failing CLI task. **Send a report.** This closes the feedback loop so the CLI and these skills can be improved.
 
 ## Workspace files
 

--- a/cargo-cli-workspace/references/examples/reports.md
+++ b/cargo-cli-workspace/references/examples/reports.md
@@ -1,0 +1,80 @@
+# Report examples
+
+`cargo-ai workspace report create` submits a report to **workspace management** — the Cargo team's official feedback channel for the CLI and its skills.
+
+**Always send a report when:**
+
+- A CLI command fails and the cause is not obvious from `--help`, `references/response-shapes.md`, or `references/troubleshooting.md`.
+- The user or the AI agent is struggling to use the CLI: repeated failed attempts (≥ 2) on the same task, ambiguous flags, unclear JSON schemas, or commands that don't behave as documented.
+- A capability seems to be missing entirely (no command exists for the operation needed).
+- A response shape, error message, or async behavior contradicts what the skills describe.
+- The CLI is being used incorrectly and the correct usage is not discoverable from the existing documentation.
+
+Reports are how these skills and the CLI improve. **Do not give up silently — file a report.**
+
+## Submit a report
+
+```bash
+cargo-ai workspace report create \
+  --title "<one-line summary of the problem>" \
+  --description "<exact command, error, expected vs actual, relevant UUIDs>"
+```
+
+Both `--title` and `--description` are required. The command returns the created report as JSON.
+
+## What to include in the description
+
+Always include, when relevant:
+
+- The exact command(s) you ran, with secrets/tokens redacted.
+- The full `errorMessage` from the JSON output.
+- What you expected to happen and what actually happened.
+- Any UUIDs referenced (run, batch, workflow, model, segment, agent, connector, …).
+- How many times the failure was reproduced and any variations tried.
+- The skill / reference page consulted before reporting (so the team knows what was already tried).
+
+## Examples
+
+### CLI command fails with an unhelpful error
+
+```bash
+cargo-ai workspace report create \
+  --title "orchestration run create returns 'playNotCompatible' on a tool workflow" \
+  --description "Ran: cargo-ai orchestration run create --workflow-uuid abc-123 --data '{\"domain\":\"acme.com\"}'. Got: {\"errorMessage\":\"playNotCompatible\"}. The workflow UUID was returned by 'orchestration tool list', so it should be a tool workflow. Skill consulted: cargo-cli-orchestration/SKILL.md decision flowchart."
+```
+
+### Filter syntax is unclear / silently returns empty
+
+```bash
+cargo-ai workspace report create \
+  --title "segment fetch returns 0 records despite UI showing matches" \
+  --description "Ran: cargo-ai segmentation segment fetch --model-uuid <uuid> --filter '{\"conjonction\":\"and\",\"groups\":[{\"conjonction\":\"and\",\"conditions\":[{\"kind\":\"string\",\"columnSlug\":\"country\",\"operator\":\"is\",\"values\":[\"US\"]}]}]}'. Got 0 records. The same filter in the app UI shows 1,200 matches. Tried 'conjunction' and 'conjonction' spellings — both return 0."
+```
+
+### Agent is struggling with the CLI after multiple retries
+
+```bash
+cargo-ai workspace report create \
+  --title "Agent unable to determine correct --action JSON for HubSpot company_create" \
+  --description "Tried 4 variants of cargo-ai orchestration action execute --action '{\"kind\":\"connector\",\"integrationSlug\":\"hubspot\",\"actionSlug\":\"company_create\",\"config\":{}}' --data '{...}'. Each fails with a different validation error ('config.portalId required', then 'data.properties required', etc.). The required shape is not documented in cargo-cli-connection or cargo-cli-orchestration. Need a worked example or a schema reference."
+```
+
+### Missing capability
+
+```bash
+cargo-ai workspace report create \
+  --title "No CLI command to bulk re-run failed records from a previous batch" \
+  --description "Trying to re-run only the failed records from batch <uuid>. 'analytics run download --statuses error' produces a CSV but there is no documented way to feed that CSV back into 'orchestration batch create' as the input set without manual transformation. A '--from-failed-batch <uuid>' option (or equivalent) appears to be missing."
+```
+
+### Documentation contradicts observed behavior
+
+```bash
+cargo-ai workspace report create \
+  --title "billing usage get-metrics --group-by workflow_uuid returns connector_uuid groupings" \
+  --description "Ran: cargo-ai billing usage get-metrics --from 2025-01-01 --to 2025-01-31 --group-by workflow_uuid. Response groups results by connector_uuid instead of workflow_uuid. cargo-cli-billing/SKILL.md says workflow_uuid is a valid --group-by value."
+```
+
+## After sending a report
+
+The CLI prints the created report as JSON. Note the returned `uuid` so it can be referenced in any follow-up communication with the Cargo team. After reporting, fall back to the closest documented workaround (e.g. the Cargo app UI) so the user is unblocked.

--- a/cargo-cli-workspace/references/troubleshooting.md
+++ b/cargo-cli-workspace/references/troubleshooting.md
@@ -2,6 +2,16 @@
 
 Common errors and recovery steps for `cargo-cli-workspace` commands.
 
+> **If the table below does not resolve the issue, or you (user or agent) are stuck on any Cargo CLI command after ≥ 2 failed attempts, send a workspace management report:**
+>
+> ```bash
+> cargo-ai workspace report create \
+>   --title "<one-line summary>" \
+>   --description "<command run, error message, what you expected, UUIDs involved>"
+> ```
+>
+> See `examples/reports.md` for guidance on what to include. Reports are how the Cargo team improves the CLI and these skills.
+
 ## General
 
 | Symptom | Cause | Fix |
@@ -40,3 +50,22 @@ Common errors and recovery steps for `cargo-cli-workspace` commands.
 |---------|-------|-----|
 | `file list-columns` returns empty | Wrong `s3-filename` or file has no headers | Verify the `s3-filename` from the upload response; ensure the CSV has a header row |
 | `file upload` fails | File too large or unsupported format | Check file size limits; ensure the file is a CSV or supported format |
+
+## When nothing else works — submit a report
+
+Whenever the CLI is failing in a way none of the tables above explain, the syntax for a flag is unclear, the agent is looping on the same task, or a needed capability appears to be missing — escalate by submitting a workspace management report:
+
+```bash
+cargo-ai workspace report create \
+  --title "<short summary>" \
+  --description "<exact command, errorMessage, expected vs actual, UUIDs>"
+```
+
+Trigger conditions (any one is enough):
+
+- A command failed ≥ 2 times in a row on the same task.
+- The user or agent does not know which flag / JSON shape to use, and `--help` plus the skill references do not resolve it.
+- A documented behavior contradicts what you observe.
+- A feature seems to be missing entirely.
+
+See `examples/reports.md` for full templates.


### PR DESCRIPTION
## Summary

This PR introduces the `cargo-ai workspace report create` command and comprehensive documentation to guide users and AI agents on when and how to submit reports to workspace management. Reports are the official feedback channel for CLI issues, missing features, and usage struggles.

## Key Changes

- **New command:** `cargo-ai workspace report create --title <title> --description <description>` for submitting issues to workspace management
- **New reference guide:** `cargo-cli-workspace/references/examples/reports.md` with detailed examples of report submissions covering:
  - CLI command failures with unhelpful errors
  - Unclear filter syntax and silent failures
  - Agent struggles after multiple retries
  - Missing capabilities
  - Documentation contradictions
- **Updated SKILL.md files:**
  - `cargo-cli-workspace/SKILL.md`: Added Reports section with trigger conditions and what to include in descriptions
  - Root `SKILL.md`: Added prominent section on when to send reports, positioned before the skills overview
- **Enhanced troubleshooting:** `cargo-cli-workspace/references/troubleshooting.md` now includes:
  - Callout at the top directing users to submit reports when stuck
  - New "When nothing else works" section with report submission guidance
  - Explicit trigger conditions for escalation

## Notable Implementation Details

- Reports require both `--title` and `--description` flags (both mandatory)
- Emphasis on including exact commands (with secrets redacted), full error messages, UUIDs, and reproduction steps
- Clear guidance that reports should be filed after ≥2 failed attempts on the same task
- Positioned as the official feedback loop for CLI and skill improvements
- Consistent messaging across all documentation that users/agents should "not give up silently"

https://claude.ai/code/session_0142TgCQUvSCFQHkA6gqxPNU