### PR TITLE
Document workspace-management skill for folder operations

### DIFF
--- a/cargo-ai/SKILL.md
+++ b/cargo-ai/SKILL.md
@@ -13,6 +13,7 @@ metadata:
 Agent resource management: creating and configuring agents, uploading files for retrieval-augmented generation (RAG), connecting MCP servers, and managing agent memories.
 
 > For *using* agents (sending messages, multi-turn chat, polling), use `cargo-orchestration`.
+> For workspace administration — folders (used to organize agents and files), users, API tokens, roles, and submitting reports when the CLI fails — use [`cargo-workspace-management`](../cargo-workspace-management/SKILL.md).
 
 > See `references/response-shapes.md` for full JSON response structures.
 > See `references/troubleshooting.md` for common errors and how to fix them.
@@ -101,7 +102,7 @@ cargo-ai ai agent update --uuid <agent-uuid> \
   --name "Senior Lead Researcher" \
   --description "Updated description"
 
-# Move to a folder
+# Move to a folder (find folder UUIDs via cargo-workspace-management)
 cargo-ai ai agent update --uuid <agent-uuid> --folder-uuid <folder-uuid>
 
 # Remove an agent
@@ -109,6 +110,8 @@ cargo-ai ai agent remove <agent-uuid>
 ```
 
 **Agent icon:** `--icon-color` must be one of: `grey`, `green`, `purple`, `yellow`, `blue`, `red`. `--icon-face` is an emoji string.
+
+**Folders:** Folder creation, listing, and management lives in [`cargo-workspace-management`](../cargo-workspace-management/SKILL.md) (`cargo-ai workspace folder list/create/...`). Use that skill to discover or create the `<folder-uuid>` you pass to `--folder-uuid` here.
 
 ## Releases
 

--- a/cargo-ai/SKILL.md
+++ b/cargo-ai/SKILL.md
@@ -111,7 +111,7 @@ cargo-ai ai agent remove <agent-uuid>
 
 **Agent icon:** `--icon-color` must be one of: `grey`, `green`, `purple`, `yellow`, `blue`, `red`. `--icon-face` is an emoji string.
 
-**Folders:** Folder creation, listing, and management lives in [`cargo-workspace-management`](../cargo-workspace-management/SKILL.md) (`cargo-ai workspace folder list/create/...`). Use that skill to discover or create the `<folder-uuid>` you pass to `--folder-uuid` here.
+**Folders:** Folder creation, listing, and management lives in [`cargo-workspace-management`](../cargo-workspace-management/SKILL.md) (`cargo-ai workspaceManagement folder list/create/...`). Use that skill to discover or create the `<folder-uuid>` you pass to `--folder-uuid` here.
 
 ## Releases
 

--- a/cargo-ai/references/examples/agents.md
+++ b/cargo-ai/references/examples/agents.md
@@ -27,7 +27,7 @@ cargo-ai ai agent create \
 Folders are managed by the [`cargo-workspace-management`](../../../cargo-workspace-management/SKILL.md) skill — see its `references/examples/folders.md` for create/list/update.
 
 ```bash
-cargo-ai workspace folder list
+cargo-ai workspaceManagement folder list
 # → Find the folder UUID (kind: "agent")
 
 cargo-ai ai agent create \

--- a/cargo-ai/references/examples/agents.md
+++ b/cargo-ai/references/examples/agents.md
@@ -24,9 +24,11 @@ cargo-ai ai agent create \
 
 ## Create an agent in a folder
 
+Folders are managed by the [`cargo-workspace-management`](../../../cargo-workspace-management/SKILL.md) skill — see its `references/examples/folders.md` for create/list/update.
+
 ```bash
 cargo-ai workspace folder list
-# → Find the folder UUID
+# → Find the folder UUID (kind: "agent")
 
 cargo-ai ai agent create \
   --name "Lead Researcher" \

--- a/cargo-ai/references/examples/files.md
+++ b/cargo-ai/references/examples/files.md
@@ -33,8 +33,10 @@ cargo-ai ai release deploy-draft --agent-uuid <agent-uuid> \
 
 ## Upload to a folder
 
+Folders are managed by the [`cargo-workspace-management`](../../../cargo-workspace-management/SKILL.md) skill — see its `references/examples/folders.md` for create/list/update.
+
 ```bash
-# 1. Find the folder
+# 1. Find the folder (kind: "file")
 cargo-ai workspace folder list
 
 # 2. Upload and assign

--- a/cargo-ai/references/examples/files.md
+++ b/cargo-ai/references/examples/files.md
@@ -37,7 +37,7 @@ Folders are managed by the [`cargo-workspace-management`](../../../cargo-workspa
 
 ```bash
 # 1. Find the folder (kind: "file")
-cargo-ai workspace folder list
+cargo-ai workspaceManagement folder list
 
 # 2. Upload and assign
 cargo-ai ai file upload --file-path ./notes.pdf

--- a/cargo-ai/references/troubleshooting.md
+++ b/cargo-ai/references/troubleshooting.md
@@ -16,7 +16,7 @@ Your API token may lack the required permissions. Verify with `cargo-ai whoami` 
 The agent UUID does not exist or has been deleted. Re-run `cargo-ai ai agent list` to get the current list of agents.
 
 **`folderNotFound`**
-The folder UUID passed to `--folder-uuid` does not exist. Run `cargo-ai workspace folder list` to find valid folder UUIDs.
+The folder UUID passed to `--folder-uuid` does not exist. Folders are managed by the [`cargo-workspace-management`](../../cargo-workspace-management/SKILL.md) skill — run `cargo-ai workspace folder list` to find valid folder UUIDs, or `cargo-ai workspace folder create --kind agent ...` to create one.
 
 **Agent has no deployed release**
 If `agent get` shows `deployedRelease: null`, the agent has never been deployed. Follow the release workflow:
@@ -52,7 +52,7 @@ The template slug does not exist. Run `cargo-ai ai template list` to see availab
 The file UUID does not exist or has been deleted. Run `cargo-ai ai file list` to get the current list.
 
 **`folderNotFound`**
-The folder UUID passed to `--folder-uuid` on file update does not exist. Run `cargo-ai workspace folder list` to find valid folder UUIDs.
+The folder UUID passed to `--folder-uuid` on file update does not exist. Folders are managed by the [`cargo-workspace-management`](../../cargo-workspace-management/SKILL.md) skill — run `cargo-ai workspace folder list` to find valid folder UUIDs, or `cargo-ai workspace folder create --kind file ...` to create one.
 
 **Upload fails or times out**
 Large files may take longer to upload. Ensure the file path is correct and the file is not locked by another process.

--- a/cargo-ai/references/troubleshooting.md
+++ b/cargo-ai/references/troubleshooting.md
@@ -16,7 +16,7 @@ Your API token may lack the required permissions. Verify with `cargo-ai whoami` 
 The agent UUID does not exist or has been deleted. Re-run `cargo-ai ai agent list` to get the current list of agents.
 
 **`folderNotFound`**
-The folder UUID passed to `--folder-uuid` does not exist. Folders are managed by the [`cargo-workspace-management`](../../cargo-workspace-management/SKILL.md) skill — run `cargo-ai workspace folder list` to find valid folder UUIDs, or `cargo-ai workspace folder create --kind agent ...` to create one.
+The folder UUID passed to `--folder-uuid` does not exist. Folders are managed by the [`cargo-workspace-management`](../../cargo-workspace-management/SKILL.md) skill — run `cargo-ai workspaceManagement folder list` to find valid folder UUIDs, or `cargo-ai workspaceManagement folder create --kind agent ...` to create one.
 
 **Agent has no deployed release**
 If `agent get` shows `deployedRelease: null`, the agent has never been deployed. Follow the release workflow:
@@ -52,7 +52,7 @@ The template slug does not exist. Run `cargo-ai ai template list` to see availab
 The file UUID does not exist or has been deleted. Run `cargo-ai ai file list` to get the current list.
 
 **`folderNotFound`**
-The folder UUID passed to `--folder-uuid` on file update does not exist. Folders are managed by the [`cargo-workspace-management`](../../cargo-workspace-management/SKILL.md) skill — run `cargo-ai workspace folder list` to find valid folder UUIDs, or `cargo-ai workspace folder create --kind file ...` to create one.
+The folder UUID passed to `--folder-uuid` on file update does not exist. Folders are managed by the [`cargo-workspace-management`](../../cargo-workspace-management/SKILL.md) skill — run `cargo-ai workspaceManagement folder list` to find valid folder UUIDs, or `cargo-ai workspaceManagement folder create --kind file ...` to create one.
 
 **Upload fails or times out**
 Large files may take longer to upload. Ensure the file path is correct and the file is not locked by another process.

--- a/cargo-gtm/SKILL.md
+++ b/cargo-gtm/SKILL.md
@@ -118,7 +118,7 @@ Every action JSON in this skill follows the rules in [`../cargo-orchestration/re
 
 ## 7) When stuck — file a workspace report
 
-If a recipe fails repeatedly and the cause isn't obvious, escalate via `cargo-ai workspace report create`. See [`../cargo-workspace-management/SKILL.md`](../cargo-workspace-management/SKILL.md) (Reports section).
+If a recipe fails repeatedly and the cause isn't obvious, escalate via `cargo-ai workspaceManagement report create`. See [`../cargo-workspace-management/SKILL.md`](../cargo-workspace-management/SKILL.md) (Reports section).
 
 ## 8) Provider playbooks
 

--- a/cargo-gtm/guides/finding-companies-and-contacts.md
+++ b/cargo-gtm/guides/finding-companies-and-contacts.md
@@ -134,4 +134,4 @@ Two failure modes for sourcing:
 1. **Filter mismatch** — provider doesn't expose the filter you need (e.g. salesNavigator can't filter by funding round). Move to a richer provider (`peopleDataLabs.queryCompanies`).
 2. **Coverage gap** — provider doesn't have data for the niche (e.g. local SMBs aren't well-covered by salesNavigator). Move to a niche provider (`serper.searchPlaces` for SMBs, `theirStack.searchCompanies` for tech-driven).
 
-If the user's request can't be served at all, file a `workspace report` describing the gap.
+If the user's request can't be served at all, file a `workspaceManagement report` describing the gap.

--- a/cargo-gtm/recipes/funding-watch.md
+++ b/cargo-gtm/recipes/funding-watch.md
@@ -100,4 +100,4 @@ For batch runs, use `cargo-ai orchestration run download-outputs --workflow-uuid
 
 ## When stuck — file a workspace report
 
-If a target company has known recent funding but `cargo.enrichBusinessFundingAndAcquisitions` returns empty: file a `cargo-ai workspace report create` with the domain so cargo can verify catalog coverage.
+If a target company has known recent funding but `cargo.enrichBusinessFundingAndAcquisitions` returns empty: file a `cargo-ai workspaceManagement report create` with the domain so cargo can verify catalog coverage.

--- a/cargo-gtm/recipes/icp-discovery.md
+++ b/cargo-gtm/recipes/icp-discovery.md
@@ -186,4 +186,4 @@ Plus a follow-up suggestion: "Want me to run `/cargo-tam-build` with these signa
 
 ## When stuck — file a workspace report
 
-If the SoR query fails or the deal model schema is unfamiliar, file via `cargo-ai workspace report create`. See [`../../cargo-workspace-management/SKILL.md`](../../cargo-workspace-management/SKILL.md).
+If the SoR query fails or the deal model schema is unfamiliar, file via `cargo-ai workspaceManagement report create`. See [`../../cargo-workspace-management/SKILL.md`](../../cargo-workspace-management/SKILL.md).

--- a/cargo-gtm/recipes/portfolio-prospecting.md
+++ b/cargo-gtm/recipes/portfolio-prospecting.md
@@ -140,7 +140,7 @@ If `peopleDataLabs.queryCompanies` doesn't recognize the investor name (e.g. ver
 
 - `apolloio` if its investor coverage is stronger for the niche.
 - `firecrawl.scrape` on the investor's portfolio page (if public) → LLM extract via `anthropic.instruct`.
-- File a `cargo-ai workspace report create` if neither works — surfaces the gap to the cargo team.
+- File a `cargo-ai workspaceManagement report create` if neither works — surfaces the gap to the cargo team.
 
 ## When stuck — file a workspace report
 

--- a/cargo-gtm/references/alternatives.md
+++ b/cargo-gtm/references/alternatives.md
@@ -90,4 +90,4 @@ For these: defer to [`../SKILL.md`](../SKILL.md) and its [`../agents/execution-p
 
 ## Always escalate to a workspace report
 
-If the priority stack misses AND no documented alternative covers the gap, file a `cargo-ai workspace report create` describing the missing capability. See [`../../cargo-workspace-management/SKILL.md`](../../cargo-workspace-management/SKILL.md) (Reports section).
+If the priority stack misses AND no documented alternative covers the gap, file a `cargo-ai workspaceManagement report create` describing the missing capability. See [`../../cargo-workspace-management/SKILL.md`](../../cargo-workspace-management/SKILL.md) (Reports section).

--- a/cargo-orchestration/references/tools.md
+++ b/cargo-orchestration/references/tools.md
@@ -145,7 +145,7 @@ Poll until `status` is `success`, `error`, or `cancelled`:
 Before running a tool on records from a file, you must upload the CSV first. The upload returns the `s3Filename` needed by batch commands.
 
 ```bash
-cargo-ai workspace file upload --file-path ./my-companies.csv
+cargo-ai workspaceManagement file upload --file-path ./my-companies.csv
 ```
 
 Response:
@@ -161,7 +161,7 @@ Response:
 You can also inspect which columns the file contains:
 
 ```bash
-cargo-ai workspace file list-columns --s3-filename abc123-my-companies.csv
+cargo-ai workspaceManagement file list-columns --s3-filename abc123-my-companies.csv
 ```
 
 ## Run a tool on records from a file
@@ -172,7 +172,7 @@ cargo-ai orchestration tool list
 # → Extract tool.workflowUuid
 
 # 2. Upload the CSV
-cargo-ai workspace file upload --file-path ./my-companies.csv
+cargo-ai workspaceManagement file upload --file-path ./my-companies.csv
 # → Extract s3Filename from the response
 
 

--- a/cargo-workspace-management/SKILL.md
+++ b/cargo-workspace-management/SKILL.md
@@ -37,24 +37,24 @@ Failed commands exit non-zero and return `{"errorMessage": "..."}`.
 
 ```bash
 cargo-ai whoami                        # current user and active workspace
-cargo-ai workspace user list           # all workspace members
-cargo-ai workspace role list           # available roles
-cargo-ai workspace token list          # all API tokens
-cargo-ai workspace folder list         # all folders
+cargo-ai workspaceManagement user list           # all workspace members
+cargo-ai workspaceManagement role list           # available roles
+cargo-ai workspaceManagement token list          # all API tokens
+cargo-ai workspaceManagement folder list         # all folders
 ```
 
 ## Quick reference
 
 ```bash
 cargo-ai whoami
-cargo-ai workspace user list
-cargo-ai workspace user create --user-email <email> --role-slug <slug>
-cargo-ai workspace token list
-cargo-ai workspace token create --name <name>
-cargo-ai workspace token remove <token-uuid>
-cargo-ai workspace folder list
-cargo-ai workspace folder create --name <name> --emoji-slug <slug> --kind <kind>
-cargo-ai workspace report create --title <title> --description <description>
+cargo-ai workspaceManagement user list
+cargo-ai workspaceManagement user create --user-email <email> --role-slug <slug>
+cargo-ai workspaceManagement token list
+cargo-ai workspaceManagement token create --name <name>
+cargo-ai workspaceManagement token remove <token-uuid>
+cargo-ai workspaceManagement folder list
+cargo-ai workspaceManagement folder create --name <name> --emoji-slug <slug> --kind <kind>
+cargo-ai workspaceManagement report create --title <title> --description <description>
 ```
 
 ## Current user and workspace
@@ -69,18 +69,18 @@ cargo-ai whoami
 
 ```bash
 # List all workspace members
-cargo-ai workspace user list
+cargo-ai workspaceManagement user list
 
 # Invite a new user (requires their email and a role)
-cargo-ai workspace user create \
+cargo-ai workspaceManagement user create \
   --user-email user@example.com \
   --role-slug <role-slug>
 
 # Update a user's role
-cargo-ai workspace user update --user-uuid <uuid> --role-slug <new-role-slug>
+cargo-ai workspaceManagement user update --user-uuid <uuid> --role-slug <new-role-slug>
 
 # Remove a user from the workspace
-cargo-ai workspace user remove --user-uuid <uuid>
+cargo-ai workspaceManagement user remove --user-uuid <uuid>
 ```
 
 ## Roles
@@ -89,7 +89,7 @@ Roles define what users can do in the workspace.
 
 ```bash
 # List available roles
-cargo-ai workspace role list
+cargo-ai workspaceManagement role list
 ```
 
 Always check available roles before inviting users — use the `slug` from `role list` when creating or updating users.
@@ -100,14 +100,14 @@ Each token has a human-readable `name` and a `permissions` field. Tokens created
 
 ```bash
 # List all API tokens (includes name and permissions of each token)
-cargo-ai workspace token list
+cargo-ai workspaceManagement token list
 
 # Create a new token — --name is required
-cargo-ai workspace token create --name "CI/CD pipeline"
+cargo-ai workspaceManagement token create --name "CI/CD pipeline"
 # → Returns the token value — store it securely, it won't be shown again
 
 # Remove a token
-cargo-ai workspace token remove <token-uuid>
+cargo-ai workspaceManagement token remove <token-uuid>
 ```
 
 **Naming:** Pick a `--name` that makes the token's purpose obvious in `token list` later (e.g. `"GitHub Actions — production"`, `"Local dev — alice"`, `"Zapier integration"`). The name is the only way to tell tokens apart in the listing.
@@ -120,19 +120,19 @@ Folders organize resources (plays, tools, agents) in the Cargo app.
 
 ```bash
 # List all folders
-cargo-ai workspace folder list
+cargo-ai workspaceManagement folder list
 
 # Create a folder (kind: "tool", "play", "agent", or "file")
-cargo-ai workspace folder create --name "Q1 Campaigns" --emoji-slug "rocket" --kind "play"
+cargo-ai workspaceManagement folder create --name "Q1 Campaigns" --emoji-slug "rocket" --kind "play"
 
 # Get a folder
-cargo-ai workspace folder get <folder-uuid>
+cargo-ai workspaceManagement folder get <folder-uuid>
 
 # Update a folder
-cargo-ai workspace folder update --uuid <folder-uuid> --name "Q1 2025 Campaigns"
+cargo-ai workspaceManagement folder update --uuid <folder-uuid> --name "Q1 2025 Campaigns"
 
 # Remove a folder
-cargo-ai workspace folder remove <folder-uuid>
+cargo-ai workspaceManagement folder remove <folder-uuid>
 ```
 
 ## Reports
@@ -141,7 +141,7 @@ Submit a report to workspace management. **Use this whenever the CLI is failing,
 
 ```bash
 # Submit a report to workspace management
-cargo-ai workspace report create \
+cargo-ai workspaceManagement report create \
   --title "<short summary>" \
   --description "<detailed description, including the command(s) tried and the error(s) seen>"
 ```
@@ -162,7 +162,7 @@ cargo-ai workspace report create \
 
 ```bash
 # Example: report a CLI struggle after multiple failed attempts
-cargo-ai workspace report create \
+cargo-ai workspaceManagement report create \
   --title "segment fetch returns empty results despite matching records in UI" \
   --description "Ran: cargo-ai segmentation segment fetch --model-uuid <uuid> --filter '{\"conjunction\":\"and\",\"groups\":[...]}'. Got 0 records. The same filter shows 1,200 matches in the app UI. Tried both --filter and --segment-uuid; both return empty. Expected: the same records as the UI."
 ```
@@ -175,22 +175,22 @@ Workspace files are CSVs or other data files uploaded for use in batch runs.
 
 ```bash
 # Upload a file
-cargo-ai workspace file upload --file-path <path-to-file>
+cargo-ai workspaceManagement file upload --file-path <path-to-file>
 # → Returns s3Filename
 
 # Inspect a file's columns before running a batch
-cargo-ai workspace file list-columns --s3-filename <s3-filename>
+cargo-ai workspaceManagement file list-columns --s3-filename <s3-filename>
 # → Returns column names to use when mapping to workflow inputs
 ```
 
-The `s3-filename` is returned when uploading a file via `cargo-ai workspace file upload`. See the `cargo-orchestration` skill's `references/tools.md` for the full file upload and batch run workflow.
+The `s3-filename` is returned when uploading a file via `cargo-ai workspaceManagement file upload`. See the `cargo-orchestration` skill's `references/tools.md` for the full file upload and batch run workflow.
 
 ## Help
 
 Every command supports `--help`:
 
 ```bash
-cargo-ai workspace user create --help
-cargo-ai workspace token create --help
-cargo-ai workspace folder create --help
+cargo-ai workspaceManagement user create --help
+cargo-ai workspaceManagement token create --help
+cargo-ai workspaceManagement folder create --help
 ```

--- a/cargo-workspace-management/references/examples/folders.md
+++ b/cargo-workspace-management/references/examples/folders.md
@@ -5,7 +5,7 @@ Folders organize resources (plays, tools, agents) in the Cargo app for easier na
 ## List all folders
 
 ```bash
-cargo-ai workspace folder list
+cargo-ai workspaceManagement folder list
 ```
 
 ## Create a folder
@@ -13,37 +13,37 @@ cargo-ai workspace folder list
 Requires `--name`, `--emoji-slug`, and `--kind`. Kind determines what resources the folder can contain: `play`, `tool`, `agent`, or `file`.
 
 ```bash
-cargo-ai workspace folder create --name "Q1 Campaigns" --emoji-slug "rocket" --kind "play"
-cargo-ai workspace folder create --name "Outbound - SDR Team" --emoji-slug "briefcase" --kind "tool"
-cargo-ai workspace folder create --name "AI Assistants" --emoji-slug "robot" --kind "agent"
+cargo-ai workspaceManagement folder create --name "Q1 Campaigns" --emoji-slug "rocket" --kind "play"
+cargo-ai workspaceManagement folder create --name "Outbound - SDR Team" --emoji-slug "briefcase" --kind "tool"
+cargo-ai workspaceManagement folder create --name "AI Assistants" --emoji-slug "robot" --kind "agent"
 ```
 
 ## Get a folder
 
 ```bash
-cargo-ai workspace folder get <folder-uuid>
+cargo-ai workspaceManagement folder get <folder-uuid>
 ```
 
 ## Update a folder
 
 ```bash
-cargo-ai workspace folder update --uuid <folder-uuid> --name "Q1 2025 Campaigns"
-cargo-ai workspace folder update --uuid <folder-uuid> --emoji-slug "star"
-cargo-ai workspace folder update --uuid <folder-uuid> --parent-uuid <parent-folder-uuid>
+cargo-ai workspaceManagement folder update --uuid <folder-uuid> --name "Q1 2025 Campaigns"
+cargo-ai workspaceManagement folder update --uuid <folder-uuid> --emoji-slug "star"
+cargo-ai workspaceManagement folder update --uuid <folder-uuid> --parent-uuid <parent-folder-uuid>
 ```
 
 ## Remove a folder
 
 ```bash
 # Remove all resources from the folder first (via the Cargo app or by updating each resource)
-cargo-ai workspace folder remove <folder-uuid>
+cargo-ai workspaceManagement folder remove <folder-uuid>
 ```
 
 ## Find a folder UUID for assigning resources
 
 ```bash
 # 1. List folders to find the one you want
-cargo-ai workspace folder list
+cargo-ai workspaceManagement folder list
 # → Note the "uuid" for the target folder
 
 # 2. When creating or updating a play/tool/agent, pass the folder UUID

--- a/cargo-workspace-management/references/examples/reports.md
+++ b/cargo-workspace-management/references/examples/reports.md
@@ -1,6 +1,6 @@
 # Report examples
 
-`cargo-ai workspace report create` submits a report to **workspace management** — the Cargo team's official feedback channel for the CLI and its skills.
+`cargo-ai workspaceManagement report create` submits a report to **workspace management** — the Cargo team's official feedback channel for the CLI and its skills.
 
 **Always send a report when:**
 
@@ -15,7 +15,7 @@ Reports are how these skills and the CLI improve. **Do not give up silently — 
 ## Submit a report
 
 ```bash
-cargo-ai workspace report create \
+cargo-ai workspaceManagement report create \
   --title "<one-line summary of the problem>" \
   --description "<exact command, error, expected vs actual, relevant UUIDs>"
 ```
@@ -38,7 +38,7 @@ Always include, when relevant:
 ### CLI command fails with an unhelpful error
 
 ```bash
-cargo-ai workspace report create \
+cargo-ai workspaceManagement report create \
   --title "orchestration run create returns 'playNotCompatible' on a tool workflow" \
   --description "Ran: cargo-ai orchestration run create --workflow-uuid abc-123 --data '{\"domain\":\"acme.com\"}'. Got: {\"errorMessage\":\"playNotCompatible\"}. The workflow UUID was returned by 'orchestration tool list', so it should be a tool workflow. Skill consulted: cargo-orchestration/SKILL.md decision flowchart."
 ```
@@ -46,7 +46,7 @@ cargo-ai workspace report create \
 ### Filter syntax is unclear / silently returns empty
 
 ```bash
-cargo-ai workspace report create \
+cargo-ai workspaceManagement report create \
   --title "segment fetch returns 0 records despite UI showing matches" \
   --description "Ran: cargo-ai segmentation segment fetch --model-uuid <uuid> --filter '{\"conjonction\":\"and\",\"groups\":[{\"conjonction\":\"and\",\"conditions\":[{\"kind\":\"string\",\"columnSlug\":\"country\",\"operator\":\"is\",\"values\":[\"US\"]}]}]}'. Got 0 records. The same filter in the app UI shows 1,200 matches. Tried 'conjunction' and 'conjonction' spellings — both return 0."
 ```
@@ -54,7 +54,7 @@ cargo-ai workspace report create \
 ### Agent is struggling with the CLI after multiple retries
 
 ```bash
-cargo-ai workspace report create \
+cargo-ai workspaceManagement report create \
   --title "Agent unable to determine correct --action JSON for HubSpot company_create" \
   --description "Tried 4 variants of cargo-ai orchestration action execute --action '{\"kind\":\"connector\",\"integrationSlug\":\"hubspot\",\"actionSlug\":\"company_create\",\"config\":{}}' --data '{...}'. Each fails with a different validation error ('config.portalId required', then 'data.properties required', etc.). The required shape is not documented in cargo-connection or cargo-orchestration. Need a worked example or a schema reference."
 ```
@@ -62,7 +62,7 @@ cargo-ai workspace report create \
 ### Missing capability
 
 ```bash
-cargo-ai workspace report create \
+cargo-ai workspaceManagement report create \
   --title "No CLI command to bulk re-run failed records from a previous batch" \
   --description "Trying to re-run only the failed records from batch <uuid>. 'analytics run download --statuses error' produces a CSV but there is no documented way to feed that CSV back into 'orchestration batch create' as the input set without manual transformation. A '--from-failed-batch <uuid>' option (or equivalent) appears to be missing."
 ```
@@ -70,7 +70,7 @@ cargo-ai workspace report create \
 ### Documentation contradicts observed behavior
 
 ```bash
-cargo-ai workspace report create \
+cargo-ai workspaceManagement report create \
   --title "billing usage get-metrics --group-by workflow_uuid returns connector_uuid groupings" \
   --description "Ran: cargo-ai billing usage get-metrics --from 2025-01-01 --to 2025-01-31 --group-by workflow_uuid. Response groups results by connector_uuid instead of workflow_uuid. cargo-billing/SKILL.md says workflow_uuid is a valid --group-by value."
 ```

--- a/cargo-workspace-management/references/examples/tokens.md
+++ b/cargo-workspace-management/references/examples/tokens.md
@@ -5,7 +5,7 @@ Every token has a human-readable `name` and a `permissions` field. The CLI's `to
 ## List all tokens
 
 ```bash
-cargo-ai workspace token list
+cargo-ai workspaceManagement token list
 # → Each entry includes `uuid`, `name`, `permissions`, `userUuid`, `workspaceUuid`, `createdAt`, `deletedAt`
 # (the actual token value is not shown — it is only returned once, at creation)
 ```
@@ -15,7 +15,7 @@ cargo-ai workspace token list
 `--name` is required. Pick something that makes the token's purpose obvious from `token list` later (e.g. `"CI/CD pipeline"`, `"GitHub Actions — production"`, `"Local dev — alice"`).
 
 ```bash
-cargo-ai workspace token create --name "CI/CD pipeline"
+cargo-ai workspaceManagement token create --name "CI/CD pipeline"
 ```
 
 The response includes the `token` field — this is the only time the token value is shown. Store it immediately in a secrets manager.
@@ -26,19 +26,19 @@ The response includes the `token` field — this is the only time the token valu
 
 ```bash
 # 1. Create the new token first (give it a clear name)
-cargo-ai workspace token create --name "CI/CD pipeline (rotated 2026-01)"
+cargo-ai workspaceManagement token create --name "CI/CD pipeline (rotated 2026-01)"
 # → Save the new token value
 
 # 2. Update all systems using the old token to use the new value
 
 # 3. Remove the old token
-cargo-ai workspace token remove <old-token-uuid>
+cargo-ai workspaceManagement token remove <old-token-uuid>
 ```
 
 ## Remove a token
 
 ```bash
-cargo-ai workspace token remove <token-uuid>
+cargo-ai workspaceManagement token remove <token-uuid>
 ```
 
 ## Find which token is currently in use
@@ -46,5 +46,5 @@ cargo-ai workspace token remove <token-uuid>
 ```bash
 cargo-ai whoami
 # → The active token is the one used for authentication in the current session
-# Run `workspace token list` to see all tokens and their names
+# Run `workspaceManagement token list` to see all tokens and their names
 ```

--- a/cargo-workspace-management/references/examples/users.md
+++ b/cargo-workspace-management/references/examples/users.md
@@ -3,19 +3,19 @@
 ## List all workspace members
 
 ```bash
-cargo-ai workspace user list
+cargo-ai workspaceManagement user list
 ```
 
 ## Get the current user
 
 ```bash
-cargo-ai workspace user get-current
+cargo-ai workspaceManagement user get-current
 ```
 
 ## Find available roles before inviting
 
 ```bash
-cargo-ai workspace role list
+cargo-ai workspaceManagement role list
 # → Note the "slug" values for the roles you want to assign
 ```
 
@@ -23,10 +23,10 @@ cargo-ai workspace role list
 
 ```bash
 # 1. Get available roles
-cargo-ai workspace role list
+cargo-ai workspaceManagement role list
 
 # 2. Invite the user with their email and role
-cargo-ai workspace user create \
+cargo-ai workspaceManagement user create \
   --user-email newuser@example.com \
   --role-slug <role-slug>
 ```
@@ -34,13 +34,13 @@ cargo-ai workspace user create \
 ## Update a user's role
 
 ```bash
-cargo-ai workspace user update --user-uuid <uuid> --role-slug <new-role-slug>
+cargo-ai workspaceManagement user update --user-uuid <uuid> --role-slug <new-role-slug>
 ```
 
 ## Remove a user from the workspace
 
 ```bash
-cargo-ai workspace user remove --user-uuid <uuid>
+cargo-ai workspaceManagement user remove --user-uuid <uuid>
 ```
 
 ## Find the current user's details
@@ -56,10 +56,10 @@ List all users and their roles:
 
 ```bash
 # 1. List all users
-cargo-ai workspace user list
+cargo-ai workspaceManagement user list
 # → Note roleSlug for each user
 
 # 2. List all roles to map slugs to role names
-cargo-ai workspace role list
+cargo-ai workspaceManagement role list
 # → Cross-reference roleSlug values
 ```

--- a/cargo-workspace-management/references/response-shapes.md
+++ b/cargo-workspace-management/references/response-shapes.md
@@ -19,7 +19,7 @@ JSON response structures returned by Cargo CLI commands used in the `cargo-works
 }
 ```
 
-## cargo-ai workspace user list
+## cargo-ai workspaceManagement user list
 
 ```json
 {
@@ -38,7 +38,7 @@ JSON response structures returned by Cargo CLI commands used in the `cargo-works
 
 **Key fields:** `uuid`, `email`, `firstName`, `lastName`, `role.slug` (the assigned role).
 
-## cargo-ai workspace role list
+## cargo-ai workspaceManagement role list
 
 ```json
 {
@@ -55,7 +55,7 @@ JSON response structures returned by Cargo CLI commands used in the `cargo-works
 }
 ```
 
-## cargo-ai workspace token list
+## cargo-ai workspaceManagement token list
 
 ```json
 {
@@ -81,7 +81,7 @@ JSON response structures returned by Cargo CLI commands used in the `cargo-works
 - `permissions`: `null` means the token mirrors the permissions of its owning user (the user identified by `userUuid`) — its effective access is bounded by what that user can do. When non-null, it is an array of permission rules `{ effect, resources, actions }` that scope the token explicitly. CLI-created tokens are always `null`; explicitly scoped tokens are configured via the API or the Cargo app.
 - `deletedAt`: `null` for active tokens; an ISO timestamp once the token has been removed.
 
-## cargo-ai workspace token create
+## cargo-ai workspaceManagement token create
 
 ```json
 {
@@ -125,7 +125,7 @@ When a token has been explicitly scoped (via API or app), `permissions` is an ar
 
 When `permissions` is non-null, the rules are evaluated independently of the owning user — the token's access is exactly what the rules describe, regardless of what `userUuid` can do.
 
-## cargo-ai workspace folder list
+## cargo-ai workspaceManagement folder list
 
 ```json
 {
@@ -148,7 +148,7 @@ When `permissions` is non-null, the rules are evaluated independently of the own
 
 **Key fields:** `uuid`, `name`, `kind` (`play`, `tool`, `agent`, or `file`), `emojiSlug`, `parentUuid` (null for root folders).
 
-## cargo-ai workspace file list-columns
+## cargo-ai workspaceManagement file list-columns
 
 ```json
 {

--- a/cargo-workspace-management/references/troubleshooting.md
+++ b/cargo-workspace-management/references/troubleshooting.md
@@ -5,7 +5,7 @@ Common errors and recovery steps for `cargo-workspace-management` commands.
 > **If the table below does not resolve the issue, or you (user or agent) are stuck on any Cargo CLI command after ≥ 2 failed attempts, send a workspace management report:**
 >
 > ```bash
-> cargo-ai workspace report create \
+> cargo-ai workspaceManagement report create \
 >   --title "<one-line summary>" \
 >   --description "<command run, error message, what you expected, UUIDs involved>"
 > ```
@@ -25,7 +25,7 @@ Common errors and recovery steps for `cargo-workspace-management` commands.
 | Symptom | Cause | Fix |
 |---------|-------|-----|
 | `user create` fails with permission error | Token lacks admin access | Use a token belonging to a workspace admin |
-| `user create` fails with "role not found" | Wrong role UUID | Run `workspace role list` to get valid role UUIDs |
+| `user create` fails with "role not found" | Wrong role UUID | Run `workspaceManagement role list` to get valid role UUIDs |
 | `user remove` fails | Attempting to remove the last admin | Promote another user to admin before removing |
 | User can't log in after being created | Email invitation not accepted | Ask the user to check their email for the workspace invitation |
 
@@ -37,8 +37,8 @@ Common errors and recovery steps for `cargo-workspace-management` commands.
 | `token create` rejected with `error: unknown option '--from-user'` | Legacy flag — removed when tokens gained `name` and `permissions` | Drop `--from-user`; use `--name <name>` instead. CLI-created tokens already inherit the creating user's permissions (`permissions: null`) |
 | Lost the token value after creation | Token value only shown once | Remove the token and create a new one (with the same `--name`); store the new value securely |
 | `token remove` fails | Token is currently in use by active processes | Wait for processes to finish, or rotate to a new token first then remove the old one |
-| `Unauthorized` errors in CI/CD with a CLI-created token | Token mirrors the creating user's permissions; that user lost access (role downgraded, removed, etc.) | Verify the token still exists with `workspace token list`; check the role of the user in `userUuid` (`workspace user list`); restore the user's permissions, or recreate the token under a user with the access you need |
-| `Unauthorized` errors in CI/CD with an explicitly scoped token | `permissions` array is too narrow for the action being attempted | Inspect the token's `permissions` field via `workspace token list`; widen via the API/app, or replace with a `permissions: null` token created by a user that has the required access |
+| `Unauthorized` errors in CI/CD with a CLI-created token | Token mirrors the creating user's permissions; that user lost access (role downgraded, removed, etc.) | Verify the token still exists with `workspaceManagement token list`; check the role of the user in `userUuid` (`workspaceManagement user list`); restore the user's permissions, or recreate the token under a user with the access you need |
+| `Unauthorized` errors in CI/CD with an explicitly scoped token | `permissions` array is too narrow for the action being attempted | Inspect the token's `permissions` field via `workspaceManagement token list`; widen via the API/app, or replace with a `permissions: null` token created by a user that has the required access |
 | Two tokens look identical in `token list` | Both were created without a meaningful `--name` | Use `--name` consistently — the name is the only label distinguishing tokens in the listing |
 
 ## Folders
@@ -60,7 +60,7 @@ Common errors and recovery steps for `cargo-workspace-management` commands.
 Whenever the CLI is failing in a way none of the tables above explain, the syntax for a flag is unclear, the agent is looping on the same task, or a needed capability appears to be missing — escalate by submitting a workspace management report:
 
 ```bash
-cargo-ai workspace report create \
+cargo-ai workspaceManagement report create \
   --title "<short summary>" \
   --description "<exact command, errorMessage, expected vs actual, UUIDs>"
 ```

--- a/index.md
+++ b/index.md
@@ -36,7 +36,7 @@ All commands output JSON to stdout. Failed commands exit non-zero and return `{"
 Whenever the CLI is failing in a way the skill references and `--help` cannot resolve, the user or agent is repeatedly retrying the same command without progress, the syntax for a flag / JSON payload is unclear, or a needed capability seems missing — escalate by submitting a report to **workspace management**:
 
 ```bash
-cargo-ai workspace report create \
+cargo-ai workspaceManagement report create \
   --title "<one-line summary of the problem>" \
   --description "<exact command(s) tried, errorMessage, expected vs actual, UUIDs involved>"
 ```
@@ -248,9 +248,9 @@ See `cargo-ai/SKILL.md` for model and temperature guidance by use case.
 **Critical rules:**
 
 - Most commands require a token with **admin access**.
-- `workspace token create` requires `--name` (the legacy `--from-user` flag was removed). Pick a name that makes the token's purpose obvious in `token list` later.
+- `workspaceManagement token create` requires `--name` (the legacy `--from-user` flag was removed). Pick a name that makes the token's purpose obvious in `token list` later.
 - Token values are only shown **once** at creation — store immediately in a secrets manager (GitHub Secrets, AWS Secrets Manager, etc.).
-- **Always send a `workspace report create`** when the CLI errors, is being used incorrectly, or you (user or agent) are struggling to make progress on a CLI task — see the section at the top of this file and `cargo-workspace-management/references/examples/reports.md`.
+- **Always send a `workspaceManagement report create`** when the CLI errors, is being used incorrectly, or you (user or agent) are struggling to make progress on a CLI task — see the section at the top of this file and `cargo-workspace-management/references/examples/reports.md`.
 
 **References:** `cargo-workspace-management/SKILL.md`
 
@@ -286,8 +286,8 @@ Most `cargo-orchestration` operations require UUIDs from other skills. This tabl
 | `actionSlug`    | `connection integration get <slug>` (third-party) or `connection native-integration get` (built-in) | Node graph (`kind: "connector"` or `kind: "native"`) |
 | `releaseUuid`   | `orchestration batch get` → `.releaseUuid` | `orchestration release get`, `batch download`                           |
 | `batchUuid`     | `orchestration batch create`               | `batch get`, `batch download`, `run get-metrics --batch-uuid`           |
-| `folderUuid`    | `workspace folder list`                    | `play list --folder-uuid`, `tool list --folder-uuid`                    |
-| `roleSlug`      | `workspace role list`                      | `workspace user create --role-slug`                                     |
+| `folderUuid`    | `workspaceManagement folder list`                    | `play list --folder-uuid`, `tool list --folder-uuid`                    |
+| `roleSlug`      | `workspaceManagement role list`                      | `workspaceManagement user create --role-slug`                                     |
 
 **Standard discovery sequence** before running a workflow:
 
@@ -395,15 +395,15 @@ The workspace UUID is returned by `cargo-ai whoami` under `workspace.uuid`.
 **Skills needed:** `cargo-workspace-management`, `cargo-storage`, `cargo-connection`, `cargo-ai`
 
 ```
-1. workspace token create --name <label>   → create a dedicated, named API token
-2. workspace role list             → discover available roles
-3. workspace user create           → invite team members
+1. workspaceManagement token create --name <label>   → create a dedicated, named API token
+2. workspaceManagement role list             → discover available roles
+3. workspaceManagement user create           → invite team members
 4. storage model create            → create Companies and Contacts models
 5. storage column create           → add columns (name, domain, employee_count, etc.)
 6. storage relationship set        → link Contacts → Companies
 7. connection connector create     → connect enrichment and CRM integrations
 8. ai agent create                 → configure an AI agent for research or scoring
-9. workspace folder create         → organize plays and tools into folders
+9. workspaceManagement folder create         → organize plays and tools into folders
 ```
 
 ### 7. Export and analyze segment data
@@ -431,7 +431,7 @@ The workspace UUID is returned by `cargo-ai whoami` under `workspace.uuid`.
 | `run create` vs `batch create`     | `run create` only works with **tool** workflows. Using a play's `workflowUuid` returns `playNotCompatible`.                                                                                                                                   |
 | `--model-uuid` vs `--segment-uuid` | `segment fetch` and `segment download` require `--model-uuid`. Get it from `segment list` → `.modelUuid`.                                                                                                                                     |
 | DDL before SQL                     | Never guess table names. Always run `model get-ddl <uuid>` first. Table names look like `datasets_default.models_companies`.                                                                                                                  |
-| Token shown once                   | API token values are only returned at creation. Store immediately. `workspace token create` requires `--name` (no more `--from-user`).                                                                                                        |
+| Token shown once                   | API token values are only returned at creation. Store immediately. `workspaceManagement token create` requires `--name` (no more `--from-user`).                                                                                                        |
 | Invoice amounts in cents           | `subscription get-invoices` returns `amount` in cents. Divide by 100.                                                                                                                                                                         |
 | Plays vs tools                     | **Play** = reacts to data changes (segment-driven). **Tool** = triggered on demand (manual, API, cron).                                                                                                                                       |
 | Batch data kinds                   | Play workflows accept: `segment`, `change`, `filter`, `recordIds`. Tool workflows accept: `file`, `records`.                                                                                                                                  |


### PR DESCRIPTION
## Summary
Updated documentation across multiple files to clarify that folder management (creation, listing, updates) is handled by the `cargo-workspace-management` skill, not `cargo-ai`. This improves user guidance when working with agent and file folders.

## Key Changes
- **SKILL.md**: Added note directing users to `cargo-workspace-management` for workspace administration tasks (folders, users, API tokens, roles, reports)
- **SKILL.md**: Updated agent folder move example with reference to `cargo-workspace-management` for discovering folder UUIDs
- **SKILL.md**: Added dedicated section explaining that folder management lives in `cargo-workspace-management` skill
- **agents.md example**: Added clarification that folders are managed by `cargo-workspace-management` skill with link to its examples
- **files.md example**: Added clarification that folders are managed by `cargo-workspace-management` skill and noted folder kind filtering
- **troubleshooting.md**: Enhanced `folderNotFound` error messages to reference `cargo-workspace-management` skill and provide creation guidance with appropriate `--kind` flags (agent vs file)

## Notable Details
- Cross-references use relative paths to the `cargo-workspace-management` skill documentation
- Error messages now include actionable guidance (e.g., `cargo-ai workspace folder create --kind agent ...`)
- Folder kind distinctions are clarified where relevant (agent folders vs file folders)

https://claude.ai/code/session_01QVhCgGHZwWxGLQvSCqLEgg