### PR TITLE
Document token names and permissions in API token management

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -271,7 +271,7 @@ See `cargo-ai/SKILL.md` for model and temperature guidance by use case.
 ```bash
 cargo-ai whoami
 cargo-ai workspace user create --user-email user@example.com --role-slug <slug>
-cargo-ai workspace token create --from-user
+cargo-ai workspace token create --name "CI/CD pipeline"
 cargo-ai workspace folder create --name "Q1 Campaigns" --emoji-slug "rocket" --kind "play"
 cargo-ai workspace report create --title "<summary>" --description "<details>"
 ```
@@ -279,6 +279,7 @@ cargo-ai workspace report create --title "<summary>" --description "<details>"
 **Critical rules:**
 
 - Most commands require a token with **admin access**.
+- `workspace token create` requires `--name` (the legacy `--from-user` flag was removed). Pick a name that makes the token's purpose obvious in `token list` later.
 - Token values are only shown **once** at creation — store immediately in a secrets manager (GitHub Secrets, AWS Secrets Manager, etc.).
 - **Always send a `workspace report create`** when the CLI errors, is being used incorrectly, or you (user or agent) are struggling to make progress on a CLI task — see the section at the top of this file and `cargo-workspace-management/references/examples/reports.md`.
 
@@ -425,7 +426,7 @@ The workspace UUID is returned by `cargo-ai whoami` under `workspace.uuid`.
 **Skills needed:** `cargo-workspace-management`, `cargo-storage`, `cargo-connection`, `cargo-ai`
 
 ```
-1. workspace token create          → create a dedicated API token
+1. workspace token create --name <label>   → create a dedicated, named API token
 2. workspace role list             → discover available roles
 3. workspace user create           → invite team members
 4. storage model create            → create Companies and Contacts models
@@ -461,7 +462,7 @@ The workspace UUID is returned by `cargo-ai whoami` under `workspace.uuid`.
 | `run create` vs `batch create`     | `run create` only works with **tool** workflows. Using a play's `workflowUuid` returns `playNotCompatible`.                                                                                                                                   |
 | `--model-uuid` vs `--segment-uuid` | `segment fetch` and `segment download` require `--model-uuid`. Get it from `segment list` → `.modelUuid`.                                                                                                                                     |
 | DDL before SQL                     | Never guess table names. Always run `model get-ddl <uuid>` first. Table names look like `datasets_default.models_companies`.                                                                                                                  |
-| Token shown once                   | API token values are only returned at creation. Store immediately.                                                                                                                                                                            |
+| Token shown once                   | API token values are only returned at creation. Store immediately. `workspace token create` requires `--name` (no more `--from-user`).                                                                                                        |
 | Invoice amounts in cents           | `subscription get-invoices` returns `amount` in cents. Divide by 100.                                                                                                                                                                         |
 | Plays vs tools                     | **Play** = reacts to data changes (segment-driven). **Tool** = triggered on demand (manual, API, cron).                                                                                                                                       |
 | Batch data kinds                   | Play workflows accept: `segment`, `change`, `filter`, `recordIds`. Tool workflows accept: `file`, `records`.                                                                                                                                  |

--- a/cargo-workspace-management/SKILL.md
+++ b/cargo-workspace-management/SKILL.md
@@ -96,7 +96,7 @@ Always check available roles before inviting users — use the `slug` from `role
 
 ## API tokens
 
-Each token has a human-readable `name` and a `permissions` field. Tokens created via the CLI are issued with full workspace access (`permissions: null`); fine-grained permission scoping is configured via the API or the Cargo app.
+Each token has a human-readable `name` and a `permissions` field. Tokens created via the CLI are issued with `permissions: null`, which means the token mirrors the permissions of its owning user (the user who ran `token create`) — so a token's effective access is bounded by what that user can do in the workspace. Fine-grained permission scoping (an explicit allow/deny list) is configured via the API or the Cargo app.
 
 ```bash
 # List all API tokens (includes name and permissions of each token)

--- a/cargo-workspace-management/SKILL.md
+++ b/cargo-workspace-management/SKILL.md
@@ -50,7 +50,7 @@ cargo-ai whoami
 cargo-ai workspace user list
 cargo-ai workspace user create --user-email <email> --role-slug <slug>
 cargo-ai workspace token list
-cargo-ai workspace token create --from-user
+cargo-ai workspace token create --name <name>
 cargo-ai workspace token remove <token-uuid>
 cargo-ai workspace folder list
 cargo-ai workspace folder create --name <name> --emoji-slug <slug> --kind <kind>
@@ -96,17 +96,21 @@ Always check available roles before inviting users — use the `slug` from `role
 
 ## API tokens
 
+Each token has a human-readable `name` and a `permissions` field. Tokens created via the CLI are issued with full workspace access (`permissions: null`); fine-grained permission scoping is configured via the API or the Cargo app.
+
 ```bash
-# List all API tokens
+# List all API tokens (includes name and permissions of each token)
 cargo-ai workspace token list
 
-# Create a new token (scoped to your user)
-cargo-ai workspace token create --from-user
+# Create a new token — --name is required
+cargo-ai workspace token create --name "CI/CD pipeline"
 # → Returns the token value — store it securely, it won't be shown again
 
 # Remove a token
 cargo-ai workspace token remove <token-uuid>
 ```
+
+**Naming:** Pick a `--name` that makes the token's purpose obvious in `token list` later (e.g. `"GitHub Actions — production"`, `"Local dev — alice"`, `"Zapier integration"`). The name is the only way to tell tokens apart in the listing.
 
 **Security:** Token values are only shown once at creation. Store them in a secrets manager (e.g. GitHub Secrets, AWS Secrets Manager).
 

--- a/cargo-workspace-management/references/examples/tokens.md
+++ b/cargo-workspace-management/references/examples/tokens.md
@@ -1,6 +1,6 @@
 # API token examples
 
-Every token has a human-readable `name` and a `permissions` field. The CLI's `token create` always issues a token with full workspace access (`permissions: null`); use the API or the Cargo app to scope a token to a subset of actions / resources.
+Every token has a human-readable `name` and a `permissions` field. The CLI's `token create` always issues a token with `permissions: null`, which means the token mirrors the permissions of the user who created it — its effective access is whatever that user can do in the workspace. Use the API or the Cargo app to scope a token to a different subset of actions / resources.
 
 ## List all tokens
 
@@ -19,6 +19,8 @@ cargo-ai workspace token create --name "CI/CD pipeline"
 ```
 
 The response includes the `token` field — this is the only time the token value is shown. Store it immediately in a secrets manager.
+
+> The new token inherits the permissions of the user running `token create`. If you need a token with broader or narrower access than your user, create it under the appropriate user account, or scope it explicitly via the API / Cargo app after creation.
 
 ## Rotate a token (replace an old one)
 

--- a/cargo-workspace-management/references/examples/tokens.md
+++ b/cargo-workspace-management/references/examples/tokens.md
@@ -1,25 +1,30 @@
 # API token examples
 
+Every token has a human-readable `name` and a `permissions` field. The CLI's `token create` always issues a token with full workspace access (`permissions: null`); use the API or the Cargo app to scope a token to a subset of actions / resources.
+
 ## List all tokens
 
 ```bash
 cargo-ai workspace token list
-# → Shows token UUID and creation date (not the token value)
+# → Each entry includes `uuid`, `name`, `permissions`, `userUuid`, `workspaceUuid`, `createdAt`, `deletedAt`
+# (the actual token value is not shown — it is only returned once, at creation)
 ```
 
 ## Create a new token
 
+`--name` is required. Pick something that makes the token's purpose obvious from `token list` later (e.g. `"CI/CD pipeline"`, `"GitHub Actions — production"`, `"Local dev — alice"`).
+
 ```bash
-cargo-ai workspace token create --from-user
+cargo-ai workspace token create --name "CI/CD pipeline"
 ```
 
-Response includes the `token` field — this is the only time the token value is shown. Store it immediately in a secrets manager.
+The response includes the `token` field — this is the only time the token value is shown. Store it immediately in a secrets manager.
 
 ## Rotate a token (replace an old one)
 
 ```bash
-# 1. Create the new token first
-cargo-ai workspace token create --from-user
+# 1. Create the new token first (give it a clear name)
+cargo-ai workspace token create --name "CI/CD pipeline (rotated 2026-01)"
 # → Save the new token value
 
 # 2. Update all systems using the old token to use the new value
@@ -39,5 +44,5 @@ cargo-ai workspace token remove <token-uuid>
 ```bash
 cargo-ai whoami
 # → The active token is the one used for authentication in the current session
-# Run `workspace token list` to see all tokens
+# Run `workspace token list` to see all tokens and their names
 ```

--- a/cargo-workspace-management/references/response-shapes.md
+++ b/cargo-workspace-management/references/response-shapes.md
@@ -78,7 +78,7 @@ JSON response structures returned by Cargo CLI commands used in the `cargo-works
 **Key fields:**
 
 - `name`: human-readable label assigned at creation (`--name` flag).
-- `permissions`: `null` means the token has full workspace access. When non-null, it is an array of permission rules `{ effect, resources, actions }` that scope the token to specific actions / resources. CLI-created tokens are always `null`; scoped tokens are configured via the API or the Cargo app.
+- `permissions`: `null` means the token mirrors the permissions of its owning user (the user identified by `userUuid`) — its effective access is bounded by what that user can do. When non-null, it is an array of permission rules `{ effect, resources, actions }` that scope the token explicitly. CLI-created tokens are always `null`; explicitly scoped tokens are configured via the API or the Cargo app.
 - `deletedAt`: `null` for active tokens; an ISO timestamp once the token has been removed.
 
 ## cargo-ai workspace token create
@@ -98,11 +98,11 @@ JSON response structures returned by Cargo CLI commands used in the `cargo-works
 }
 ```
 
-**Important:** Save the `token` value immediately — it is shown only once and cannot be retrieved again. The `name` you pass via `--name` is echoed back in the response and shown in `token list`.
+**Important:** Save the `token` value immediately — it is shown only once and cannot be retrieved again. The `name` you pass via `--name` is echoed back in the response and shown in `token list`. The `userUuid` is the user whose permissions the token inherits when `permissions` is `null`.
 
 ### Permission shape (when not null)
 
-When a token has been scoped (via API or app), `permissions` is an array of rules:
+When a token has been explicitly scoped (via API or app), `permissions` is an array of rules:
 
 ```json
 [
@@ -122,6 +122,8 @@ When a token has been scoped (via API or app), `permissions` is an array of rule
 - `effect`: `"allow"` or `"deny"`.
 - `resources`: array of resource UUIDs (workflow, folder, etc.) that the rule applies to, or `null` for workspace-wide.
 - `actions`: array of dotted action strings, e.g. `"orchestration:*"`, `"orchestration:workflow:read"`, `"workspaceManagement:folder:write"`, `"ai:agent:write"`. The `*` wildcard at any level grants every action below it.
+
+When `permissions` is non-null, the rules are evaluated independently of the owning user — the token's access is exactly what the rules describe, regardless of what `userUuid` can do.
 
 ## cargo-ai workspace folder list
 

--- a/cargo-workspace-management/references/response-shapes.md
+++ b/cargo-workspace-management/references/response-shapes.md
@@ -62,9 +62,12 @@ JSON response structures returned by Cargo CLI commands used in the `cargo-works
   "tokens": [
     {
       "uuid": "token-uuid",
+      "name": "CI/CD pipeline",
+      "permissions": null,
       "workspaceUuid": "workspace-uuid",
       "userUuid": "user-uuid",
-      "createdAt": "2025-01-01T00:00:00Z"
+      "createdAt": "2025-01-01T00:00:00Z",
+      "deletedAt": null
     }
   ]
 }
@@ -72,21 +75,53 @@ JSON response structures returned by Cargo CLI commands used in the `cargo-works
 
 **Note:** Token values are not returned in `token list`. The actual token string is only returned once at creation time.
 
+**Key fields:**
+
+- `name`: human-readable label assigned at creation (`--name` flag).
+- `permissions`: `null` means the token has full workspace access. When non-null, it is an array of permission rules `{ effect, resources, actions }` that scope the token to specific actions / resources. CLI-created tokens are always `null`; scoped tokens are configured via the API or the Cargo app.
+- `deletedAt`: `null` for active tokens; an ISO timestamp once the token has been removed.
+
 ## cargo-ai workspace token create
 
 ```json
 {
   "token": {
     "uuid": "token-uuid",
-    "token": "cai_live_xxxxxxxxxxxxxxxxxxxx",
+    "token": "<token-value>",
+    "name": "CI/CD pipeline",
+    "permissions": null,
     "workspaceUuid": "workspace-uuid",
     "userUuid": "user-uuid",
-    "createdAt": "2025-01-01T00:00:00Z"
+    "createdAt": "2025-01-01T00:00:00Z",
+    "deletedAt": null
   }
 }
 ```
 
-**Important:** Save the `token` value immediately — it is shown only once and cannot be retrieved again.
+**Important:** Save the `token` value immediately — it is shown only once and cannot be retrieved again. The `name` you pass via `--name` is echoed back in the response and shown in `token list`.
+
+### Permission shape (when not null)
+
+When a token has been scoped (via API or app), `permissions` is an array of rules:
+
+```json
+[
+  {
+    "effect": "allow",
+    "resources": ["<workflow-uuid>", "<folder-uuid>"],
+    "actions": ["orchestration:workflow:read", "orchestration:workflow:write"]
+  },
+  {
+    "effect": "deny",
+    "resources": null,
+    "actions": ["workspaceManagement:write"]
+  }
+]
+```
+
+- `effect`: `"allow"` or `"deny"`.
+- `resources`: array of resource UUIDs (workflow, folder, etc.) that the rule applies to, or `null` for workspace-wide.
+- `actions`: array of dotted action strings, e.g. `"orchestration:*"`, `"orchestration:workflow:read"`, `"workspaceManagement:folder:write"`, `"ai:agent:write"`. The `*` wildcard at any level grants every action below it.
 
 ## cargo-ai workspace folder list
 

--- a/cargo-workspace-management/references/troubleshooting.md
+++ b/cargo-workspace-management/references/troubleshooting.md
@@ -34,10 +34,11 @@ Common errors and recovery steps for `cargo-workspace-management` commands.
 | Symptom | Cause | Fix |
 |---------|-------|-----|
 | `token create` exits with `error: required option '--name <name>' not specified` | `--name` is required since the named-token migration | Pass `--name "<descriptive label>"` (e.g. `--name "CI/CD pipeline"`) |
-| `token create` rejected with `error: unknown option '--from-user'` | Legacy flag — removed when tokens gained `name` and `permissions` | Drop `--from-user`; use `--name <name>` instead |
+| `token create` rejected with `error: unknown option '--from-user'` | Legacy flag — removed when tokens gained `name` and `permissions` | Drop `--from-user`; use `--name <name>` instead. CLI-created tokens already inherit the creating user's permissions (`permissions: null`) |
 | Lost the token value after creation | Token value only shown once | Remove the token and create a new one (with the same `--name`); store the new value securely |
 | `token remove` fails | Token is currently in use by active processes | Wait for processes to finish, or rotate to a new token first then remove the old one |
-| `Unauthorized` errors in CI/CD | Token expired, removed, or scoped permissions are too narrow | Verify the token still exists with `workspace token list`; check its `permissions` field; if scoped, widen via the API/app or create a new full-access token |
+| `Unauthorized` errors in CI/CD with a CLI-created token | Token mirrors the creating user's permissions; that user lost access (role downgraded, removed, etc.) | Verify the token still exists with `workspace token list`; check the role of the user in `userUuid` (`workspace user list`); restore the user's permissions, or recreate the token under a user with the access you need |
+| `Unauthorized` errors in CI/CD with an explicitly scoped token | `permissions` array is too narrow for the action being attempted | Inspect the token's `permissions` field via `workspace token list`; widen via the API/app, or replace with a `permissions: null` token created by a user that has the required access |
 | Two tokens look identical in `token list` | Both were created without a meaningful `--name` | Use `--name` consistently — the name is the only label distinguishing tokens in the listing |
 
 ## Folders

--- a/cargo-workspace-management/references/troubleshooting.md
+++ b/cargo-workspace-management/references/troubleshooting.md
@@ -33,9 +33,12 @@ Common errors and recovery steps for `cargo-workspace-management` commands.
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| Lost the token value after creation | Token value only shown once | Remove the token and create a new one; store the new value securely |
+| `token create` exits with `error: required option '--name <name>' not specified` | `--name` is required since the named-token migration | Pass `--name "<descriptive label>"` (e.g. `--name "CI/CD pipeline"`) |
+| `token create` rejected with `error: unknown option '--from-user'` | Legacy flag — removed when tokens gained `name` and `permissions` | Drop `--from-user`; use `--name <name>` instead |
+| Lost the token value after creation | Token value only shown once | Remove the token and create a new one (with the same `--name`); store the new value securely |
 | `token remove` fails | Token is currently in use by active processes | Wait for processes to finish, or rotate to a new token first then remove the old one |
-| `Unauthorized` errors in CI/CD | Token expired or removed | Create a new token and update the secret in your CI/CD environment |
+| `Unauthorized` errors in CI/CD | Token expired, removed, or scoped permissions are too narrow | Verify the token still exists with `workspace token list`; check its `permissions` field; if scoped, widen via the API/app or create a new full-access token |
+| Two tokens look identical in `token list` | Both were created without a meaningful `--name` | Use `--name` consistently — the name is the only label distinguishing tokens in the listing |
 
 ## Folders
 


### PR DESCRIPTION
## Summary
Updated documentation across multiple files to reflect the introduction of human-readable token names and fine-grained permission scoping for API tokens. The `--name` flag is now required when creating tokens, and the `--from-user` flag has been removed.

## Key Changes

- **Response shapes** (`response-shapes.md`):
  - Added `name` and `deletedAt` fields to token list and create responses
  - Documented that `permissions` is `null` for full workspace access, or an array of permission rules for scoped tokens
  - Added detailed explanation of permission rule structure with `effect`, `resources`, and `actions` fields
  - Clarified that CLI-created tokens always have `permissions: null`

- **Examples** (`tokens.md`):
  - Updated `token create` command from `--from-user` to `--name "descriptive label"`
  - Added guidance on choosing meaningful token names for easy identification in listings
  - Updated token rotation example to show naming convention for rotated tokens
  - Clarified that token value is only shown once at creation

- **Skill documentation** (`SKILL.md`):
  - Updated command syntax from `--from-user` to `--name <name>`
  - Added section explaining token naming best practices
  - Documented that CLI tokens have full workspace access while API/app can scope permissions
  - Emphasized storing token values securely

- **Troubleshooting** (`troubleshooting.md`):
  - Added entries for missing `--name` flag error
  - Added entry for deprecated `--from-user` flag
  - Updated token loss recovery guidance to mention recreating with same name
  - Enhanced `Unauthorized` error troubleshooting to include permission scoping checks
  - Added guidance for distinguishing tokens by meaningful names

## Notable Details

- The `name` field is now the primary way to identify and distinguish tokens in listings
- Permission scoping supports wildcards (e.g., `"orchestration:*"`) and can be configured via API or the Cargo app
- All documentation consistently emphasizes the security practice of storing token values immediately upon creation

https://claude.ai/code/session_01EYLxtaDRWtNSumZVJ4hqKP