### PR TITLE
Update storage query docs to use `storage query execute` with slug-based table names

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -45,7 +45,7 @@ A conversation session between a user and an agent. Created with `ai chat create
 The intentional French spelling used as the key name in Cargo filter JSON objects. Always `"conjonction"`, never `"conjunction"`. A typo here silently returns no records — no error is thrown.
 
 **column**
-A typed field on a Cargo model. Each column has a `slug`, `type` (see **column type** below), `label`, and `kind` (see **column kind** below). Columns have no `uuid` — they are identified by `slug` within the model. Managed via `cargo-storage` (`storage column list|create|update|remove|reorder`). Column `slug` values are used in filter conditions and in system-of-record SQL queries.
+A typed field on a Cargo model. Each column has a `slug`, `type` (see **column type** below), `label`, and `kind` (see **column kind** below). Columns have no `uuid` — they are identified by `slug` within the model. Managed via `cargo-storage` (`storage column list|create|update|remove|reorder`). Column `slug` values are used in filter conditions and in `storage query execute` SQL queries.
 
 **column type**
 The data type of a model column. Stored as the `type` field on the column object. Set on `column create --type <value>` and returned as `type` in `column list` and `model list` responses.
@@ -95,7 +95,7 @@ The unit of consumption on Cargo. Workflows consume credits when they execute no
 A logical grouping of models in the Cargo workspace. Similar to a schema or folder. Models belong to datasets. Listed via `storage dataset list`.
 
 **DDL**
-Data Definition Language. In Cargo context, the result of `storage model get-ddl <uuid>` — contains the exact SQL table name and column definitions needed to query the system of record. Always run this before writing SQL.
+Data Definition Language. In Cargo context, the result of `storage model get-ddl <uuid>` — contains the warehouse-native SQL table name, column definitions, and SQL dialect (`language`). For `storage query execute`, the slug-based name `<datasetSlug>.<modelSlug>` is enough; run the DDL when you need column types, the SQL dialect, or the warehouse-native name (required by the legacy `system-of-record client fetch | download`).
 
 ---
 
@@ -164,7 +164,7 @@ A piece of information an agent stores from a conversation for future reference.
 A structured data table in the Cargo workspace — e.g. Companies, Contacts, Deals. Has columns, relationships, and an associated SQL table in the system of record. Not to be confused with a language model.
 
 **modelUuid**
-The UUID of a Cargo data model (table). Required for `segment fetch`, `segment download`, and as input to `model get-ddl` before SoR queries.
+The UUID of a Cargo data model (table). Required for `segment fetch`, `segment download`, and as input to `model get-ddl`. Note: `storage query execute` references models by their **slug** (`<datasetSlug>.<modelSlug>`), not their UUID.
 
 ---
 
@@ -256,7 +256,7 @@ See **intent signal**. In cargo recipes, signals are the basis for segment const
 The activity of finding companies or people matching ICP criteria. Cheapest at-scale options: `salesNavigator.searchLeads` (0.02 cred/record), `salesNavigator.searchAccounts` (0.05). For investor / funding / complex filters: `peopleDataLabs.queryCompanies` (3). For local SMBs: `serper.searchPlaces` (1).
 
 **system of record (SoR)**
-A connected data warehouse (BigQuery, Snowflake, etc.) that Cargo can query via SQL. Queried with `system-of-record client query`. Always requires a DDL lookup first to get the exact table name.
+A connected data warehouse (BigQuery, Snowflake, etc.) that Cargo can query via SQL. Queried with `cargo-ai storage query execute "<sql>"`, which references tables as `<datasetSlug>.<modelSlug>` (e.g. `default.companies`) and rewrites them to the underlying warehouse table under the hood — no DDL lookup is required. The legacy `system-of-record client fetch | download | get-documentation` commands still operate on the warehouse-native table name from the DDL.
 
 ---
 

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -95,7 +95,7 @@ The unit of consumption on Cargo. Workflows consume credits when they execute no
 A logical grouping of models in the Cargo workspace. Similar to a schema or folder. Models belong to datasets. Listed via `storage dataset list`.
 
 **DDL**
-Data Definition Language. In Cargo context, the result of `storage model get-ddl <uuid>` — contains the warehouse-native SQL table name, column definitions, and SQL dialect (`language`). For `storage query execute`, the slug-based name `<datasetSlug>.<modelSlug>` is enough; run the DDL when you need column types, the SQL dialect, or the warehouse-native name (required by the legacy `system-of-record client download`).
+Data Definition Language. In Cargo context, the result of `storage model get-ddl <uuid>` — contains the SQL table name, column definitions, and SQL dialect (`language`). Run when you need column types or the SQL dialect; `storage query execute` and `storage query download` reference tables by `<datasetSlug>.<modelSlug>` directly.
 
 ---
 
@@ -256,7 +256,7 @@ See **intent signal**. In cargo recipes, signals are the basis for segment const
 The activity of finding companies or people matching ICP criteria. Cheapest at-scale options: `salesNavigator.searchLeads` (0.02 cred/record), `salesNavigator.searchAccounts` (0.05). For investor / funding / complex filters: `peopleDataLabs.queryCompanies` (3). For local SMBs: `serper.searchPlaces` (1).
 
 **system of record (SoR)**
-A connected data warehouse (BigQuery, Snowflake, etc.) that Cargo can query via SQL. Queried with `cargo-ai storage query execute "<sql>"`, which references tables as `<datasetSlug>.<modelSlug>` (e.g. `default.companies`) and rewrites them to the underlying warehouse table under the hood — no DDL lookup is required. The legacy `system-of-record client download | get-documentation` commands still operate on the warehouse-native table name from the DDL.
+A connected data warehouse (BigQuery, Snowflake, etc.) that Cargo can query via SQL. Queried with `cargo-ai storage query execute "<sql>"` (or `storage query download "<sql>"` for full exports), which references tables as `<datasetSlug>.<modelSlug>` (e.g. `default.companies`). For SoR docs, use `cargo-ai system-of-record client get-documentation`.
 
 ---
 

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -95,7 +95,7 @@ The unit of consumption on Cargo. Workflows consume credits when they execute no
 A logical grouping of models in the Cargo workspace. Similar to a schema or folder. Models belong to datasets. Listed via `storage dataset list`.
 
 **DDL**
-Data Definition Language. In Cargo context, the result of `storage model get-ddl <uuid>` — contains the warehouse-native SQL table name, column definitions, and SQL dialect (`language`). For `storage query execute`, the slug-based name `<datasetSlug>.<modelSlug>` is enough; run the DDL when you need column types, the SQL dialect, or the warehouse-native name (required by the legacy `system-of-record client fetch | download`).
+Data Definition Language. In Cargo context, the result of `storage model get-ddl <uuid>` — contains the warehouse-native SQL table name, column definitions, and SQL dialect (`language`). For `storage query execute`, the slug-based name `<datasetSlug>.<modelSlug>` is enough; run the DDL when you need column types, the SQL dialect, or the warehouse-native name (required by the legacy `system-of-record client download`).
 
 ---
 
@@ -256,7 +256,7 @@ See **intent signal**. In cargo recipes, signals are the basis for segment const
 The activity of finding companies or people matching ICP criteria. Cheapest at-scale options: `salesNavigator.searchLeads` (0.02 cred/record), `salesNavigator.searchAccounts` (0.05). For investor / funding / complex filters: `peopleDataLabs.queryCompanies` (3). For local SMBs: `serper.searchPlaces` (1).
 
 **system of record (SoR)**
-A connected data warehouse (BigQuery, Snowflake, etc.) that Cargo can query via SQL. Queried with `cargo-ai storage query execute "<sql>"`, which references tables as `<datasetSlug>.<modelSlug>` (e.g. `default.companies`) and rewrites them to the underlying warehouse table under the hood — no DDL lookup is required. The legacy `system-of-record client fetch | download | get-documentation` commands still operate on the warehouse-native table name from the DDL.
+A connected data warehouse (BigQuery, Snowflake, etc.) that Cargo can query via SQL. Queried with `cargo-ai storage query execute "<sql>"`, which references tables as `<datasetSlug>.<modelSlug>` (e.g. `default.companies`) and rewrites them to the underlying warehouse table under the hood — no DDL lookup is required. The legacy `system-of-record client download | get-documentation` commands still operate on the warehouse-native table name from the DDL.
 
 ---
 

--- a/cargo-gtm/recipes/icp-discovery.md
+++ b/cargo-gtm/recipes/icp-discovery.md
@@ -1,6 +1,6 @@
 # Recipe — Surface ICP signals from Closed-Won vs Closed-Lost
 
-Use this skill when the user wants to **discover their real ICP from conversion data**, not from gut feel. The skill pulls Closed-Won and Closed-Lost segments from the system-of-record, enriches both with the same firmographic and tech signals, and surfaces the features that differ most between them. Output: a ranked list of "high-fit signals" the user can use to filter prospecting.
+Use this skill when the user wants to **discover their real ICP from conversion data**, not from gut feel. The skill pulls Closed-Won and Closed-Lost segments via `storage query execute`, enriches both with the same firmographic and tech signals, and surfaces the features that differ most between them. Output: a ranked list of "high-fit signals" the user can use to filter prospecting.
 
 **Trigger phrases:**
 - *"What does our ideal customer look like?"*
@@ -12,7 +12,7 @@ Use this skill when the user wants to **discover their real ICP from conversion 
 
 Most prospecting skills are forward-looking ("find me X" / "enrich Y"). ICP discovery is **backward-looking** — analyze what worked, then turn the patterns into filters. It exercises:
 
-- The system-of-record (`cargo-ai system-of-record client query`) to pull Won/Lost segments.
+- The system-of-record (`cargo-ai storage query execute`) to pull Won/Lost segments.
 - Cargo native enrichments (`enrichBusinessFirmographics`, `…Technographics`, `…FundingAndAcquisitions`) to fill comparison signals.
 - LLM analysis (`anthropic.instruct`) to surface non-obvious patterns.
 
@@ -23,35 +23,35 @@ Most prospecting skills are forward-looking ("find me X" / "enrich Y"). ICP disc
 ```bash
 # Find the model holding deals (usually a Deals or Opportunities model in the workspace)
 cargo-ai storage model list
+cargo-ai storage dataset list
 
-# Get its DDL — the SoR table name lives there
+# Optional — fetch the DDL for column types and SQL dialect
 cargo-ai storage model get-ddl <deals-model-uuid>
-# → Look for table name like datasets_default.models_deals
 ```
 
-Pull both segments via SoR:
+Pull both segments via `storage query execute` (tables are referenced as `<datasetSlug>.<modelSlug>` and rewritten to the warehouse table under the hood):
 
 ```bash
 # Closed-Won deals + their associated companies
-cargo-ai system-of-record client query "
+cargo-ai storage query execute "
   SELECT d.uuid as deal_uuid, c.uuid as company_uuid, c.domain, c.name
-  FROM datasets_default.models_deals d
-  JOIN datasets_default.models_companies c ON d.company_uuid = c.uuid
+  FROM default.deals d
+  JOIN default.companies c ON d.company_uuid = c.uuid
   WHERE d.stage = 'closed-won'
   AND d.closed_at >= CURRENT_DATE - INTERVAL '12 months'
 " > /tmp/won.json
 
 # Closed-Lost deals + their associated companies
-cargo-ai system-of-record client query "
+cargo-ai storage query execute "
   SELECT d.uuid as deal_uuid, c.uuid as company_uuid, c.domain, c.name
-  FROM datasets_default.models_deals d
-  JOIN datasets_default.models_companies c ON d.company_uuid = c.uuid
+  FROM default.deals d
+  JOIN default.companies c ON d.company_uuid = c.uuid
   WHERE d.stage = 'closed-lost'
   AND d.closed_at >= CURRENT_DATE - INTERVAL '12 months'
 " > /tmp/lost.json
 ```
 
-(Adjust the table names to match the user's DDL output. Adjust the stage filter to match the user's pipeline stage labels.)
+(Swap `default` for the user's dataset slug if it differs, and adjust the stage filter to match the user's pipeline stage labels.)
 
 ### Step 2 — Match each company to cargo
 
@@ -118,7 +118,7 @@ For deal sets > 100 records, do the diff in Python directly — LLM is more reli
 For each surfaced signal, validate by running it as a filter against the Won segment and checking hit rate:
 
 ```bash
-# Example: signal is "uses Snowflake" → query the SoR + cargo technographics
+# Example: signal is "uses Snowflake" → query storage + cargo technographics
 cargo-ai orchestration action execute \
   --action '{"kind":"connector","integrationSlug":"theirStack","actionSlug":"searchTechnologies","config":{}}' \
   --data '{"fields":{"keywords":"snowflake"},"limit":1}' \
@@ -186,4 +186,4 @@ Plus a follow-up suggestion: "Want me to run `/cargo-tam-build` with these signa
 
 ## When stuck — file a workspace report
 
-If the SoR query fails or the deal model schema is unfamiliar, file via `cargo-ai workspace report create`. See [`../../cargo-workspace-management/SKILL.md`](../../cargo-workspace-management/SKILL.md).
+If `storage query execute` fails or the deal model schema is unfamiliar, file via `cargo-ai workspace report create`. See [`../../cargo-workspace-management/SKILL.md`](../../cargo-workspace-management/SKILL.md).

--- a/cargo-orchestration/SKILL.md
+++ b/cargo-orchestration/SKILL.md
@@ -36,7 +36,7 @@ Need to run something?
 > `references/agents.md` — AI agent chat examples
 > `references/nodes.md` — full node creation guide (kinds, native actions, expressions, validation, routing)
 > `references/templates.md` — pre-built workflow templates
-> `references/queries.md` — system of record query examples
+> `references/queries.md` — `storage query execute` SQL examples
 > `references/segments.md` — segment fetch and filter examples
 > `references/response-shapes.md` — full JSON response structures
 > `references/filter-syntax.md` — complete filter condition reference
@@ -102,7 +102,7 @@ cargo-ai orchestration batch create --workflow-uuid <uuid> --data '{"kind":"segm
 cargo-ai ai message create --chat-uuid <uuid> --parts '[{"type":"text","text":"..."}]'
 
 # Data
-cargo-ai system-of-record client query "SELECT * FROM companies LIMIT 10"
+cargo-ai storage query execute "SELECT * FROM default.companies LIMIT 10"
 cargo-ai segmentation segment fetch --model-uuid <uuid> --filter '{"conjonction":"and","groups":[]}' --fetching-limit 100
 cargo-ai storage model get-ddl <model-uuid>
 ```
@@ -248,18 +248,15 @@ cargo-ai orchestration record cancel --workflow-uuid <uuid> --ids record-id-1,re
 
 ## Query the system of record
 
-Run SQL against your connected data warehouse. **Always get the DDL first** — it contains the exact table name and columns. Do not guess table names.
+Run SQL against your connected data warehouse with `storage query execute`. Tables are referenced as `<datasetSlug>.<modelSlug>` and rewritten to the underlying warehouse table under the hood — no DDL lookup needed for the table name.
 
 ```bash
-cargo-ai storage model get-ddl <model-uuid>
-# → Use the table name from DDL (e.g. datasets_default.models_companies)
-
-cargo-ai system-of-record client query \
-  "SELECT * FROM datasets_default.models_companies LIMIT 10"
-# → Check outcome: "queried" (success) or "notQueried" (error)
+cargo-ai storage query execute \
+  "SELECT name, domain FROM default.companies LIMIT 10"
+# → { "rows": [...] } on success; non-zero exit with { "errorMessage": "..." } on error
 ```
 
-Also supports `fetch` (paginated), `download` (full export), and `get-documentation` (plain text, not JSON). See `references/queries.md` for WHERE clauses, aggregations, joins, date queries, and pagination.
+Get column slugs from `storage column list --model-uuid <uuid>` (or run `storage model get-ddl <model-uuid>` for full schema). For paginated results, large exports, or SoR docs, use `cargo-ai system-of-record client fetch | download | get-documentation` (these still use the warehouse-native table name from the DDL — e.g. `datasets_default.models_companies`). See `references/queries.md` for WHERE clauses, aggregations, joins, date queries, and pagination.
 
 ## Fetch segment data
 

--- a/cargo-orchestration/SKILL.md
+++ b/cargo-orchestration/SKILL.md
@@ -256,7 +256,7 @@ cargo-ai storage query execute \
 # → { "rows": [...] } on success; non-zero exit with { "errorMessage": "..." } on error
 ```
 
-Get column slugs from `storage column list --model-uuid <uuid>` (or run `storage model get-ddl <model-uuid>` for full schema). For paginated results, large exports, or SoR docs, use `cargo-ai system-of-record client fetch | download | get-documentation` (these still use the warehouse-native table name from the DDL — e.g. `datasets_default.models_companies`). See `references/queries.md` for WHERE clauses, aggregations, joins, date queries, and pagination.
+Get column slugs from `storage column list --model-uuid <uuid>` (or run `storage model get-ddl <model-uuid>` for full schema). Page through large result sets with `LIMIT` / `OFFSET` directly in the SQL. For full exports, use `cargo-ai system-of-record client download`; for SoR docs, use `cargo-ai system-of-record client get-documentation` (both still use the warehouse-native table name from the DDL — e.g. `datasets_default.models_companies`). See `references/queries.md` for WHERE clauses, aggregations, joins, date queries, and pagination.
 
 ## Fetch segment data
 

--- a/cargo-orchestration/SKILL.md
+++ b/cargo-orchestration/SKILL.md
@@ -258,7 +258,7 @@ cargo-ai storage query execute \
 # → { "rows": [...] } on success; non-zero exit with { "errorMessage": "..." } on error
 ```
 
-Get column slugs from `storage column list --model-uuid <uuid>` (or run `storage model get-ddl <model-uuid>` for full schema). Page through large result sets with `LIMIT` / `OFFSET` directly in the SQL. For full exports, use `cargo-ai system-of-record client download`; for SoR docs, use `cargo-ai system-of-record client get-documentation` (both still use the warehouse-native table name from the DDL — e.g. `datasets_default.models_companies`). See `references/queries.md` for WHERE clauses, aggregations, joins, date queries, and pagination.
+Get column slugs from `storage column list --model-uuid <uuid>` (or run `storage model get-ddl <model-uuid>` for full schema). Page through large result sets with `LIMIT` / `OFFSET` directly in the SQL. For full exports, use `cargo-ai storage query download "<sql>"`. For SoR docs, use `cargo-ai system-of-record client get-documentation`. See `references/queries.md` for WHERE clauses, aggregations, joins, date queries, and pagination.
 
 ## Fetch segment data
 

--- a/cargo-orchestration/references/queries.md
+++ b/cargo-orchestration/references/queries.md
@@ -65,23 +65,18 @@ cargo-ai storage query execute \
   "SELECT country, SUM(revenue) as total_revenue, AVG(employee_count) as avg_employees FROM default.companies GROUP BY country"
 ```
 
-## Pagination with fetch
+## Pagination
 
-`storage query execute` returns the full result set in one call. For paginated results, use `system-of-record client fetch` with `--limit` and `--offset` (note: this command still expects the warehouse-native table name from the DDL, e.g. `datasets_default.models_companies`).
+Page through large result sets with SQL `LIMIT` and `OFFSET` clauses. Always include an `ORDER BY` so pages are stable across calls.
 
 ```bash
-# Get the warehouse table name from the DDL first
-cargo-ai storage model get-ddl <model-uuid>
-
 # First page
-cargo-ai system-of-record client fetch \
-  --query "SELECT * FROM datasets_default.models_companies ORDER BY name" \
-  --limit 100 --offset 0
+cargo-ai storage query execute \
+  "SELECT * FROM default.companies ORDER BY name LIMIT 100 OFFSET 0"
 
 # Second page
-cargo-ai system-of-record client fetch \
-  --query "SELECT * FROM datasets_default.models_companies ORDER BY name" \
-  --limit 100 --offset 100
+cargo-ai storage query execute \
+  "SELECT * FROM default.companies ORDER BY name LIMIT 100 OFFSET 100"
 ```
 
 ## Download full results

--- a/cargo-orchestration/references/queries.md
+++ b/cargo-orchestration/references/queries.md
@@ -1,40 +1,25 @@
-# System of record query examples
+# Storage query examples
 
-**Rule: always get the DDL first.** Do not guess table names or column names.
+Run SQL against your connected data warehouse with `cargo-ai storage query execute`. Tables are referenced as `<datasetSlug>.<modelSlug>` and rewritten to the underlying warehouse table under the hood. No DDL lookup is required for the table name — just use the dataset and model slugs.
 
-## Basic query flow (DDL first)
+For column slugs, run `cargo-ai storage column list --model-uuid <uuid>` or `cargo-ai storage model get-ddl <model-uuid>` (the DDL also shows column types and the SQL dialect).
 
-```bash
-# 1. List models to find the one you need
-cargo-ai storage model list
-# → Find model by name (e.g. "Companies"), extract uuid
-
-# 2. Get DDL — this gives you the exact table name and all columns
-cargo-ai storage model get-ddl <model-uuid>
-```
-
-DDL response:
-
-```json
-{
-  "ddl": "CREATE TABLE `project.datasets_default.models_companies` (\n  `_id` STRING,\n  `name` STRING,\n  `domain` STRING,\n  `employee_count` INT64\n);",
-  "language": "bigquery"
-}
-```
-
-Use `datasets_default.models_companies` as the table name.
+## Basic query flow
 
 ```bash
-# 3. Query using the table name from DDL
-cargo-ai system-of-record client query \
-  "SELECT name, domain, employee_count FROM datasets_default.models_companies LIMIT 10"
+# 1. Discover the dataset slug and the model slug
+cargo-ai storage dataset list   # → datasets[].slug (e.g. "default")
+cargo-ai storage model list     # → models[].slug   (e.g. "companies")
+
+# 2. Query using <datasetSlug>.<modelSlug> as the table name
+cargo-ai storage query execute \
+  "SELECT name, domain, employee_count FROM default.companies LIMIT 10"
 ```
 
 Success response:
 
 ```json
 {
-  "outcome": "queried",
   "rows": [
     { "name": "Acme Corp", "domain": "acme.com", "employee_count": 500 },
     { "name": "Globex", "domain": "globex.com", "employee_count": 1200 }
@@ -42,52 +27,52 @@ Success response:
 }
 ```
 
-Always check `outcome` first — `"notQueried"` means an error occurred (see the error handling section below).
+Failed commands exit non-zero with `{"errorMessage": "..."}` (or `{"reason": "clientNotFound"|"unknown"}`). See the error handling section below.
 
 ## Query with WHERE clauses
 
 ```bash
-# Get DDL first
-cargo-ai storage model get-ddl <model-uuid>
-
 # Filter by a column
-cargo-ai system-of-record client query \
-  "SELECT name, domain FROM datasets_default.models_companies WHERE employee_count > 100"
+cargo-ai storage query execute \
+  "SELECT name, domain FROM default.companies WHERE employee_count > 100"
 
 # Multiple conditions
-cargo-ai system-of-record client query \
-  "SELECT name, domain, revenue FROM datasets_default.models_companies WHERE employee_count > 100 AND country = 'US'"
+cargo-ai storage query execute \
+  "SELECT name, domain, revenue FROM default.companies WHERE employee_count > 100 AND country = 'US'"
 
 # LIKE for partial matches
-cargo-ai system-of-record client query \
-  "SELECT name, domain FROM datasets_default.models_companies WHERE name LIKE '%tech%'"
+cargo-ai storage query execute \
+  "SELECT name, domain FROM default.companies WHERE name LIKE '%tech%'"
 
 # NULL checks
-cargo-ai system-of-record client query \
-  "SELECT name, domain FROM datasets_default.models_companies WHERE email IS NOT NULL"
+cargo-ai storage query execute \
+  "SELECT name, domain FROM default.companies WHERE email IS NOT NULL"
 ```
 
 ## Aggregation queries
 
 ```bash
 # Count records
-cargo-ai system-of-record client query \
-  "SELECT COUNT(*) as total FROM datasets_default.models_companies"
+cargo-ai storage query execute \
+  "SELECT COUNT(*) as total FROM default.companies"
 
 # Group by with counts
-cargo-ai system-of-record client query \
-  "SELECT country, COUNT(*) as count FROM datasets_default.models_companies GROUP BY country ORDER BY count DESC"
+cargo-ai storage query execute \
+  "SELECT country, COUNT(*) as count FROM default.companies GROUP BY country ORDER BY count DESC"
 
 # Sum and average
-cargo-ai system-of-record client query \
-  "SELECT country, SUM(revenue) as total_revenue, AVG(employee_count) as avg_employees FROM datasets_default.models_companies GROUP BY country"
+cargo-ai storage query execute \
+  "SELECT country, SUM(revenue) as total_revenue, AVG(employee_count) as avg_employees FROM default.companies GROUP BY country"
 ```
 
 ## Pagination with fetch
 
-For large result sets, use `fetch` with `--limit` and `--offset`.
+`storage query execute` returns the full result set in one call. For paginated results, use `system-of-record client fetch` with `--limit` and `--offset` (note: this command still expects the warehouse-native table name from the DDL, e.g. `datasets_default.models_companies`).
 
 ```bash
+# Get the warehouse table name from the DDL first
+cargo-ai storage model get-ddl <model-uuid>
+
 # First page
 cargo-ai system-of-record client fetch \
   --query "SELECT * FROM datasets_default.models_companies ORDER BY name" \
@@ -101,30 +86,34 @@ cargo-ai system-of-record client fetch \
 
 ## Download full results
 
-For exporting to a file.
+For exporting to a file, use `system-of-record client download` (also expects the warehouse-native table name):
 
 ```bash
+cargo-ai storage model get-ddl <model-uuid>
+
 cargo-ai system-of-record client download \
   --query "SELECT name, domain, employee_count, revenue FROM datasets_default.models_companies ORDER BY revenue DESC"
 ```
 
 ## Query across multiple models
 
-Get the DDL for each model, then join.
+Just join on `<datasetSlug>.<modelSlug>` table references:
 
 ```bash
-# 1. Get DDL for both models
-cargo-ai storage model get-ddl <companies-model-uuid>
-cargo-ai storage model get-ddl <deals-model-uuid>
+cargo-ai storage query execute \
+  "SELECT c.name, c.domain, d.stage, d.amount FROM default.companies c JOIN default.deals d ON c._id = d.company_id WHERE d.amount > 10000"
+```
 
-# 2. Join query
-cargo-ai system-of-record client query \
-  "SELECT c.name, c.domain, d.stage, d.amount FROM datasets_default.models_companies c JOIN datasets_default.models_deals d ON c._id = d.company_id WHERE d.amount > 10000"
+## Common table expressions
+
+```bash
+cargo-ai storage query execute \
+  "WITH recent AS (SELECT * FROM default.companies WHERE created_at >= CURRENT_DATE - INTERVAL '30' DAY) SELECT count(*) FROM recent"
 ```
 
 ## Get SoR documentation
 
-Useful to understand available tables and conventions before querying.
+Useful to understand available tables and warehouse-specific SQL dialect conventions.
 
 ```bash
 # List all systems of record
@@ -138,31 +127,35 @@ cargo-ai system-of-record client get-documentation <slug>
 
 ```bash
 # Records created in the last 30 days
-cargo-ai system-of-record client query \
-  "SELECT name, created_at FROM datasets_default.models_companies WHERE created_at >= DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY)"
+cargo-ai storage query execute \
+  "SELECT name, created_at FROM default.companies WHERE created_at >= DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY)"
 
 # Records in a specific range
-cargo-ai system-of-record client query \
-  "SELECT name, created_at FROM datasets_default.models_companies WHERE created_at BETWEEN '2025-01-01' AND '2025-03-31'"
+cargo-ai storage query execute \
+  "SELECT name, created_at FROM default.companies WHERE created_at BETWEEN '2025-01-01' AND '2025-03-31'"
 ```
 
 ## Subqueries
 
 ```bash
 # Companies with above-average employee count
-cargo-ai system-of-record client query \
-  "SELECT name, employee_count FROM datasets_default.models_companies WHERE employee_count > (SELECT AVG(employee_count) FROM datasets_default.models_companies)"
+cargo-ai storage query execute \
+  "SELECT name, employee_count FROM default.companies WHERE employee_count > (SELECT AVG(employee_count) FROM default.companies)"
 ```
 
 ## Error handling
 
-If a query fails, the response has `outcome: "notQueried"`:
+If a query fails, the command exits non-zero. Failure shapes:
 
 ```json
-{ "outcome": "notQueried", "errorMessage": "Table not found: datasets_default.models_nonexistent" }
+{ "errorMessage": "Table not found: default.nonexistent" }
+```
+
+```json
+{ "reason": "clientNotFound" }
 ```
 
 Common causes:
-- Wrong table name → re-check DDL output
-- Syntax error → check SQL syntax for your warehouse dialect (BigQuery vs Snowflake)
-- Permission error → verify SoR connection is active
+- Wrong dataset or model slug → re-check with `storage dataset list` and `storage model list`
+- Syntax error → check SQL syntax for your warehouse dialect (BigQuery vs Snowflake) — `storage model get-ddl` reports `language`
+- `clientNotFound` → no SoR client is configured for this workspace; verify with `system-of-record sor list`

--- a/cargo-orchestration/references/queries.md
+++ b/cargo-orchestration/references/queries.md
@@ -81,13 +81,11 @@ cargo-ai storage query execute \
 
 ## Download full results
 
-For exporting to a file, use `system-of-record client download` (also expects the warehouse-native table name):
+For exporting full result sets to a file, use `storage query download`:
 
 ```bash
-cargo-ai storage model get-ddl <model-uuid>
-
-cargo-ai system-of-record client download \
-  --query "SELECT name, domain, employee_count, revenue FROM datasets_default.models_companies ORDER BY revenue DESC"
+cargo-ai storage query download \
+  "SELECT name, domain, employee_count, revenue FROM default.companies ORDER BY revenue DESC"
 ```
 
 ## Query across multiple models

--- a/cargo-orchestration/references/response-shapes.md
+++ b/cargo-orchestration/references/response-shapes.md
@@ -387,9 +387,38 @@ Poll until `status` is `success`, `error`, or `cancelled`. Note: `batch get` als
 
 The table name in the DDL follows the pattern `datasets_{datasetSlug}.models_{modelSlug}` (or `datasets_{datasetSlug}__models_{modelSlug}` in BigQuery dataset-scoped). Use this name in SoR queries.
 
-## cargo-ai system-of-record client query / fetch
+## cargo-ai storage query execute
 
-Returns a discriminated union — always check `outcome` first:
+Tables are referenced as `<datasetSlug>.<modelSlug>` and rewritten to the underlying warehouse table under the hood.
+
+**Success:**
+
+```json
+{
+  "rows": [
+    { "name": "Acme Corp", "domain": "acme.com", "employee_count": 500 },
+    { "name": "Globex", "domain": "globex.com", "employee_count": 1200 }
+  ]
+}
+```
+
+**Failure (non-zero exit):**
+
+```json
+{ "errorMessage": "Table not found: default.nonexistent" }
+```
+
+```json
+{ "reason": "clientNotFound" }
+```
+
+```json
+{ "reason": "unknown" }
+```
+
+## cargo-ai system-of-record client fetch
+
+Used for paginated reads. Returns the legacy discriminated union — always check `outcome` first:
 
 **Success:**
 
@@ -397,8 +426,7 @@ Returns a discriminated union — always check `outcome` first:
 {
   "outcome": "queried",
   "rows": [
-    { "name": "Acme Corp", "domain": "acme.com", "employee_count": 500 },
-    { "name": "Globex", "domain": "globex.com", "employee_count": 1200 }
+    { "name": "Acme Corp", "domain": "acme.com", "employee_count": 500 }
   ]
 }
 ```
@@ -412,7 +440,7 @@ Returns a discriminated union — always check `outcome` first:
 }
 ```
 
-Always check `outcome === "queried"` before reading `rows`. On `"notQueried"`, read `errorMessage` for the SQL error.
+`fetch` and `download` still expect the warehouse-native table name from the DDL (e.g. `datasets_default.models_companies`).
 
 ## cargo-ai system-of-record client get-documentation
 

--- a/cargo-orchestration/references/response-shapes.md
+++ b/cargo-orchestration/references/response-shapes.md
@@ -416,9 +416,9 @@ Tables are referenced as `<datasetSlug>.<modelSlug>` and rewritten to the underl
 { "reason": "unknown" }
 ```
 
-## cargo-ai system-of-record client fetch
+## cargo-ai system-of-record client download
 
-Used for paginated reads. Returns the legacy discriminated union — always check `outcome` first:
+Used for full exports. Returns the legacy discriminated union — always check `outcome` first:
 
 **Success:**
 
@@ -440,7 +440,7 @@ Used for paginated reads. Returns the legacy discriminated union — always chec
 }
 ```
 
-`fetch` and `download` still expect the warehouse-native table name from the DDL (e.g. `datasets_default.models_companies`).
+`download` still expects the warehouse-native table name from the DDL (e.g. `datasets_default.models_companies`).
 
 ## cargo-ai system-of-record client get-documentation
 

--- a/cargo-orchestration/references/response-shapes.md
+++ b/cargo-orchestration/references/response-shapes.md
@@ -416,31 +416,25 @@ Tables are referenced as `<datasetSlug>.<modelSlug>` and rewritten to the underl
 { "reason": "unknown" }
 ```
 
-## cargo-ai system-of-record client download
+## cargo-ai storage query download
 
-Used for full exports. Returns the legacy discriminated union — always check `outcome` first:
+Used for full exports. Same table-naming convention as `storage query execute` (`<datasetSlug>.<modelSlug>`).
 
 **Success:**
 
 ```json
 {
-  "outcome": "queried",
   "rows": [
     { "name": "Acme Corp", "domain": "acme.com", "employee_count": 500 }
   ]
 }
 ```
 
-**Failure:**
+**Failure (non-zero exit):**
 
 ```json
-{
-  "outcome": "notQueried",
-  "errorMessage": "Table not found: datasets_default.models_nonexistent"
-}
+{ "errorMessage": "Table not found: default.nonexistent" }
 ```
-
-`download` still expects the warehouse-native table name from the DDL (e.g. `datasets_default.models_companies`).
 
 ## cargo-ai system-of-record client get-documentation
 

--- a/cargo-orchestration/references/troubleshooting.md
+++ b/cargo-orchestration/references/troubleshooting.md
@@ -32,14 +32,15 @@ Common errors and recovery steps for `cargo-orchestration` commands.
 | `Chat not found`                                                     | Wrong UUID or chat was deleted           | Re-create with `chat create`                                               |
 | `Agent not found`                                                    | Wrong UUID                               | Re-run `agent list` to get current UUIDs                                   |
 
-## System of record queries
+## Storage queries (`storage query execute`)
 
-| Symptom                                        | Cause                                  | Fix                                                                               |
-| ---------------------------------------------- | -------------------------------------- | --------------------------------------------------------------------------------- |
-| `outcome: "notQueried"` with "Table not found" | Wrong table name                       | Re-run `storage model get-ddl <uuid>` and use the exact table name from the DDL   |
-| `outcome: "notQueried"` with syntax error      | SQL dialect mismatch                   | Check whether your SoR is BigQuery, Snowflake, etc. and adjust syntax accordingly |
-| `outcome: "notQueried"` with permission error  | SoR connection issue                   | Verify the connection is active in Cargo; try `sor list` to check status          |
-| Query returns empty rows                       | Filter too restrictive, or wrong table | Verify table name with DDL; try a broader query first (`SELECT * ... LIMIT 5`)    |
+| Symptom                                                   | Cause                                  | Fix                                                                                                |
+| --------------------------------------------------------- | -------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `errorMessage` with "Table not found"                     | Wrong dataset or model slug            | Verify with `storage dataset list` and `storage model list`. Tables are `<datasetSlug>.<modelSlug>` |
+| `errorMessage` with syntax error                          | SQL dialect mismatch                   | Check whether your SoR is BigQuery, Snowflake, etc. and adjust syntax accordingly                  |
+| `reason: "clientNotFound"`                                | No SoR client configured               | Verify the connection is active; try `system-of-record sor list` to check status                   |
+| Query returns empty `rows`                                | Filter too restrictive, or wrong model | Try a broader query first (`SELECT * FROM <dataset>.<model> LIMIT 5`)                              |
+| Column not found                                          | Wrong column slug                      | Run `storage column list --model-uuid <uuid>` to get exact slugs                                   |
 
 ## Debugging a workflow run
 
@@ -126,7 +127,7 @@ When a run reaches `status: "error"`, follow this sequence:
 | Agent `maxSteps` exceeded | Agent ran too many tool calls | Increase `--max-steps` on the message, or simplify the agent's task |
 | `filter` node stopped execution | Record didn't meet the filter condition | This is expected behavior, not an error — adjust the filter if needed |
 | Null reference in expression | Upstream node returned empty/null | Add a `filter` node before the failing node to skip records with missing data |
-| `outcome: "notQueried"` on SoR | Wrong table name or SQL syntax error | Re-run `model get-ddl <uuid>` and use the exact table name |
+| `errorMessage` on `storage query execute` | Wrong dataset/model slug or SQL syntax error | Verify slugs with `storage dataset list` / `storage model list`; check warehouse dialect (BigQuery vs Snowflake) |
 
 4. **Re-trigger after fixing:** Create a new run with the corrected data or node config.
 5. **For systematic failures:** Use `run download --statuses error` to export all failed records, fix the data, then re-batch with `batch create --data '{"kind":"recordIds",...}'`.

--- a/cargo-storage/SKILL.md
+++ b/cargo-storage/SKILL.md
@@ -68,9 +68,9 @@ cargo-ai storage model list --dataset-uuid <uuid>
 # Get a single model (includes columns)
 cargo-ai storage model get <model-uuid>
 
-# Get the DDL (exact table name and columns for SQL queries)
+# Get the DDL (full schema, table name and SQL dialect)
 cargo-ai storage model get-ddl <model-uuid>
-# → Always do this before running system-of-record queries — the table name is in the DDL
+# → Useful for column discovery and SQL dialect (BigQuery vs Snowflake) before writing queries
 
 # Create a model
 cargo-ai storage model create \
@@ -87,7 +87,7 @@ cargo-ai storage model update --uuid <model-uuid> --name "New Name"
 cargo-ai storage model remove <model-uuid>
 ```
 
-**Important:** When querying a model via the system of record, always get the DDL first to find the exact table name (e.g. `datasets_default.models_companies`). Do not guess table names. See the `cargo-orchestration` skill for system-of-record query examples.
+**Querying:** Use `cargo-ai storage query execute "<sql>"` to run SQL against your warehouse. Tables are referenced as `<datasetSlug>.<modelSlug>` (e.g. `default.companies`) and rewritten to the underlying warehouse table under the hood — no DDL lookup is needed for the table name. Run `model get-ddl` for column types and SQL dialect when writing more involved queries. See the `cargo-orchestration` skill for query examples.
 
 ## Datasets
 

--- a/cargo-storage/SKILL.md
+++ b/cargo-storage/SKILL.md
@@ -89,7 +89,7 @@ cargo-ai storage model update --uuid <model-uuid> --name "New Name"
 cargo-ai storage model remove <model-uuid>
 ```
 
-**Querying:** Use `cargo-ai storage query execute "<sql>"` to run SQL against your warehouse. Tables are referenced as `<datasetSlug>.<modelSlug>` (e.g. `default.companies`) and rewritten to the underlying warehouse table under the hood — no DDL lookup is needed for the table name. Run `model get-ddl` for column types and SQL dialect when writing more involved queries. See the `cargo-orchestration` skill for query examples.
+**Querying:** Use `cargo-ai storage query execute "<sql>"` to query storage. Tables are referenced as `<datasetSlug>.<modelSlug>` (e.g. `default.companies`). Run `model get-ddl` for column types and SQL dialect when writing more involved queries. See the `cargo-orchestration` skill for query examples.
 
 ## Datasets
 

--- a/cargo-storage/references/examples/columns.md
+++ b/cargo-storage/references/examples/columns.md
@@ -134,4 +134,4 @@ cargo-ai storage column reorder --model-uuid <uuid> --column-slug website_url --
 | `metric`   | Aggregated values from a related model                      | `relationshipUuid`, `aggregation.function`, `aggregation.columnSlug`; optionally `filter`                |
 | `lookup`   | A single field value pulled from a related model via a join | `join.toModelUuid`, `join.fromColumnSlug`, `join.toColumnSlug`, `extractColumnSlug`; optionally `filter` |
 
-Column `slug` values are used in filter conditions (see `cargo-orchestration` skill's `references/filter-syntax.md`) and in system-of-record SQL queries.
+Column `slug` values are used in filter conditions (see `cargo-orchestration` skill's `references/filter-syntax.md`) and in `storage query execute` SQL queries.

--- a/cargo-storage/references/examples/models.md
+++ b/cargo-storage/references/examples/models.md
@@ -25,7 +25,7 @@ cargo-ai storage model get <model-uuid>
 
 ## Get the DDL (column types and SQL dialect)
 
-`storage query execute` rewrites `<datasetSlug>.<modelSlug>` (e.g. `default.companies`) to the underlying warehouse table, so you don't need the DDL just for the table name. Run `model get-ddl` when you need column types or the SQL dialect.
+`storage query execute` accepts `<datasetSlug>.<modelSlug>` (e.g. `default.companies`) as the table name, so you don't need the DDL just for the table name. Run `model get-ddl` when you need column types or the SQL dialect.
 
 ```bash
 cargo-ai storage model get-ddl <model-uuid>
@@ -39,7 +39,7 @@ Example response:
 }
 ```
 
-The `language` field tells you which SQL dialect to use. `storage query execute` accepts the slug-based name (`<datasetSlug>.<modelSlug>`) directly — you don't need to extract the warehouse-native name from the DDL.
+The `language` field tells you which SQL dialect to use.
 
 ## Create a model
 

--- a/cargo-storage/references/examples/models.md
+++ b/cargo-storage/references/examples/models.md
@@ -25,7 +25,7 @@ cargo-ai storage model get <model-uuid>
 
 ## Get the DDL (column types and SQL dialect)
 
-`storage query execute` rewrites `<datasetSlug>.<modelSlug>` (e.g. `default.companies`) to the underlying warehouse table, so you don't need the DDL just for the table name. Run `model get-ddl` when you need column types, the SQL dialect, or the warehouse-native table name (the latter is required by the legacy `system-of-record client fetch | download` commands).
+`storage query execute` rewrites `<datasetSlug>.<modelSlug>` (e.g. `default.companies`) to the underlying warehouse table, so you don't need the DDL just for the table name. Run `model get-ddl` when you need column types, the SQL dialect, or the warehouse-native table name (the latter is required by the legacy `system-of-record client download` command).
 
 ```bash
 cargo-ai storage model get-ddl <model-uuid>
@@ -39,7 +39,7 @@ Example response:
 }
 ```
 
-The `language` field tells you which SQL dialect to use. The warehouse-native name (`datasets_default.models_companies`) is needed only for `system-of-record client fetch | download`; `storage query execute` accepts the slug-based name directly.
+The `language` field tells you which SQL dialect to use. The warehouse-native name (`datasets_default.models_companies`) is needed only for `system-of-record client download`; `storage query execute` accepts the slug-based name directly.
 
 ## Create a model
 

--- a/cargo-storage/references/examples/models.md
+++ b/cargo-storage/references/examples/models.md
@@ -23,9 +23,9 @@ cargo-ai storage model get <model-uuid>
 # → Returns the model with all columns, their types and slugs
 ```
 
-## Get the DDL (for SQL queries)
+## Get the DDL (column types and SQL dialect)
 
-Always get the DDL before writing system-of-record queries — it contains the exact table name.
+`storage query execute` rewrites `<datasetSlug>.<modelSlug>` (e.g. `default.companies`) to the underlying warehouse table, so you don't need the DDL just for the table name. Run `model get-ddl` when you need column types, the SQL dialect, or the warehouse-native table name (the latter is required by the legacy `system-of-record client fetch | download` commands).
 
 ```bash
 cargo-ai storage model get-ddl <model-uuid>
@@ -39,7 +39,7 @@ Example response:
 }
 ```
 
-Extract the table name from the `ddl` field: `datasets_default.models_companies`.
+The `language` field tells you which SQL dialect to use. The warehouse-native name (`datasets_default.models_companies`) is needed only for `system-of-record client fetch | download`; `storage query execute` accepts the slug-based name directly.
 
 ## Create a model
 
@@ -75,16 +75,15 @@ Note: This will fail if the model is referenced by segments, plays, or tools. Re
 Full flow to understand a model before querying it:
 
 ```bash
-# 1. Find the model
+# 1. Find the model and its dataset slug
 cargo-ai storage model list
+cargo-ai storage dataset list
 
-# 2. Get the full schema with column types
+# 2. Get the full schema with column types (optional — also returns SQL dialect)
 cargo-ai storage model get <model-uuid>
-
-# 3. Get the exact table name for SQL
 cargo-ai storage model get-ddl <model-uuid>
 
-# 4. Now you can write a system-of-record query using the exact table name and column slugs
-cargo-ai system-of-record client query \
-  "SELECT uuid, name, domain FROM datasets_default.models_companies LIMIT 10"
+# 3. Query using <datasetSlug>.<modelSlug> as the table name
+cargo-ai storage query execute \
+  "SELECT uuid, name, domain FROM default.companies LIMIT 10"
 ```

--- a/cargo-storage/references/examples/models.md
+++ b/cargo-storage/references/examples/models.md
@@ -25,7 +25,7 @@ cargo-ai storage model get <model-uuid>
 
 ## Get the DDL (column types and SQL dialect)
 
-`storage query execute` rewrites `<datasetSlug>.<modelSlug>` (e.g. `default.companies`) to the underlying warehouse table, so you don't need the DDL just for the table name. Run `model get-ddl` when you need column types, the SQL dialect, or the warehouse-native table name (the latter is required by the legacy `system-of-record client download` command).
+`storage query execute` rewrites `<datasetSlug>.<modelSlug>` (e.g. `default.companies`) to the underlying warehouse table, so you don't need the DDL just for the table name. Run `model get-ddl` when you need column types or the SQL dialect.
 
 ```bash
 cargo-ai storage model get-ddl <model-uuid>
@@ -39,7 +39,7 @@ Example response:
 }
 ```
 
-The `language` field tells you which SQL dialect to use. The warehouse-native name (`datasets_default.models_companies`) is needed only for `system-of-record client download`; `storage query execute` accepts the slug-based name directly.
+The `language` field tells you which SQL dialect to use. `storage query execute` accepts the slug-based name (`<datasetSlug>.<modelSlug>`) directly — you don't need to extract the warehouse-native name from the DDL.
 
 ## Create a model
 

--- a/cargo-storage/references/response-shapes.md
+++ b/cargo-storage/references/response-shapes.md
@@ -72,9 +72,9 @@ Same structure as a single item from `model list`, nested under `model`:
 }
 ```
 
-**Key fields:** `ddl` (contains the exact table name and column names), `language` (SQL dialect).
+**Key fields:** `ddl` (contains the warehouse-native table name and column names), `language` (SQL dialect).
 
-Always extract the table name from `ddl` before writing system-of-record queries. The table name pattern is typically `datasets_<dataset-slug>.models_<model-slug>`.
+For `cargo-ai storage query execute`, reference tables as `<datasetSlug>.<modelSlug>` (e.g. `default.companies`) — the slug form is rewritten to the underlying warehouse table. The warehouse-native name from `ddl` (typically `datasets_<dataset-slug>.models_<model-slug>`) is only needed for the legacy `system-of-record client fetch | download` commands.
 
 ## cargo-ai storage dataset list
 

--- a/cargo-storage/references/response-shapes.md
+++ b/cargo-storage/references/response-shapes.md
@@ -74,7 +74,7 @@ Same structure as a single item from `model list`, nested under `model`:
 
 **Key fields:** `ddl` (contains the warehouse-native table name and column names), `language` (SQL dialect).
 
-For `cargo-ai storage query execute`, reference tables as `<datasetSlug>.<modelSlug>` (e.g. `default.companies`) — the slug form is rewritten to the underlying warehouse table. The warehouse-native name from `ddl` (typically `datasets_<dataset-slug>.models_<model-slug>`) is only needed for the legacy `system-of-record client fetch | download` commands.
+For `cargo-ai storage query execute`, reference tables as `<datasetSlug>.<modelSlug>` (e.g. `default.companies`) — the slug form is rewritten to the underlying warehouse table. The warehouse-native name from `ddl` (typically `datasets_<dataset-slug>.models_<model-slug>`) is only needed for the legacy `system-of-record client download` command.
 
 ## cargo-ai storage dataset list
 

--- a/cargo-storage/references/response-shapes.md
+++ b/cargo-storage/references/response-shapes.md
@@ -74,7 +74,7 @@ Same structure as a single item from `model list`, nested under `model`:
 
 **Key fields:** `ddl` (contains the warehouse-native table name and column names), `language` (SQL dialect).
 
-For `cargo-ai storage query execute`, reference tables as `<datasetSlug>.<modelSlug>` (e.g. `default.companies`) — the slug form is rewritten to the underlying warehouse table.
+For `cargo-ai storage query execute`, reference tables as `<datasetSlug>.<modelSlug>` (e.g. `default.companies`).
 
 ## cargo-ai storage dataset list
 

--- a/cargo-storage/references/response-shapes.md
+++ b/cargo-storage/references/response-shapes.md
@@ -74,7 +74,7 @@ Same structure as a single item from `model list`, nested under `model`:
 
 **Key fields:** `ddl` (contains the warehouse-native table name and column names), `language` (SQL dialect).
 
-For `cargo-ai storage query execute`, reference tables as `<datasetSlug>.<modelSlug>` (e.g. `default.companies`) — the slug form is rewritten to the underlying warehouse table. The warehouse-native name from `ddl` (typically `datasets_<dataset-slug>.models_<model-slug>`) is only needed for the legacy `system-of-record client download` command.
+For `cargo-ai storage query execute`, reference tables as `<datasetSlug>.<modelSlug>` (e.g. `default.companies`) — the slug form is rewritten to the underlying warehouse table.
 
 ## cargo-ai storage dataset list
 

--- a/cargo-storage/references/troubleshooting.md
+++ b/cargo-storage/references/troubleshooting.md
@@ -16,7 +16,7 @@ Common errors and recovery steps for `cargo-storage` commands.
 |---------|-------|-----|
 | `model get` returns not found | Wrong UUID | Re-run `model list` to get the correct UUID |
 | `model get-ddl` returns empty DDL | Model has no sync connection to the warehouse | Confirm the model has an extractor configured and has synced at least once |
-| Table not found when querying SoR | Using the model name instead of the DDL table name | Always use `model get-ddl` to get the exact table name before querying |
+| Table not found in `storage query execute` | Wrong dataset or model slug | Verify with `dataset list` and `model list`; tables are referenced as `<datasetSlug>.<modelSlug>` |
 | `model remove` returns an error | Model is referenced by segments, plays, or tools | Remove or update the dependent resources before deleting the model |
 
 ## Columns

--- a/index.md
+++ b/index.md
@@ -230,7 +230,7 @@ Load for a specific CLI domain.
 
 **Critical rules:**
 
-- Query via `cargo-ai storage query execute "<sql>"` using `<datasetSlug>.<modelSlug>` table names (e.g. `default.companies`). `model get-ddl` is optional — useful for column types and SQL dialect, and required only for the legacy `system-of-record client download` commands.
+- Query via `cargo-ai storage query execute "<sql>"` (or `storage query download "<sql>"` for full exports) using `<datasetSlug>.<modelSlug>` table names (e.g. `default.companies`). `model get-ddl` is optional — useful for column types and SQL dialect.
 - For advanced record queries (filtering, sorting, pagination), use `segmentation segment fetch` from `cargo-orchestration`.
 
 **References:** `cargo-storage/SKILL.md`
@@ -452,7 +452,7 @@ The workspace UUID is returned by `cargo-ai whoami` under `workspace.uuid`.
 | `conjonction` spelling             | Filter JSON uses `conjonction` (not `conjunction`). This is intentional. A typo here fails silently — no records returned.                                                                                                                    |
 | `run create` vs `batch create`     | `run create` only works with **tool** workflows. Using a play's `workflowUuid` returns `playNotCompatible`.                                                                                                                                   |
 | `--model-uuid` vs `--segment-uuid` | `segment fetch` and `segment download` require `--model-uuid`. Get it from `segment list` → `.modelUuid`.                                                                                                                                     |
-| Storage query table names          | `storage query execute` references tables as `<datasetSlug>.<modelSlug>` (e.g. `default.companies`) — they're rewritten under the hood. The DDL form `datasets_default.models_companies` is only needed by `system-of-record client download`.                  |
+| Storage query table names          | `storage query execute` and `storage query download` reference tables as `<datasetSlug>.<modelSlug>` (e.g. `default.companies`).                                                                                                              |
 | Token shown once                   | API token values are only returned at creation. Store immediately. `workspaceManagement token create` requires `--name` (no more `--from-user`).                                                                                                        |
 | Invoice amounts in cents           | `subscription get-invoices` returns `amount` in cents. Divide by 100.                                                                                                                                                                         |
 | Plays vs tools                     | **Play** = reacts to data changes (segment-driven). **Tool** = triggered on demand (manual, API, cron).                                                                                                                                       |

--- a/index.md
+++ b/index.md
@@ -209,7 +209,7 @@ Load for a specific CLI domain.
 
 **Critical rules:**
 
-- Query via `cargo-ai storage query execute "<sql>"` using `<datasetSlug>.<modelSlug>` table names (e.g. `default.companies`). `model get-ddl` is optional — useful for column types and SQL dialect, and required only for the legacy `system-of-record client fetch | download` commands.
+- Query via `cargo-ai storage query execute "<sql>"` using `<datasetSlug>.<modelSlug>` table names (e.g. `default.companies`). `model get-ddl` is optional — useful for column types and SQL dialect, and required only for the legacy `system-of-record client download` commands.
 - For advanced record queries (filtering, sorting, pagination), use `segmentation segment fetch` from `cargo-orchestration`.
 
 **References:** `cargo-storage/SKILL.md`
@@ -431,7 +431,7 @@ The workspace UUID is returned by `cargo-ai whoami` under `workspace.uuid`.
 | `conjonction` spelling             | Filter JSON uses `conjonction` (not `conjunction`). This is intentional. A typo here fails silently — no records returned.                                                                                                                    |
 | `run create` vs `batch create`     | `run create` only works with **tool** workflows. Using a play's `workflowUuid` returns `playNotCompatible`.                                                                                                                                   |
 | `--model-uuid` vs `--segment-uuid` | `segment fetch` and `segment download` require `--model-uuid`. Get it from `segment list` → `.modelUuid`.                                                                                                                                     |
-| Storage query table names          | `storage query execute` references tables as `<datasetSlug>.<modelSlug>` (e.g. `default.companies`) — they're rewritten under the hood. The DDL form `datasets_default.models_companies` is only needed by `system-of-record client fetch | download`.                  |
+| Storage query table names          | `storage query execute` references tables as `<datasetSlug>.<modelSlug>` (e.g. `default.companies`) — they're rewritten under the hood. The DDL form `datasets_default.models_companies` is only needed by `system-of-record client download`.                  |
 | Token shown once                   | API token values are only returned at creation. Store immediately. `workspace token create` requires `--name` (no more `--from-user`).                                                                                                        |
 | Invoice amounts in cents           | `subscription get-invoices` returns `amount` in cents. Divide by 100.                                                                                                                                                                         |
 | Plays vs tools                     | **Play** = reacts to data changes (segment-driven). **Tool** = triggered on demand (manual, API, cron).                                                                                                                                       |

--- a/index.md
+++ b/index.md
@@ -121,7 +121,7 @@ Load for a specific CLI domain.
 - `cargo-gtm` delegates to capability skills via relative paths (`../cargo-orchestration/...`). Capability skills never reference `cargo-gtm`.
 - `cargo-workspace-management` provides auth context for every skill — set it up first.
 - `cargo-storage`, `cargo-connection`, and `cargo-ai` are peer skills that supply UUIDs to `cargo-orchestration`. They don't depend on each other.
-- Before querying via system-of-record, load `cargo-storage` to get the DDL (exact table name).
+- For SQL queries against the system-of-record, use `cargo-ai storage query execute "<sql>"` (tables as `<datasetSlug>.<modelSlug>`). Load `cargo-storage` to discover dataset and model slugs, and to fetch the DDL when you need column types or the SQL dialect.
 - Before building a workflow node graph, load `cargo-connection` to get `connectorUuid` and `actionSlug`.
 - Before executing a workflow that uses an agent node, load `cargo-ai` to get `agentUuid`.
 - After runs complete, load `cargo-analytics` to download results or measure performance. **For action output retrieval, prefer `cargo-ai orchestration run download-outputs` over `run download` — the former returns a signed-URL CSV/JSON of just the output node's data.**
@@ -168,7 +168,7 @@ Load for a specific CLI domain.
 
 - See the decision flowchart at the top of `cargo-orchestration/SKILL.md` for when to use `action execute` vs `run create` vs `batch create`.
 - Filter JSON uses `conjonction` (not `conjunction`) — breaks silently if misspelled.
-- Always get DDL before querying the system-of-record: `cargo-ai storage model get-ddl <model-uuid>`.
+- Query the system-of-record with `cargo-ai storage query execute "<sql>"` using `<datasetSlug>.<modelSlug>` table names (e.g. `default.companies`). Run `cargo-ai storage model get-ddl <model-uuid>` for column types or SQL dialect.
 - All operations are async — poll or pass `--wait-until-finished`. See [Async polling](#async-polling).
 
 **References:** `cargo-orchestration/SKILL.md`
@@ -209,7 +209,7 @@ Load for a specific CLI domain.
 
 **Critical rules:**
 
-- Always run `model get-ddl` before querying via system-of-record — it contains the exact table name (e.g. `datasets_default.models_companies`).
+- Query via `cargo-ai storage query execute "<sql>"` using `<datasetSlug>.<modelSlug>` table names (e.g. `default.companies`). `model get-ddl` is optional — useful for column types and SQL dialect, and required only for the legacy `system-of-record client fetch | download` commands.
 - For advanced record queries (filtering, sorting, pagination), use `segmentation segment fetch` from `cargo-orchestration`.
 
 **References:** `cargo-storage/SKILL.md`
@@ -279,7 +279,7 @@ Most `cargo-orchestration` operations require UUIDs from other skills. This tabl
 | UUID            | Produced by                                | Consumed by                                                             |
 | --------------- | ------------------------------------------ | ----------------------------------------------------------------------- |
 | `workflowUuid`  | `orchestration play list` / `tool list`    | `run create`, `batch create`, `run get-metrics`, `run download`         |
-| `modelUuid`     | `storage model list`                       | `segment fetch`, `segment download`, `system-of-record query` (via DDL) |
+| `modelUuid`     | `storage model list`                       | `segment fetch`, `segment download`, `model get-ddl`. Note: `storage query execute` references models by slug, not UUID |
 | `segmentUuid`   | `segmentation segment list`                | `batch create --data '{"kind":"segment",...}'`                          |
 | `agentUuid`     | `ai agent list`                            | `ai chat create`, node graph (`kind: "agent"`)                          |
 | `connectorUuid` | `connection connector list`                | Node graph (`kind: "connector"`), `billing usage --connector-uuid`      |
@@ -299,9 +299,10 @@ cargo-ai whoami
 cargo-ai orchestration tool list
 cargo-ai orchestration play list
 
-# 3. Find the model and get its DDL (if querying via SoR)
+# 3. Find the model (and dataset slug) for SoR queries
 cargo-ai storage model list
-cargo-ai storage model get-ddl <model-uuid>
+cargo-ai storage dataset list
+cargo-ai storage model get-ddl <model-uuid>   # optional — for column types and SQL dialect
 
 # 4. Find connectors needed by the workflow nodes
 cargo-ai connection connector list
@@ -430,7 +431,7 @@ The workspace UUID is returned by `cargo-ai whoami` under `workspace.uuid`.
 | `conjonction` spelling             | Filter JSON uses `conjonction` (not `conjunction`). This is intentional. A typo here fails silently — no records returned.                                                                                                                    |
 | `run create` vs `batch create`     | `run create` only works with **tool** workflows. Using a play's `workflowUuid` returns `playNotCompatible`.                                                                                                                                   |
 | `--model-uuid` vs `--segment-uuid` | `segment fetch` and `segment download` require `--model-uuid`. Get it from `segment list` → `.modelUuid`.                                                                                                                                     |
-| DDL before SQL                     | Never guess table names. Always run `model get-ddl <uuid>` first. Table names look like `datasets_default.models_companies`.                                                                                                                  |
+| Storage query table names          | `storage query execute` references tables as `<datasetSlug>.<modelSlug>` (e.g. `default.companies`) — they're rewritten under the hood. The DDL form `datasets_default.models_companies` is only needed by `system-of-record client fetch | download`.                  |
 | Token shown once                   | API token values are only returned at creation. Store immediately. `workspace token create` requires `--name` (no more `--from-user`).                                                                                                        |
 | Invoice amounts in cents           | `subscription get-invoices` returns `amount` in cents. Divide by 100.                                                                                                                                                                         |
 | Plays vs tools                     | **Play** = reacts to data changes (segment-driven). **Tool** = triggered on demand (manual, API, cron).                                                                                                                                       |


### PR DESCRIPTION
## Summary
This PR updates documentation across multiple skills to reflect a new simplified SQL query interface. The `cargo-ai storage query execute` command now accepts tables as `<datasetSlug>.<modelSlug>` (e.g., `default.companies`) instead of requiring users to look up warehouse-native table names from DDL first. The command automatically rewrites slug-based references to the underlying warehouse table.

## Key Changes

- **Simplified query flow**: Removed the requirement to always fetch DDL before querying. Users can now discover dataset and model slugs via `storage dataset list` and `storage model list`, then query directly using those slugs.

- **Updated command examples**: Changed all query examples from `cargo-ai system-of-record client query` with warehouse-native table names (e.g., `datasets_default.models_companies`) to `cargo-ai storage query execute` with slug-based names (e.g., `default.companies`).

- **Clarified DDL usage**: DDL is now optional for basic queries—it's primarily useful for discovering column types, SQL dialect, and the warehouse-native table name (which is still required by legacy `system-of-record client fetch | download` commands).

- **Updated error handling**: Changed from checking `outcome: "notQueried"` to handling non-zero exit codes with `errorMessage` or `reason` fields. Added new error shapes (`clientNotFound`, `unknown`).

- **Updated response shapes**: Documented the new success response format (just `rows` array, no `outcome` field) and failure formats for `storage query execute`.

- **Updated troubleshooting**: Changed error diagnosis from "wrong table name" to "wrong dataset or model slug" with corrected recovery steps.

- **Updated all skill references**: Modified `cargo-orchestration`, `cargo-gtm`, `cargo-storage`, and root documentation to reflect the new query interface and remove the "always get DDL first" rule.

## Notable Details

- The legacy `system-of-record client fetch | download | get-documentation` commands still use warehouse-native table names and the old response format.
- Column slugs can be discovered via `storage column list --model-uuid <uuid>` or by examining the DDL output.
- All SQL examples (WHERE clauses, aggregations, joins, CTEs, subqueries, date queries) now use the simplified slug-based syntax.

https://claude.ai/code/session_01KeM8tQTjdBF8SgBDye6REg