### PR TITLE
Add documentation for keeping skills and CLI up to date

### DIFF
--- a/index.md
+++ b/index.md
@@ -31,6 +31,26 @@ Without a global install, prefix every command with `npx @cargo-ai/cli` instead 
 
 All commands output JSON to stdout. Failed commands exit non-zero and return `{"errorMessage": "..."}`.
 
+## Keeping skills and CLI up to date
+
+Both the skills repo and the CLI ship updates regularly. Re-run these to pull the latest:
+
+```bash
+# Update the skills (re-running the install pulls latest)
+npx skills add getcargohq/cargo-skills@latest
+
+# Update the CLI
+npm install -g @cargo-ai/cli@latest
+```
+
+If the user (or agent) asks to **always** stay on the latest version, run both commands at the start of the session before any other Cargo work. Agents may proactively offer to refresh when:
+
+- A documented command flag or response shape doesn't match what the CLI returns.
+- A `workspace report` confirms the issue is fixed in a newer release.
+- The user explicitly asks ("always keep cargo updated", "make sure I'm on latest", etc.).
+
+For Claude Code users who want this automatic, configure a `SessionStart` hook in `.claude/settings.json` that runs both update commands.
+
 ## When the CLI fails or you're stuck — send a workspace management report
 
 Whenever the CLI is failing in a way the skill references and `--help` cannot resolve, the user or agent is repeatedly retrying the same command without progress, the syntax for a flag / JSON payload is unclear, or a needed capability seems missing — escalate by submitting a report to **workspace management**:


### PR DESCRIPTION
## Summary
Added a new section to the documentation explaining how to keep both the skills repository and CLI updated, along with guidance on when agents should proactively refresh versions.

## Changes
- **New "Keeping skills and CLI up to date" section** with:
  - Commands to update both the skills repo and CLI to their latest versions
  - Guidance for when agents should proactively offer to refresh (mismatched documentation, confirmed fixes in newer releases, explicit user requests)
  - Instructions for Claude Code users to configure automatic updates via a `SessionStart` hook in `.claude/settings.json`

## Details
This documentation clarifies the update process for users and agents working with Cargo, helping prevent issues caused by version mismatches between the CLI and skills repository. It provides clear criteria for when version updates should be suggested and offers automation options for users who want to stay current automatically.

https://claude.ai/code/session_012WMFGva7D43Bny3iQogX7u