### PR TITLE
Add cargo-quickstart skill and install.sh bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,16 @@ Agent skill for [Cargo](https://getcargo.ai) — the AI-native revenue infrastru
 
 ## Install
 
+**One-line bootstrap (recommended):**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/getcargohq/cargo-skills/main/install.sh | sh
+```
+
+Installs the Cargo CLI, registers the skills with your local agents, writes the Claude Code permissions allowlist so commands don't prompt every time, and (optionally) launches `claude '/cargo-quickstart …'` with a starter goal. See `install.sh` in this repo for what it does.
+
+**Skills only:**
+
 ```bash
 npx skills add getcargohq/cargo-skills
 ```
@@ -25,6 +35,7 @@ Works with Claude Code, Cursor, Windsurf, GitHub Copilot, and any agent that sup
 
 | Domain            | What the agent learns                                                                                                                                              |
 | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Quickstart**    | Turn a stated goal ("find 5 CTOs in NYC", "enrich acme.com") into the right action, execute it, and summarize — without the user touching a CLI flag               |
 | **Orchestration** | Execute single actions, chain actions into workflows, trigger batches across segments, poll async operations, query the data warehouse with SQL, fetch segment data |
 | **Storage**       | Inspect models and their DDL, create columns, navigate datasets, set relationships between models                                                                  |
 | **Connection**    | Authenticate connectors (HubSpot, Clearbit, Salesforce…), discover integration actions and their slugs                                                             |

--- a/SKILL.md
+++ b/SKILL.md
@@ -61,6 +61,7 @@ This is the official feedback channel — every report is reviewed by the Cargo 
 
 | Skill                                                 | Load when you need to…                                                                             |
 | ----------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| [`cargo-quickstart`](#cargo-quickstart)       | The user states a real-world goal ("find 5 CTOs in NYC", "enrich acme.com") and wants a result, not a CLI tour. Front door / dispatcher. |
 | [`cargo-orchestration`](#cargo-orchestration) | Execute actions, run workflows, trigger batches, chat with agents, query your data warehouse       |
 | [`cargo-analytics`](#cargo-analytics)         | Download run results, export segment data, monitor error rates and metrics                         |
 | [`cargo-billing`](#cargo-billing)             | Check credit usage, view subscription details, track costs per workflow or connector               |
@@ -74,6 +75,12 @@ This is the official feedback channel — every report is reviewed by the Cargo 
 ## How the skills relate
 
 ```
+                ┌──────────────────────────────────┐
+                │         cargo-quickstart         │
+                │  Goal → dispatch → execute → say │
+                │  (front door for real outcomes)  │
+                └─────────────────┬────────────────┘
+                                  │ delegates to ↓
 ┌──────────────────────────────────────────────────────────────┐
 │                  cargo-workspace-management                  │
 │             Authentication, users, tokens, folders           │
@@ -103,6 +110,7 @@ This is the official feedback channel — every report is reviewed by the Cargo 
 
 **Dependency rules in practice:**
 
+- `cargo-quickstart` is the **front door** when the user states a real-world outcome. It chooses one of the lower skills, drives the discovery sequence, and executes. Load it when the user says what they want, not how to do it.
 - `cargo-workspace-management` provides auth context for every skill — set it up first.
 - `cargo-storage`, `cargo-connection`, and `cargo-ai` are peer skills that supply UUIDs to `cargo-orchestration`. They don't depend on each other.
 - Before querying via system-of-record, load `cargo-storage` to get the DDL (exact table name).
@@ -114,6 +122,24 @@ This is the official feedback channel — every report is reviewed by the Cargo 
 ---
 
 ## Skill details
+
+### cargo-quickstart
+
+**The front door.** Use when the user states a real-world goal (a *what*, not a *how*) and wants a result — not a tour of the CLI.
+
+**Trigger phrases:**
+
+- "Find 5 CTOs in NYC and get their verified work emails."
+- "Enrich acme.com with Clearbit."
+- "Score the leads added this week."
+- "Push our new MQLs to HubSpot."
+- "How many companies in our model are headquartered in the US?"
+
+**What it does:** classifies the goal → picks one of `action execute`, `action execute-batch`, `run create` / `batch create`, `ai message create`, or `system-of-record query` → runs the discovery sequence → executes → summarizes. Defers to the relevant lower skill for any *construction* task (creating models, designing node graphs, configuring agents).
+
+**References:** `cargo-quickstart/SKILL.md`, `cargo-quickstart/references/classification.md`, `cargo-quickstart/references/recipes.md`
+
+---
 
 ### cargo-orchestration
 

--- a/cargo-quickstart/SKILL.md
+++ b/cargo-quickstart/SKILL.md
@@ -40,14 +40,18 @@ User states a goal
 │ ───────────────────────────────────────     │
 │ a single record /    → action execute       │
 │   one domain                                │
-│ a list / segment /   → action execute-batch │
-│   "all X that Y"       OR batch create      │
+│ a list of records /  → action execute-batch │
+│   "for each of these"  (with --records)     │
+│ a segment, "all X    → segment fetch first, │
+│   that Y"              then action          │
+│                        execute-batch        │
 │ "score / research /  → ai message create    │
 │   ask the agent"       (chat-uuid)          │
 │ "how many / which /  → system-of-record     │
 │   what's the avg"      query (after DDL)    │
-│ "trigger / run the   → run create or        │
-│   <play|tool> X"       batch create         │
+│                                             │
+│ Anything that needs a saved workflow        │
+│   → defer to cargo-orchestration            │
 └─────────────────────────────────────────────┘
        │
        ▼
@@ -60,8 +64,8 @@ User states a goal
 │ Need a built-in action   → connection       │
 │   (find_people, …)         native-          │
 │                            integration get  │
-│ Need a saved workflow    → orchestration    │
-│                            tool/play list   │
+│ Need a saved tool        → orchestration    │
+│                            tool list        │
 │ Need a model + DDL       → storage model    │
 │   (for SQL or segments)    list / get-ddl   │
 │ Need an AI agent         → ai agent list    │
@@ -145,18 +149,30 @@ cargo-ai orchestration action execute \
   --wait-until-finished
 ```
 
-### R3 — Run a saved play on a segment
+### R3 — Run an action across every record in a segment
 
-User: *"Trigger the scoring play on this week's MQLs."*
+User: *"Enrich every company in our 'New Inbound' segment with Clearbit."*
 
 ```bash
-cargo-ai orchestration play list                        # find workflowUuid
-cargo-ai segmentation segment list                      # find segmentUuid
-cargo-ai orchestration batch create \
-  --workflow-uuid <workflowUuid> \
-  --data '{"kind":"segment","segmentUuid":"<segmentUuid>"}' \
+MODEL_UUID=$(cargo-ai storage model list | jq -r '.models[] | select(.slug=="companies") | .uuid')
+
+# Pull the segment's records
+cargo-ai segmentation segment fetch \
+  --model-uuid "$MODEL_UUID" \
+  --filter '{"conjonction":"and","groups":[{"conjonction":"and","conditions":[
+    {"kind":"string","columnSlug":"lifecycle_stage","operator":"is","values":["new_inbound"]}
+  ]}]}' > /tmp/records.json
+
+# Run the action across them
+cargo-ai orchestration action execute-batch \
+  --action '{
+    "kind":"connector",
+    "integrationSlug":"clearbit",
+    "actionSlug":"company_enrich",
+    "config":{"connectorUuid":"<uuid>"}
+  }' \
+  --records "$(jq -c '.records' /tmp/records.json)" \
   --wait-until-finished
-cargo-ai orchestration run get-metrics --workflow-uuid <workflowUuid>
 ```
 
 ### R4 — Ask an AI agent

--- a/cargo-quickstart/SKILL.md
+++ b/cargo-quickstart/SKILL.md
@@ -1,0 +1,217 @@
+---
+name: cargo-quickstart
+description: Goal-oriented dispatcher for Cargo. Use this when the user states a real-world outcome (e.g. "find 5 CTOs in NYC and get their emails", "score these new leads", "enrich acme.com with Clearbit") rather than a CLI command. This skill picks the right execution path across orchestration / connection / ai / storage and runs it end-to-end.
+license: MIT
+compatibility: Requires @cargo-ai/cli (npm) and a Cargo API token
+metadata:
+  author: getcargo
+  version: "1.0"
+---
+
+# Cargo Quickstart — Goal → Result
+
+This skill turns a natural-language goal into a single executed Cargo action. Use it as the **first** skill when the user says something like:
+
+- "Find 5 CTOs in NYC and get their verified work emails."
+- "Enrich acme.com with Clearbit."
+- "Score the leads added this week."
+- "Push our new MQLs to HubSpot."
+- "How many companies in our model are headquartered in the US?"
+
+If the user instead wants to *build infrastructure* (create a model, set up a connector, design a node graph), defer to the relevant skill (`cargo-storage`, `cargo-connection`, `cargo-orchestration`).
+
+## The dispatch flow
+
+```
+User states a goal
+       │
+       ▼
+┌─────────────────────────────────────────────┐
+│ 1. AUTH CHECK                               │
+│    cargo-ai whoami                          │
+│    └─ if it fails → see "Bootstrap" below   │
+└─────────────────────────────────────────────┘
+       │
+       ▼
+┌─────────────────────────────────────────────┐
+│ 2. CLASSIFY THE GOAL                        │
+│                                             │
+│ Goal mentions…       → Run…                 │
+│ ───────────────────────────────────────     │
+│ a single record /    → action execute       │
+│   one domain                                │
+│ a list / segment /   → action execute-batch │
+│   "all X that Y"       OR batch create      │
+│ "score / research /  → ai message create    │
+│   ask the agent"       (chat-uuid)          │
+│ "how many / which /  → system-of-record     │
+│   what's the avg"      query (after DDL)    │
+│ "trigger / run the   → run create or        │
+│   <play|tool> X"       batch create         │
+└─────────────────────────────────────────────┘
+       │
+       ▼
+┌─────────────────────────────────────────────┐
+│ 3. DISCOVER THE UUIDS YOU NEED              │
+│    (only fetch what the chosen path needs)  │
+│                                             │
+│ Need a connector action  → connection       │
+│   (Clearbit, HubSpot…)     integration get  │
+│ Need a built-in action   → connection       │
+│   (find_people, …)         native-          │
+│                            integration get  │
+│ Need a saved workflow    → orchestration    │
+│                            tool/play list   │
+│ Need a model + DDL       → storage model    │
+│   (for SQL or segments)    list / get-ddl   │
+│ Need an AI agent         → ai agent list    │
+└─────────────────────────────────────────────┘
+       │
+       ▼
+┌─────────────────────────────────────────────┐
+│ 4. EXECUTE                                  │
+│    Pass --wait-until-finished when sane     │
+│    (single record, small batch). Otherwise  │
+│    poll per cargo-orchestration/polling.md  │
+└─────────────────────────────────────────────┘
+       │
+       ▼
+┌─────────────────────────────────────────────┐
+│ 5. SUMMARIZE                                │
+│    Report: what ran, how many records,      │
+│    success/error counts, where to find      │
+│    full results in the UI                   │
+└─────────────────────────────────────────────┘
+```
+
+If any step fails twice in a row and the cause is not obvious, **submit a workspace report** before trying a third time — see `cargo-workspace-management/SKILL.md` (Reports) and the top-level `SKILL.md`.
+
+## Canonical recipes
+
+Each recipe is a worked example for one of the dispatch branches above. Pick the closest match, then swap variables.
+
+### R1 — Find people matching a description (research goal)
+
+User: *"Find 5 CTOs in NYC and get their verified work emails."*
+
+```bash
+# 1. Discover the people-finder action (typically a native action or a tool)
+cargo-ai connection native-integration get | jq '.actions[] | select(.slug | test("people|prospect|search"))'
+
+# 2. Execute as a one-shot action
+cargo-ai orchestration action execute \
+  --action '{
+    "kind": "native",
+    "actionSlug": "find_people",
+    "config": {}
+  }' \
+  --data '{
+    "title": "CTO",
+    "location": "New York, NY, US",
+    "limit": 5
+  }' \
+  --wait-until-finished
+
+# 3. (optional) Enrich each result with email-verification
+cargo-ai orchestration action execute-batch \
+  --action '{
+    "kind": "connector",
+    "integrationSlug": "<email-provider>",
+    "actionSlug": "verify_email",
+    "config": {"connectorUuid": "<uuid>"}
+  }' \
+  --records '[ ...output of step 2... ]' \
+  --wait-until-finished
+```
+
+> If the workspace already has a saved tool that does this end-to-end, prefer `orchestration tool list` and `run create --workflow-uuid`. Always check for existing tools before composing from scratch.
+
+### R2 — Enrich one record
+
+User: *"Enrich acme.com with Clearbit."*
+
+```bash
+cargo-ai connection connector list | jq '.connectors[] | select(.integrationSlug=="clearbit")'
+cargo-ai connection integration get clearbit  # confirm actionSlug
+
+cargo-ai orchestration action execute \
+  --action '{
+    "kind": "connector",
+    "integrationSlug": "clearbit",
+    "actionSlug": "company_enrich",
+    "config": {"connectorUuid": "<uuid>"}
+  }' \
+  --data '{"domain":"acme.com"}' \
+  --wait-until-finished
+```
+
+### R3 — Run a saved play on a segment
+
+User: *"Trigger the scoring play on this week's MQLs."*
+
+```bash
+cargo-ai orchestration play list                        # find workflowUuid
+cargo-ai segmentation segment list                      # find segmentUuid
+cargo-ai orchestration batch create \
+  --workflow-uuid <workflowUuid> \
+  --data '{"kind":"segment","segmentUuid":"<segmentUuid>"}' \
+  --wait-until-finished
+cargo-ai orchestration run get-metrics --workflow-uuid <workflowUuid>
+```
+
+### R4 — Ask an AI agent
+
+User: *"Use the lead researcher to find each contact's LinkedIn."*
+
+```bash
+cargo-ai ai agent list                                  # find agentUuid
+cargo-ai ai chat create --agent-uuid <agentUuid>        # → chatUuid
+cargo-ai ai message create \
+  --chat-uuid <chatUuid> \
+  --parts '[{"type":"text","text":"Find the LinkedIn for ..."}]' \
+  --wait-until-finished
+```
+
+### R5 — Answer a question from the warehouse
+
+User: *"How many companies have employee_count > 500 and country = US?"*
+
+```bash
+cargo-ai storage model list                             # find Companies modelUuid
+cargo-ai storage model get-ddl <modelUuid>              # exact table name
+cargo-ai system-of-record client query \
+  "SELECT count(*) FROM datasets_default.models_companies
+   WHERE employee_count > 500 AND country = 'US'"
+```
+
+## Bootstrap (when `whoami` fails)
+
+If `cargo-ai whoami` errors out, the user has not authenticated. Tell them — do not attempt to proceed.
+
+```bash
+# Install the CLI if missing
+npm install -g @cargo-ai/cli
+
+# Authenticate
+cargo-ai login --token <api-token-from-Settings-API>
+
+# Verify
+cargo-ai whoami
+```
+
+After auth, re-run the goal.
+
+## What this skill is NOT
+
+- **Not a substitute** for `cargo-orchestration` when designing a new node graph from scratch — load that skill once you know you need custom nodes.
+- **Not a substitute** for `cargo-storage` when the user wants to *create* models / columns / relationships.
+- **Not a substitute** for `cargo-workspace-management` when the user wants to invite users, create tokens, or organize folders.
+
+This skill is the **front door**: classify, dispatch, execute, summarize.
+
+## References
+
+- `references/classification.md` — extended phrase-to-path matching, ambiguous cases, when to ask the user a clarifying question vs. proceed.
+- `references/recipes.md` — additional worked recipes beyond R1–R5 (CRM push-back, monitoring, exports, multi-step research).
+- Top-level `SKILL.md` — the master index, UUID-flow table, async polling table.
+- `cargo-orchestration/SKILL.md` — for any execution detail beyond the dispatcher.

--- a/cargo-quickstart/SKILL.md
+++ b/cargo-quickstart/SKILL.md
@@ -122,7 +122,7 @@ cargo-ai orchestration action execute-batch \
     "kind": "connector",
     "integrationSlug": "<email-provider>",
     "actionSlug": "verify_email",
-    "config": {"connectorUuid": "<uuid>"}
+    "config": {}
   }' \
   --records '[ ...output of step 2... ]' \
   --wait-until-finished
@@ -135,7 +135,6 @@ cargo-ai orchestration action execute-batch \
 User: *"Enrich acme.com with Clearbit."*
 
 ```bash
-cargo-ai connection connector list | jq '.connectors[] | select(.integrationSlug=="clearbit")'
 cargo-ai connection integration get clearbit  # confirm actionSlug
 
 cargo-ai orchestration action execute \
@@ -143,7 +142,7 @@ cargo-ai orchestration action execute \
     "kind": "connector",
     "integrationSlug": "clearbit",
     "actionSlug": "company_enrich",
-    "config": {"connectorUuid": "<uuid>"}
+    "config": {}
   }' \
   --data '{"domain":"acme.com"}' \
   --wait-until-finished
@@ -169,7 +168,7 @@ cargo-ai orchestration action execute-batch \
     "kind":"connector",
     "integrationSlug":"clearbit",
     "actionSlug":"company_enrich",
-    "config":{"connectorUuid":"<uuid>"}
+    "config":{}
   }' \
   --records "$(jq -c '.records' /tmp/records.json)" \
   --wait-until-finished

--- a/cargo-quickstart/references/classification.md
+++ b/cargo-quickstart/references/classification.md
@@ -7,9 +7,9 @@ How to map a natural-language goal to one of the five execution paths in `SKILL.
 | Phrase shape in the user's request                           | Path                          |
 | ------------------------------------------------------------ | ----------------------------- |
 | "enrich X", "score X", "verify X" — single record            | `action execute`              |
-| "enrich these N", "for each of these records"                | `action execute-batch`        |
-| "all X that Y", "everyone in segment Z"                      | `batch create` with segment   |
-| "trigger / run / kick off the <play\|tool>"                  | `run create` or `batch create` (workflow-uuid) |
+| "enrich these N", "for each of these records"                | `action execute-batch` with `--records` |
+| "all X that Y", "everyone in segment Z"                      | `segmentation segment fetch`, then `action execute-batch` |
+| "trigger / run / kick off the saved tool X"                  | defer to `cargo-orchestration` |
 | "research X with the agent", "ask the agent about Y"         | `ai message create`           |
 | "how many / which / what's the average / list me all"        | `system-of-record query`      |
 | "export …", "download all …"                                 | `segmentation segment download` |
@@ -35,15 +35,15 @@ Do **not** ask for clarification when:
 
 ### "Find people who match X"
 
-This is *almost always* `action execute` against a `find_people`-shaped native or connector action — not a tool, not a batch. Find-people actions accept a search-spec as `--data` and return records inline. Only escalate to a tool/play when the user explicitly says "set this up to run repeatedly" or "every time a new company gets added".
+This is *almost always* `action execute` against a `find_people`-shaped native or connector action — not a saved workflow, not a batch. Find-people actions accept a search-spec as `--data` and return records inline. Only escalate to a saved workflow when the user explicitly says "set this up to run repeatedly" or "every time a new company gets added".
 
 ### "Sync to CRM" / "push to HubSpot"
 
-If the user says "push *this list*" → `action execute-batch` with `--records`. If they say "set up a sync" → defer to `cargo-orchestration` to build a play. The quickstart is for one-shots, not for designing recurring automations.
+If the user says "push *this list*" → `action execute-batch` with `--records`. If they say "set up a sync" → defer to `cargo-orchestration`. The quickstart is for one-shots, not for designing recurring automations.
 
 ### "Score the leads"
 
-Almost always wants the existing scoring play. Run `orchestration play list | grep -i score` first; if found, use `batch create --workflow-uuid …`. Only fall back to `action execute --kind agent` if no scoring play exists.
+Use the AI agent path: `ai agent list` to find a scoring agent (usually named "Lead Scorer" or similar), then either `action execute --kind agent` per record, or fan-out across `--records` with `action execute-batch`. If the user references a saved scoring workflow, defer to `cargo-orchestration`.
 
 ### "How many X"
 

--- a/cargo-quickstart/references/classification.md
+++ b/cargo-quickstart/references/classification.md
@@ -1,0 +1,66 @@
+# Goal classification
+
+How to map a natural-language goal to one of the five execution paths in `SKILL.md`.
+
+## Quick reference
+
+| Phrase shape in the user's request                           | Path                          |
+| ------------------------------------------------------------ | ----------------------------- |
+| "enrich X", "score X", "verify X" — single record            | `action execute`              |
+| "enrich these N", "for each of these records"                | `action execute-batch`        |
+| "all X that Y", "everyone in segment Z"                      | `batch create` with segment   |
+| "trigger / run / kick off the <play\|tool>"                  | `run create` or `batch create` (workflow-uuid) |
+| "research X with the agent", "ask the agent about Y"         | `ai message create`           |
+| "how many / which / what's the average / list me all"        | `system-of-record query`      |
+| "export …", "download all …"                                 | `segmentation segment download` |
+
+## Disambiguation prompts
+
+Ask the user **one** clarifying question when:
+
+- The goal could equally be a one-shot research call or a saved workflow run, and **both exist** in the workspace.
+  → "Want to use the saved `<tool-name>` we already have, or run a fresh one-off?"
+- The goal mentions a list but no source ("score the leads we have").
+  → "Which segment / model should I pull from?"
+- The goal implies write-back but the destination is ambiguous ("update the CRM").
+  → "Push to HubSpot, Salesforce, or both?"
+
+Do **not** ask for clarification when:
+
+- The user is exploratory ("show me…", "how many…") — just run the SQL.
+- The user has already been specific enough that one default path dominates (e.g. names a domain → single action).
+- A discovery call (`tool list`, `connector list`) would answer the question faster than a chat round-trip — run it.
+
+## Ambiguous cases worth memorizing
+
+### "Find people who match X"
+
+This is *almost always* `action execute` against a `find_people`-shaped native or connector action — not a tool, not a batch. Find-people actions accept a search-spec as `--data` and return records inline. Only escalate to a tool/play when the user explicitly says "set this up to run repeatedly" or "every time a new company gets added".
+
+### "Sync to CRM" / "push to HubSpot"
+
+If the user says "push *this list*" → `action execute-batch` with `--records`. If they say "set up a sync" → defer to `cargo-orchestration` to build a play. The quickstart is for one-shots, not for designing recurring automations.
+
+### "Score the leads"
+
+Almost always wants the existing scoring play. Run `orchestration play list | grep -i score` first; if found, use `batch create --workflow-uuid …`. Only fall back to `action execute --kind agent` if no scoring play exists.
+
+### "How many X"
+
+Always SQL via system-of-record. Get DDL first (`storage model get-ddl`) — never guess table names. The DDL output contains the qualified name like `datasets_default.models_companies`.
+
+### "Enrich the new companies"
+
+Resolve "new" to a segment if one exists ("New Companies", "Last 7 days"), otherwise to a recordIds batch. If neither maps cleanly, ask: "Which segment counts as 'new'?"
+
+## Not a quickstart task
+
+Push these back to the dedicated skill rather than trying to handle them in the dispatcher:
+
+- "Create a Companies model with these columns" → `cargo-storage`
+- "Connect our Clearbit account" → `cargo-connection`
+- "Configure a new agent for outbound research" → `cargo-ai`
+- "Invite alice@… as an admin" → `cargo-workspace-management`
+- "Build a workflow that does A → B → C" → `cargo-orchestration` (custom node graph)
+
+The quickstart's job is **execution**, not **construction**.

--- a/cargo-quickstart/references/recipes.md
+++ b/cargo-quickstart/references/recipes.md
@@ -46,12 +46,12 @@ cargo-ai orchestration run create \
 
 > If this pattern shows up repeatedly, suggest the user save it as a tool (defer to `cargo-orchestration`).
 
-## R8 — Daily monitoring report
+## R8 — Health check on a saved tool
 
-User: *"How is the CRM-sync play doing this week?"*
+User: *"How is the CRM-sync tool doing this week?"*
 
 ```bash
-WORKFLOW_UUID=$(cargo-ai orchestration play list | jq -r '.plays[] | select(.name|test("CRM Sync";"i")) | .workflowUuid')
+WORKFLOW_UUID=$(cargo-ai orchestration tool list | jq -r '.tools[] | select(.name|test("CRM Sync";"i")) | .workflowUuid')
 
 cargo-ai orchestration run get-metrics --workflow-uuid "$WORKFLOW_UUID"
 cargo-ai orchestration run count --workflow-uuid "$WORKFLOW_UUID" --statuses error
@@ -99,7 +99,7 @@ For a list larger than ~10 records, prefer R7 (node graph with `kind: "agent"`) 
 
 ## R11 — Credit-spend snapshot
 
-User: *"How much did the enrichment play cost last month?"*
+User: *"How much did enrichment cost last month?"*
 
 ```bash
 cargo-ai billing usage get-metrics \
@@ -118,8 +118,8 @@ Requires admin token.
 | One record, multiple transformations                   | R7 (single-record `run create`) |
 | Many records, one transformation                       | R6         |
 | Many records, multi-step (find/enrich/score)           | R7         |
-| Existing play / tool the user named                    | R3         |
+| All records in a segment, one transformation           | R3         |
 | Free-form research question                            | R5 or R10  |
-| Operational / health question about a workflow         | R8         |
+| Operational / health question about a saved tool       | R8         |
 | "Export / download" of model data                      | R9         |
 | Cost / credit / billing question                       | R11        |

--- a/cargo-quickstart/references/recipes.md
+++ b/cargo-quickstart/references/recipes.md
@@ -1,0 +1,125 @@
+# Quickstart recipes
+
+Recipes are paste-and-tweak templates for the most common goals. Each recipe is a complete, runnable sequence — pick one, replace the placeholders, run it. Recipes intentionally favor `--wait-until-finished` for ergonomics; for large batches, switch to polling per `cargo-orchestration/references/polling.md`.
+
+## R6 — Push a list of records to a CRM
+
+User: *"Push these 100 companies to HubSpot."*
+
+```bash
+cargo-ai connection connector list | jq '.connectors[] | select(.integrationSlug=="hubspot")'
+cargo-ai connection integration get hubspot
+
+cargo-ai orchestration action execute-batch \
+  --action '{
+    "kind":"connector",
+    "integrationSlug":"hubspot",
+    "actionSlug":"upsert_company",
+    "config":{"connectorUuid":"<uuid>"}
+  }' \
+  --records '[{"domain":"acme.com","name":"Acme"}, ... ]' \
+  --wait-until-finished
+```
+
+## R7 — Multi-step research (find → enrich → score)
+
+User: *"Find 20 series-A SaaS companies, enrich them, and score for ICP fit."*
+
+Build a one-off node graph rather than three sequential actions — the run executes all three steps server-side and returns a single result set.
+
+```bash
+cargo-ai connection native-integration get   # confirm find-companies actionSlug
+cargo-ai connection integration get clearbit # confirm enrich actionSlug
+cargo-ai ai agent list                       # find scoring agentUuid
+
+cargo-ai orchestration node validate --nodes '[
+  {"slug":"find","kind":"native","actionSlug":"find_companies","config":{...}},
+  {"slug":"enrich","kind":"connector","integrationSlug":"clearbit","actionSlug":"company_enrich","config":{"connectorUuid":"<uuid>"},"input":{"domain":"{{find.domain}}"}},
+  {"slug":"score","kind":"agent","agentUuid":"<uuid>","input":{"company":"{{enrich}}"}}
+]'
+
+cargo-ai orchestration run create \
+  --nodes '<same nodes>' \
+  --data '{"stage":"series-a","industry":"saas","limit":20}' \
+  --wait-until-finished
+```
+
+> If this pattern shows up repeatedly, suggest the user save it as a tool (defer to `cargo-orchestration`).
+
+## R8 — Daily monitoring report
+
+User: *"How is the CRM-sync play doing this week?"*
+
+```bash
+WORKFLOW_UUID=$(cargo-ai orchestration play list | jq -r '.plays[] | select(.name|test("CRM Sync";"i")) | .workflowUuid')
+
+cargo-ai orchestration run get-metrics --workflow-uuid "$WORKFLOW_UUID"
+cargo-ai orchestration run count --workflow-uuid "$WORKFLOW_UUID" --statuses error
+cargo-ai orchestration run download --workflow-uuid "$WORKFLOW_UUID" --statuses error --is-finished
+```
+
+Summarize: success rate, top error types, sample of failed records.
+
+## R9 — Export a filtered slice of a model
+
+User: *"Export US companies with < 200 employees, sorted by created date."*
+
+```bash
+MODEL_UUID=$(cargo-ai storage model list | jq -r '.models[] | select(.slug=="companies") | .uuid')
+
+cargo-ai segmentation segment download \
+  --model-uuid "$MODEL_UUID" \
+  --filter '{
+    "conjonction":"and",
+    "groups":[{"conjonction":"and","conditions":[
+      {"kind":"string","columnSlug":"country","operator":"is","values":["US"]},
+      {"kind":"number","columnSlug":"employee_count","operator":"lt","values":[200]}
+    ]}]
+  }' \
+  --sort '[{"columnSlug":"created_at","kind":"desc"}]'
+```
+
+> `conjonction` — that spelling is intentional. Typos here fail silently.
+
+## R10 — Conversational research with an agent
+
+User: *"Use the lead-researcher agent to find LinkedIns for these 10 contacts."*
+
+```bash
+AGENT_UUID=$(cargo-ai ai agent list | jq -r '.agents[] | select(.name|test("research";"i")) | .uuid')
+CHAT_UUID=$(cargo-ai ai chat create --agent-uuid "$AGENT_UUID" | jq -r .uuid)
+
+cargo-ai ai message create \
+  --chat-uuid "$CHAT_UUID" \
+  --parts '[{"type":"text","text":"For each of these contacts, return their LinkedIn URL. Contacts: ..."}]' \
+  --wait-until-finished
+```
+
+For a list larger than ~10 records, prefer R7 (node graph with `kind: "agent"`) so each record gets an isolated run.
+
+## R11 — Credit-spend snapshot
+
+User: *"How much did the enrichment play cost last month?"*
+
+```bash
+cargo-ai billing usage get-metrics \
+  --from 2026-03-01 --to 2026-03-31 \
+  --group-by workflow_uuid \
+  | jq '.metrics[] | select(.workflowName|test("Enrich";"i"))'
+```
+
+Requires admin token.
+
+## Picking the right recipe
+
+| If the goal looks like…                                | Start with |
+| ------------------------------------------------------ | ---------- |
+| One record, one transformation                         | R2         |
+| One record, multiple transformations                   | R7 (single-record `run create`) |
+| Many records, one transformation                       | R6         |
+| Many records, multi-step (find/enrich/score)           | R7         |
+| Existing play / tool the user named                    | R3         |
+| Free-form research question                            | R5 or R10  |
+| Operational / health question about a workflow         | R8         |
+| "Export / download" of model data                      | R9         |
+| Cost / credit / billing question                       | R11        |

--- a/cargo-quickstart/references/recipes.md
+++ b/cargo-quickstart/references/recipes.md
@@ -7,15 +7,14 @@ Recipes are paste-and-tweak templates for the most common goals. Each recipe is 
 User: *"Push these 100 companies to HubSpot."*
 
 ```bash
-cargo-ai connection connector list | jq '.connectors[] | select(.integrationSlug=="hubspot")'
-cargo-ai connection integration get hubspot
+cargo-ai connection integration get hubspot   # confirm actionSlug
 
 cargo-ai orchestration action execute-batch \
   --action '{
     "kind":"connector",
     "integrationSlug":"hubspot",
     "actionSlug":"upsert_company",
-    "config":{"connectorUuid":"<uuid>"}
+    "config":{}
   }' \
   --records '[{"domain":"acme.com","name":"Acme"}, ... ]' \
   --wait-until-finished
@@ -25,26 +24,34 @@ cargo-ai orchestration action execute-batch \
 
 User: *"Find 20 series-A SaaS companies, enrich them, and score for ICP fit."*
 
-Build a one-off node graph rather than three sequential actions — the run executes all three steps server-side and returns a single result set.
+Run as three sequential `action execute` / `action execute-batch` calls, piping each step's output into the next. This keeps the quickstart in pure-action territory — for a reusable graph, defer to `cargo-orchestration` to build a tool.
 
 ```bash
-cargo-ai connection native-integration get   # confirm find-companies actionSlug
-cargo-ai connection integration get clearbit # confirm enrich actionSlug
-cargo-ai ai agent list                       # find scoring agentUuid
-
-cargo-ai orchestration node validate --nodes '[
-  {"slug":"find","kind":"native","actionSlug":"find_companies","config":{...}},
-  {"slug":"enrich","kind":"connector","integrationSlug":"clearbit","actionSlug":"company_enrich","config":{"connectorUuid":"<uuid>"},"input":{"domain":"{{find.domain}}"}},
-  {"slug":"score","kind":"agent","agentUuid":"<uuid>","input":{"company":"{{enrich}}"}}
-]'
-
-cargo-ai orchestration run create \
-  --nodes '<same nodes>' \
+# 1. Find — one-shot native action
+cargo-ai connection native-integration get | jq '.actions[] | select(.slug|test("find_compan"))'
+cargo-ai orchestration action execute \
+  --action '{"kind":"native","actionSlug":"find_companies","config":{}}' \
   --data '{"stage":"series-a","industry":"saas","limit":20}' \
+  --wait-until-finished > /tmp/found.json
+
+# 2. Enrich — fan-out across the results from step 1
+#    (extract per-record inputs from /tmp/found.json — exact jq path depends on the
+#     find action's output shape; inspect run.runContext.<slug> to confirm)
+cargo-ai connection integration get clearbit
+cargo-ai orchestration action execute-batch \
+  --action '{"kind":"connector","integrationSlug":"clearbit","actionSlug":"company_enrich","config":{}}' \
+  --records '<JSON array of {"domain":"..."} extracted from step 1>' \
+  --wait-until-finished > /tmp/enriched.json
+
+# 3. Score — pass enriched records through the scoring agent
+AGENT_UUID=$(cargo-ai ai agent list | jq -r '.agents[] | select(.name|test("score";"i")) | .uuid')
+cargo-ai orchestration action execute-batch \
+  --action "$(jq -nc --arg uuid "$AGENT_UUID" '{kind:"agent",agentUuid:$uuid,config:{}}')" \
+  --records '<JSON array of enriched records extracted from step 2>' \
   --wait-until-finished
 ```
 
-> If this pattern shows up repeatedly, suggest the user save it as a tool (defer to `cargo-orchestration`).
+> Reaching for `run create --nodes` to chain these in one server-side run? That's a node graph — load `cargo-orchestration` and use the `{{nodes.<slug>.<field>}}` interpolation syntax documented in its `references/nodes.md`. Inside a node graph, `connectorUuid` lives at the **top level of the node**, not inside `config`.
 
 ## R8 — Health check on a saved tool
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env sh
+#
+# Cargo bootstrap installer.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/getcargohq/cargo-skills/main/install.sh | sh
+#
+# What it does (in order):
+#   1. Installs @cargo-ai/cli globally via npm (or via npx fallback if npm install -g fails).
+#   2. Authenticates: prefers an existing session (cargo-ai whoami); otherwise prompts for an API token.
+#   3. Installs Cargo agent skills via `npx skills add` for codex / claude-code / cursor.
+#   4. Optionally writes Bash(cargo-ai *) into ~/.claude/settings.json so Claude does not prompt.
+#   5. Optionally launches `claude '/cargo-quickstart <goal>'` with a starter goal.
+#
+# Honors:
+#   CARGO_API_TOKEN   — non-interactive auth (skips token prompt).
+#   CARGO_INSTALL_NO_CLAUDE_PERMS=1 — skip the Claude permissions prompt.
+#   CARGO_INSTALL_NO_LAUNCH=1       — skip launching `claude` at the end.
+#   CARGO_QUICKSTART_GOAL           — override the default starter goal.
+
+set -e
+
+# ─────────────────────────────────────────────────────────────────────
+# Output helpers
+# ─────────────────────────────────────────────────────────────────────
+if [ -t 1 ]; then
+  RESET="\033[0m"
+  GREEN="\033[32m"
+  CYAN="\033[36m"
+  YELLOW="\033[33m"
+  RED="\033[31m"
+  GREY="\033[90m"
+else
+  RESET=""; GREEN=""; CYAN=""; YELLOW=""; RED=""; GREY=""
+fi
+
+say()  { printf "%b\n" "$*"; }
+warn() { printf "%b\n" "${YELLOW}$*${RESET}" >&2; }
+fail() { printf "%b\n" "${RED}$*${RESET}" >&2; exit 1; }
+
+print_logo() {
+  if [ -t 1 ]; then
+    say "${CYAN}"
+    say "██████    ████    █████    ██████   ██████"
+    say "██    ░  ██  ██░  ██  ██   ██    ░  ██  ██░"
+    say "██       ██████░  █████ ░  ██ ███   ██  ██░"
+    say "██       ██  ██░  ██ ██    ██  ██░  ██  ██░"
+    say "██████   ██  ██░  ██  ██   ██████░  ██████░"
+    say "${RESET}"
+  fi
+}
+
+# ─────────────────────────────────────────────────────────────────────
+# Step 1 — install @cargo-ai/cli
+# ─────────────────────────────────────────────────────────────────────
+ensure_node() {
+  command -v node >/dev/null 2>&1 || fail "Node.js is required. Install from https://nodejs.org/ and re-run."
+  command -v npm  >/dev/null 2>&1 || fail "npm is required (ships with Node.js). Re-install Node from https://nodejs.org/."
+}
+
+install_cli() {
+  if command -v cargo-ai >/dev/null 2>&1; then
+    say "${GREY}  cargo-ai already on PATH — skipping install.${RESET}"
+    return 0
+  fi
+  say "${GREY}  Installing @cargo-ai/cli globally...${RESET}"
+  if npm install -g @cargo-ai/cli >/dev/null 2>&1; then
+    say "${GREEN}✓ Cargo CLI installed.${RESET}"
+    return 0
+  fi
+  warn "  npm install -g failed (likely a permissions issue)."
+  warn "  Falling back to npx — every \`cargo-ai\` call will resolve via \`npx @cargo-ai/cli\`."
+  if ! command -v npx >/dev/null 2>&1; then
+    fail "npx not found and npm install -g failed. Fix npm permissions or install Node.js with a writable global prefix."
+  fi
+  CARGO_BIN="npx @cargo-ai/cli"
+}
+
+CARGO_BIN="cargo-ai"
+
+# ─────────────────────────────────────────────────────────────────────
+# Step 2 — authenticate
+# ─────────────────────────────────────────────────────────────────────
+authenticate() {
+  if $CARGO_BIN whoami >/dev/null 2>&1; then
+    WHO=$($CARGO_BIN whoami 2>/dev/null || true)
+    say "${GREEN}✓ Already authenticated.${RESET}"
+    return 0
+  fi
+
+  TOKEN="${CARGO_API_TOKEN:-}"
+  if [ -z "$TOKEN" ]; then
+    say ""
+    say "${CYAN}Cargo API token required.${RESET}"
+    say "  Get one at: ${CYAN}https://app.getcargo.io${RESET} → Settings → API"
+    say "  (token values are shown only once — copy it now)"
+    say ""
+    if [ ! -t 0 ] && [ ! -r /dev/tty ]; then
+      fail "No TTY available for token entry. Re-run with CARGO_API_TOKEN=<token> set."
+    fi
+    printf "${CYAN}Paste API token:${RESET} "
+    if [ -r /dev/tty ]; then
+      stty -echo </dev/tty 2>/dev/null || true
+      IFS= read -r TOKEN </dev/tty || true
+      stty echo </dev/tty 2>/dev/null || true
+    else
+      stty -echo 2>/dev/null || true
+      IFS= read -r TOKEN || true
+      stty echo 2>/dev/null || true
+    fi
+    printf "\n"
+  fi
+
+  [ -n "$TOKEN" ] || fail "No token entered. Aborting."
+
+  if ! $CARGO_BIN login --token "$TOKEN" >/dev/null 2>&1; then
+    fail "cargo-ai login failed. Verify the token at https://app.getcargo.io → Settings → API."
+  fi
+  $CARGO_BIN whoami >/dev/null 2>&1 || fail "Login appeared to succeed but whoami fails. Check network and re-run."
+  say "${GREEN}✓ Authenticated.${RESET}"
+}
+
+# ─────────────────────────────────────────────────────────────────────
+# Step 3 — install agent skills
+# ─────────────────────────────────────────────────────────────────────
+install_skills() {
+  if ! command -v npx >/dev/null 2>&1; then
+    warn "  npx not found — skipping skill install."
+    warn "  Run later: npx skills add getcargohq/cargo-skills --agents claude-code cursor codex --global --yes"
+    return 0
+  fi
+  say "${GREY}  Installing Cargo skills for claude-code, cursor, codex...${RESET}"
+  if npx --yes skills add getcargohq/cargo-skills \
+       --agents claude-code cursor codex \
+       --global --yes --skill '*' --full-depth >/dev/null 2>&1; then
+    say "${GREEN}✓ Cargo skills installed.${RESET}"
+  else
+    warn "  Skill install failed. Run manually:"
+    warn "    npx skills add getcargohq/cargo-skills --agents claude-code cursor codex --global --yes"
+  fi
+}
+
+# ─────────────────────────────────────────────────────────────────────
+# Step 4 — Claude permissions allowlist
+# ─────────────────────────────────────────────────────────────────────
+install_claude_permissions() {
+  [ "${CARGO_INSTALL_NO_CLAUDE_PERMS:-0}" = "1" ] && return 0
+  if ! command -v python3 >/dev/null 2>&1 && ! command -v python >/dev/null 2>&1; then
+    return 0
+  fi
+  PYTHON_BIN=$(command -v python3 || command -v python)
+
+  if [ -t 0 ] || [ -r /dev/tty ]; then
+    say ""
+    say "${CYAN}Allow Claude Code to run \`cargo-ai *\` without prompting?${RESET}"
+    say "  (only updates ~/.claude/settings.json — you can revert any time)"
+    printf "  [y/N]: "
+    REPLY=""
+    if [ -r /dev/tty ]; then
+      IFS= read -r REPLY </dev/tty || true
+    else
+      IFS= read -r REPLY || true
+    fi
+    case "$REPLY" in
+      y|Y|yes|YES) ;;
+      *) say "${GREY}  Keeping existing Claude settings.${RESET}"; return 0 ;;
+    esac
+  else
+    return 0
+  fi
+
+  SETTINGS="$HOME/.claude/settings.json"
+  "$PYTHON_BIN" - "$SETTINGS" <<'PY'
+import json, os, pathlib, sys
+p = pathlib.Path(sys.argv[1])
+allow_entries = ["Bash(cargo-ai *)", "Bash(npx @cargo-ai/cli *)"]
+data = {}
+try:
+    if p.exists():
+        parsed = json.loads(p.read_text(encoding="utf-8"))
+        if isinstance(parsed, dict):
+            data = parsed
+except Exception:
+    data = {}
+perms = data.get("permissions") if isinstance(data.get("permissions"), dict) else {}
+allow = perms.get("allow") if isinstance(perms.get("allow"), list) else []
+seen, out = set(), []
+for item in allow:
+    if isinstance(item, str) and item not in seen:
+        seen.add(item); out.append(item)
+for item in allow_entries:
+    if item not in seen:
+        seen.add(item); out.append(item)
+perms["allow"] = out
+data["permissions"] = perms
+p.parent.mkdir(parents=True, exist_ok=True)
+p.write_text(json.dumps(data, indent=2) + os.linesep, encoding="utf-8")
+PY
+  say "${GREEN}✓ Claude settings updated (~/.claude/settings.json).${RESET}"
+}
+
+# ─────────────────────────────────────────────────────────────────────
+# Step 5 — launch Claude with a starter quickstart
+# ─────────────────────────────────────────────────────────────────────
+launch_claude() {
+  [ "${CARGO_INSTALL_NO_LAUNCH:-0}" = "1" ] && return 0
+  if ! command -v claude >/dev/null 2>&1; then
+    say ""
+    say "${YELLOW}Claude Code not found.${RESET} Install: ${CYAN}https://code.claude.com/docs/en/overview${RESET}"
+    say "Then run: ${CYAN}claude '/cargo-quickstart Find 5 CTOs in NYC and get their verified work emails.'${RESET}"
+    return 0
+  fi
+  GOAL="${CARGO_QUICKSTART_GOAL:-Find 5 CTOs in NYC and get their verified work emails.}"
+  say ""
+  say "${GREEN}Launching Claude with /cargo-quickstart...${RESET}"
+  exec claude "/cargo-quickstart $GOAL"
+}
+
+# ─────────────────────────────────────────────────────────────────────
+# Main
+# ─────────────────────────────────────────────────────────────────────
+print_logo
+ensure_node
+install_cli
+authenticate
+install_skills
+install_claude_permissions
+launch_claude


### PR DESCRIPTION
## Summary

Today the skills are great for *building infrastructure* in Cargo (models, connectors, agents) but stop short of pushing the agent toward *executing real outcomes*. This PR adds two pieces to close that gap:

- **`cargo-quickstart` skill** — front-door dispatcher. Classifies a stated goal (e.g. "find 5 CTOs in NYC", "enrich acme.com", "score the leads added this week") into one of `action execute` / `action execute-batch` / `run create` / `batch create` / `ai message create` / SoR query, runs the discovery sequence, executes, summarizes. Five canonical recipes inline; six more in `references/recipes.md`. `references/classification.md` covers phrase-to-path matching and when to ask vs. proceed.
- **`install.sh`** — `curl | sh` bootstrap. Installs `@cargo-ai/cli`, handles auth (`CARGO_API_TOKEN` env or interactive token prompt), installs skills across `claude-code` / `cursor` / `codex` via `npx skills add`, optionally writes `Bash(cargo-ai *)` into `~/.claude/settings.json` so Claude doesn't prompt every call, and optionally launches `claude '/cargo-quickstart <goal>'` to land the user on a working agent. Honors `CARGO_INSTALL_NO_CLAUDE_PERMS=1` and `CARGO_INSTALL_NO_LAUNCH=1` for headless / CI installs.
- Top-level `SKILL.md` and `README.md` updated: new skill in the table + dependency diagram, and a "one-line bootstrap" install option above the existing `npx skills add` command.

## Test plan

- [ ] `sh -n install.sh` (already verified locally)
- [ ] `bash install.sh` against a clean machine without `cargo-ai` on PATH — verifies the npm install + token prompt + skill install path
- [ ] `CARGO_API_TOKEN=… CARGO_INSTALL_NO_CLAUDE_PERMS=1 CARGO_INSTALL_NO_LAUNCH=1 sh install.sh` for the headless path
- [ ] Re-run on a machine that already has `cargo-ai` authenticated — should skip token prompt
- [ ] Inspect `~/.claude/settings.json` after opting in — verify `Bash(cargo-ai *)` and `Bash(npx @cargo-ai/cli *)` are appended without duplicates
- [ ] In Claude Code, type `/cargo-quickstart Find 5 CTOs in NYC and get their verified work emails.` and confirm the agent loads `cargo-quickstart/SKILL.md` and follows the dispatch flow
- [ ] Spot-check a couple of recipes (R2 single-record enrich, R5 SoR query) end-to-end against a real workspace

## Notes / follow-ups (not in this PR)

- No browser-based auth flow yet — the installer prompts for a token. Worth shipping a `cargo-ai auth register` command on the CLI side later; the installer can swap to it without other changes.
- No version pinning of skills/CLI in the installer — npm handles CLI versioning; if we want to gate skill updates separately we can add a stamped state dir later.
- Quickstart starter goal is hardcoded to a CTO-finder demo. Override via `CARGO_QUICKSTART_GOAL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)