### PR TITLE
Update authentication docs to highlight OAuth as primary method

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,11 +130,12 @@ The agent queries billing metrics broken down by workflow, connector, or date ra
 
 ```bash
 npm install -g @cargo-ai/cli
-cargo-ai login --token <your-api-token>
+cargo-ai login --oauth                          # browser sign-in (recommended)
+# or: cargo-ai login --token <your-api-token>   # workspace-scoped API token
 cargo-ai whoami
 ```
 
-Get an API token from your workspace under **Settings > API**. Token values are shown only once — store immediately in a secrets manager.
+`--oauth` runs the OAuth 2.0 Device Authorization Flow against the Cargo OAuth provider — no setup required. For non-interactive environments (CI, scripts), use `--token` with a workspace-scoped API token from **Settings > API**. Token values are shown only once — store immediately in a secrets manager.
 
 ## Links
 

--- a/cargo-ai/SKILL.md
+++ b/cargo-ai/SKILL.md
@@ -2,7 +2,7 @@
 name: cargo-ai
 description: Create and configure AI agents, upload files for RAG, manage MCP servers, and handle agent memories using the Cargo CLI. Use when the user wants to create or update agents, upload knowledge base files, connect MCP tool servers, or manage agent memories. For sending messages to agents, use the cargo-orchestration skill instead.
 license: MIT
-compatibility: Requires @cargo-ai/cli (npm) and a Cargo API token
+compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 metadata:
   author: getcargo
   version: "1.1"
@@ -24,8 +24,10 @@ Agent resource management: creating and configuring agents, uploading files for 
 
 ```bash
 npm install -g @cargo-ai/cli
-cargo-ai login --token <your-api-token>
-cargo-ai login --token <your-api-token> --workspace-uuid <uuid>
+cargo-ai login --oauth                                  # browser sign-in (recommended)
+# or: cargo-ai login --token <your-api-token>           # workspace-scoped API token (non-interactive)
+# Pin a default workspace at login (with --oauth)
+cargo-ai login --oauth --workspace-uuid <uuid>
 ```
 
 Verify with `cargo-ai whoami`. All commands output JSON to stdout. Without a global install, prefix every command with `npx @cargo-ai/cli` instead of `cargo-ai`.

--- a/cargo-analytics/SKILL.md
+++ b/cargo-analytics/SKILL.md
@@ -2,7 +2,7 @@
 name: cargo-analytics
 description: Download workflow run results, export segment data, and monitor run metrics using the Cargo CLI. Use when the user wants run metrics, error rates, data export, or download results for their Cargo workspace. For billing and credit usage, use the cargo-billing skill instead.
 license: MIT
-compatibility: Requires @cargo-ai/cli (npm) and a Cargo API token
+compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 metadata:
   author: getcargo
   version: "1.4"
@@ -22,8 +22,10 @@ Measurement and export: monitoring run metrics, downloading run and batch result
 
 ```bash
 npm install -g @cargo-ai/cli
-cargo-ai login --token <your-api-token>
-cargo-ai login --token <your-api-token> --workspace-uuid <uuid>
+cargo-ai login --oauth                                  # browser sign-in (recommended)
+# or: cargo-ai login --token <your-api-token>           # workspace-scoped API token (non-interactive)
+# Pin a default workspace at login (with --oauth)
+cargo-ai login --oauth --workspace-uuid <uuid>
 ```
 
 Verify with `cargo-ai whoami`. All commands output JSON to stdout. Without a global install, prefix every command with `npx @cargo-ai/cli` instead of `cargo-ai`.

--- a/cargo-analytics/references/troubleshooting.md
+++ b/cargo-analytics/references/troubleshooting.md
@@ -8,7 +8,7 @@ Common errors and recovery steps for `cargo-analytics` commands.
 |---------|-------|-----|
 | `{"errorMessage": "..."}` with non-zero exit | Any CLI error | Read the `errorMessage` — it usually says exactly what's wrong |
 | `command not found: cargo-ai` | CLI not installed or not in PATH | Run `npm install -g @cargo-ai/cli` or prefix with `npx @cargo-ai/cli` |
-| `Unauthorized` or `Forbidden` | Bad or expired API token | Re-run `cargo-ai login --token <token>` and verify with `cargo-ai whoami` |
+| `Unauthorized` or `Forbidden` | Bad or expired credentials | Re-run `cargo-ai login --oauth` (browser sign-in) or `cargo-ai login --token <token>`; verify with `cargo-ai whoami` |
 
 ## Run metrics and counts
 

--- a/cargo-billing/SKILL.md
+++ b/cargo-billing/SKILL.md
@@ -2,7 +2,7 @@
 name: cargo-billing
 description: Pull usage metrics, check subscription status, view invoices, and manage credits using the Cargo CLI. Use when the user wants billing analytics, usage reports, credit usage, cost analysis, subscription details, or invoice history for their Cargo workspace.
 license: MIT
-compatibility: Requires @cargo-ai/cli (npm) and a Cargo API token
+compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 metadata:
   author: getcargo
   version: "1.0"
@@ -20,8 +20,10 @@ Billing and credit management: pulling usage metrics, checking subscription stat
 
 ```bash
 npm install -g @cargo-ai/cli
-cargo-ai login --token <your-api-token>
-cargo-ai login --token <your-api-token> --workspace-uuid <uuid>
+cargo-ai login --oauth                                  # browser sign-in (recommended)
+# or: cargo-ai login --token <your-api-token>           # workspace-scoped API token (non-interactive)
+# Pin a default workspace at login (with --oauth)
+cargo-ai login --oauth --workspace-uuid <uuid>
 ```
 
 Verify with `cargo-ai whoami`. All commands output JSON to stdout. Without a global install, prefix every command with `npx @cargo-ai/cli` instead of `cargo-ai`.

--- a/cargo-billing/references/troubleshooting.md
+++ b/cargo-billing/references/troubleshooting.md
@@ -8,7 +8,7 @@ Common errors and recovery steps for `cargo-billing` commands.
 |---------|-------|-----|
 | `{"errorMessage": "..."}` with non-zero exit | Any CLI error | Read the `errorMessage` — it usually says exactly what's wrong |
 | `command not found: cargo-ai` | CLI not installed or not in PATH | Run `npm install -g @cargo-ai/cli` or prefix with `npx @cargo-ai/cli` |
-| `Unauthorized` or `Forbidden` | Bad or expired API token | Re-run `cargo-ai login --token <token>` and verify with `cargo-ai whoami` |
+| `Unauthorized` or `Forbidden` | Bad or expired credentials | Re-run `cargo-ai login --oauth` (browser sign-in) or `cargo-ai login --token <token>`; verify with `cargo-ai whoami` |
 
 ## Usage metrics
 

--- a/cargo-connection/SKILL.md
+++ b/cargo-connection/SKILL.md
@@ -2,7 +2,7 @@
 name: cargo-connection
 description: Manage connectors and integrations using the Cargo CLI. Use when the user wants to list, create, update, or remove connectors, discover available integrations, or understand what connector actions are available for use in workflows.
 license: MIT
-compatibility: Requires @cargo-ai/cli (npm) and a Cargo API token
+compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 metadata:
   author: getcargo
   version: "1.0"
@@ -22,8 +22,10 @@ Connector and integration management: listing connectors, discovering available 
 
 ```bash
 npm install -g @cargo-ai/cli
-cargo-ai login --token <your-api-token>
-cargo-ai login --token <your-api-token> --workspace-uuid <uuid>
+cargo-ai login --oauth                                  # browser sign-in (recommended)
+# or: cargo-ai login --token <your-api-token>           # workspace-scoped API token (non-interactive)
+# Pin a default workspace at login (with --oauth)
+cargo-ai login --oauth --workspace-uuid <uuid>
 ```
 
 Verify with `cargo-ai whoami`. All commands output JSON to stdout. Without a global install, prefix every command with `npx @cargo-ai/cli` instead of `cargo-ai`.

--- a/cargo-connection/references/troubleshooting.md
+++ b/cargo-connection/references/troubleshooting.md
@@ -8,7 +8,7 @@ Common errors and recovery steps for `cargo-connection` commands.
 | -------------------------------------------- | -------------------------------- | ------------------------------------------------------------------------- |
 | `{"errorMessage": "..."}` with non-zero exit | Any CLI error                    | Read the `errorMessage` — it usually says exactly what's wrong            |
 | `command not found: cargo-ai`                | CLI not installed or not in PATH | Run `npm install -g @cargo-ai/cli` or prefix with `npx @cargo-ai/cli`     |
-| `Unauthorized` or `Forbidden`                | Bad or expired API token         | Re-run `cargo-ai login --token <token>` and verify with `cargo-ai whoami` |
+| `Unauthorized` or `Forbidden`                | Bad or expired credentials       | Re-run `cargo-ai login --oauth` (browser sign-in) or `cargo-ai login --token <token>`; verify with `cargo-ai whoami` |
 
 ## Connectors
 

--- a/cargo-gtm/SKILL.md
+++ b/cargo-gtm/SKILL.md
@@ -2,7 +2,7 @@
 name: cargo-gtm
 description: "Front door for any GTM task on Cargo — sourcing, waterfall enrichment, email/phone/LinkedIn lookup, email verification, scoring, qualification, sequencing, CRM sync, and signal monitoring (job changes, funding, tech-stack/hiring intent). Use when the user states a real-world goal involving prospects, leads, accounts, contacts, ICP lists, or campaign activation. Routes to phase guides (Level 2), recipes (Level 2.5), and per-provider playbooks (Level 3) before any action call."
 license: MIT
-compatibility: Requires @cargo-ai/cli (npm) and a Cargo API token
+compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 metadata:
   author: getcargo
   version: "1.0"

--- a/cargo-orchestration/SKILL.md
+++ b/cargo-orchestration/SKILL.md
@@ -2,7 +2,7 @@
 name: cargo-orchestration
 description: Interact with the Cargo platform via CLI. Use when the user wants to execute an action, run a workflow, trigger a batch, message an AI agent, query a data warehouse, fetch segment records, or inspect a model schema.
 license: MIT
-compatibility: Requires @cargo-ai/cli (npm) and a Cargo API token
+compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 metadata:
   author: getcargo
   version: "1.4"
@@ -47,8 +47,10 @@ Need to run something?
 
 ```bash
 npm install -g @cargo-ai/cli
-cargo-ai login --token <your-api-token>
-cargo-ai login --token <your-api-token> --workspace-uuid <uuid>
+cargo-ai login --oauth                                  # browser sign-in (recommended)
+# or: cargo-ai login --token <your-api-token>           # workspace-scoped API token (non-interactive)
+# Pin a default workspace at login (with --oauth)
+cargo-ai login --oauth --workspace-uuid <uuid>
 ```
 
 Verify with `cargo-ai whoami`. All commands output JSON to stdout. Without a global install, prefix every command with `npx @cargo-ai/cli` instead of `cargo-ai`.

--- a/cargo-orchestration/references/troubleshooting.md
+++ b/cargo-orchestration/references/troubleshooting.md
@@ -10,7 +10,7 @@ Common errors and recovery steps for `cargo-orchestration` commands.
 | -------------------------------------------- | -------------------------------- | ------------------------------------------------------------------------- |
 | `{"errorMessage": "..."}` with non-zero exit | Any CLI error                    | Read the `errorMessage` — it usually says exactly what's wrong            |
 | `command not found: cargo-ai`                | CLI not installed or not in PATH | Run `npm install -g @cargo-ai/cli` or prefix with `npx @cargo-ai/cli`     |
-| `Unauthorized` or `Forbidden`                | Bad or expired API token         | Re-run `cargo-ai login --token <token>` and verify with `cargo-ai whoami` |
+| `Unauthorized` or `Forbidden`                | Bad or expired credentials       | Re-run `cargo-ai login --oauth` (browser sign-in) or `cargo-ai login --token <token>`; verify with `cargo-ai whoami` |
 
 ## Runs and batches
 

--- a/cargo-storage/SKILL.md
+++ b/cargo-storage/SKILL.md
@@ -2,7 +2,7 @@
 name: cargo-storage
 description: Manage models, datasets, columns, and relationships using the Cargo CLI. Use when the user wants to inspect or modify data models, create or update columns, list datasets, set model relationships, or understand the schema of their Cargo workspace.
 license: MIT
-compatibility: Requires @cargo-ai/cli (npm) and a Cargo API token
+compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 metadata:
   author: getcargo
   version: "1.0"
@@ -22,8 +22,10 @@ Data layer management: inspecting and modifying models, datasets, columns, relat
 
 ```bash
 npm install -g @cargo-ai/cli
-cargo-ai login --token <your-api-token>
-cargo-ai login --token <your-api-token> --workspace-uuid <uuid>
+cargo-ai login --oauth                                  # browser sign-in (recommended)
+# or: cargo-ai login --token <your-api-token>           # workspace-scoped API token (non-interactive)
+# Pin a default workspace at login (with --oauth)
+cargo-ai login --oauth --workspace-uuid <uuid>
 ```
 
 Verify with `cargo-ai whoami`. All commands output JSON to stdout. Without a global install, prefix every command with `npx @cargo-ai/cli` instead of `cargo-ai`.

--- a/cargo-storage/references/troubleshooting.md
+++ b/cargo-storage/references/troubleshooting.md
@@ -8,7 +8,7 @@ Common errors and recovery steps for `cargo-storage` commands.
 |---------|-------|-----|
 | `{"errorMessage": "..."}` with non-zero exit | Any CLI error | Read the `errorMessage` — it usually says exactly what's wrong |
 | `command not found: cargo-ai` | CLI not installed or not in PATH | Run `npm install -g @cargo-ai/cli` or prefix with `npx @cargo-ai/cli` |
-| `Unauthorized` or `Forbidden` | Bad or expired API token | Re-run `cargo-ai login --token <token>` and verify with `cargo-ai whoami` |
+| `Unauthorized` or `Forbidden` | Bad or expired credentials | Re-run `cargo-ai login --oauth` (browser sign-in) or `cargo-ai login --token <token>`; verify with `cargo-ai whoami` |
 
 ## Models
 

--- a/cargo-workspace-management/SKILL.md
+++ b/cargo-workspace-management/SKILL.md
@@ -2,7 +2,7 @@
 name: cargo-workspace-management
 description: Manage workspace users, API tokens, folders, roles, and submit reports to workspace management using the Cargo CLI. Use when the user wants to invite or manage workspace members, create or rotate API tokens, organize resources into folders, inspect workspace roles and permissions, or submit a report to workspace management when the CLI fails or is misused.
 license: MIT
-compatibility: Requires @cargo-ai/cli (npm) and a Cargo API token
+compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 metadata:
   author: getcargo
   version: "1.0"
@@ -23,8 +23,10 @@ Workspace administration: managing users, API tokens, folders, roles, workspace-
 
 ```bash
 npm install -g @cargo-ai/cli
-cargo-ai login --token <your-api-token>
-cargo-ai login --token <your-api-token> --workspace-uuid <uuid>
+cargo-ai login --oauth                                  # browser sign-in (recommended)
+# or: cargo-ai login --token <your-api-token>           # workspace-scoped API token (non-interactive)
+# Pin a default workspace at login (with --oauth)
+cargo-ai login --oauth --workspace-uuid <uuid>
 ```
 
 Verify with `cargo-ai whoami`. All commands output JSON to stdout. Without a global install, prefix every command with `npx @cargo-ai/cli` instead of `cargo-ai`.

--- a/cargo-workspace-management/references/troubleshooting.md
+++ b/cargo-workspace-management/references/troubleshooting.md
@@ -18,7 +18,7 @@ Common errors and recovery steps for `cargo-workspace-management` commands.
 |---------|-------|-----|
 | `{"errorMessage": "..."}` with non-zero exit | Any CLI error | Read the `errorMessage` — it usually says exactly what's wrong |
 | `command not found: cargo-ai` | CLI not installed or not in PATH | Run `npm install -g @cargo-ai/cli` or prefix with `npx @cargo-ai/cli` |
-| `Unauthorized` or `Forbidden` | Bad or expired token, or insufficient permissions | Re-run `cargo-ai login --token <token>`; verify with `cargo-ai whoami`; use an admin token for workspace management |
+| `Unauthorized` or `Forbidden` | Bad or expired credentials, or insufficient permissions | Re-run `cargo-ai login --oauth` (browser sign-in) or `cargo-ai login --token <token>`; verify with `cargo-ai whoami`; use an admin account/token for workspace management |
 
 ## Users
 

--- a/index.md
+++ b/index.md
@@ -20,9 +20,10 @@ This repository contains 8 skills at the repo root: one **outcome skill** (`carg
 
 ```bash
 npm install -g @cargo-ai/cli
-cargo-ai login --token <your-api-token>
-# Optional: target a specific workspace
-cargo-ai login --token <your-api-token> --workspace-uuid <uuid>
+cargo-ai login --oauth                                   # browser sign-in (recommended)
+# or: cargo-ai login --token <your-api-token>            # use an existing workspace-scoped API token
+# Optional: pin a default workspace at login
+cargo-ai login --oauth --workspace-uuid <uuid>
 # Verify
 cargo-ai whoami
 ```


### PR DESCRIPTION
## Summary
Updated documentation across all skill files and guides to promote OAuth 2.0 Device Authorization Flow as the recommended authentication method, while maintaining support for API token-based authentication for non-interactive environments.

## Key Changes
- **Authentication guidance**: Updated all `SKILL.md` files to indicate OAuth browser sign-in (`--oauth`) as the recommended approach, with API tokens as an alternative for CI/scripts
- **Login examples**: Standardized login command examples across 8 skill files to show:
  - `cargo-ai login --oauth` as the primary method (with "recommended" label)
  - `cargo-ai login --token <token>` as the non-interactive alternative
  - Optional workspace pinning with `--oauth --workspace-uuid <uuid>`
- **Compatibility statements**: Updated compatibility lines in all skill files from "Requires...a Cargo API token" to "Requires...a Cargo account (browser sign-in via --oauth, or an API token)"
- **Troubleshooting updates**: Changed error messages from "Bad or expired API token" to "Bad or expired credentials" with updated recovery steps mentioning both OAuth and token options
- **Main documentation**: Updated `README.md` and `index.md` with clearer explanations of when to use each authentication method and how OAuth works

## Implementation Details
- No functional changes to CLI behavior—purely documentation updates
- Consistent messaging across all 8 skills (cargo-ai, cargo-analytics, cargo-billing, cargo-connection, cargo-orchestration, cargo-storage, cargo-workspace-management, cargo-gtm)
- Added inline comments in code examples to clarify the purpose of each login variant
- Maintained backward compatibility messaging for existing API token users

https://claude.ai/code/session_01Pan1J9T2ZbpHHoSpFZxKNz