### PR TITLE
Add cargo-context SKILL documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,10 +9,10 @@
 
 # Cargo CLI — Skills Overview
 
-This repository contains 8 skills at the repo root: one **outcome skill** (`cargo-gtm`) and seven **capability skills**.
+This repository contains 9 skills at the repo root: one **outcome skill** (`cargo-gtm`) and eight **capability skills**.
 
 - **`cargo-gtm`** — application library. The front door for any GTM task ("build a TAM list", "find 5 fintech CTOs", "monitor job changes"). Routes via internal recipes (`cargo-gtm/recipes/*.md`) and provider playbooks (`cargo-gtm/provider-playbooks/*.md`).
-- **Capability skills** — standard library. One per CLI domain (orchestration, storage, connection, AI, analytics, billing, workspace management). Loaded by `cargo-gtm`, or directly when you need a specific CLI domain.
+- **Capability skills** — standard library. One per CLI domain (orchestration, storage, connection, AI, context, analytics, billing, workspace management). Loaded by `cargo-gtm`, or directly when you need a specific CLI domain.
 
 `cargo-gtm` delegates to capability skills; capability skills never reference `cargo-gtm` (one-way dependency).
 
@@ -95,6 +95,7 @@ Load for a specific CLI domain.
 | [`cargo-storage`](#cargo-storage)                                     | Inspect or modify data models, columns, datasets, and relationships                                |
 | [`cargo-connection`](#cargo-connection)                               | Manage connector authentication, discover available integrations and their actions                 |
 | [`cargo-ai`](#cargo-ai)                                               | Create and configure agents, upload files for RAG, manage MCP servers                              |
+| [`cargo-context`](#cargo-context)                                     | Browse/read/write/edit the workspace's git-backed GTM context repo, run commands in its runtime sandbox, inspect the knowledge graph |
 | [`cargo-workspace-management`](#cargo-workspace-management)           | Invite users, create API tokens, organize folders, manage roles, report CLI issues to management   |
 
 ---
@@ -135,6 +136,13 @@ Load for a specific CLI domain.
  │  Results, metrics,     │  │    Credit usage, costs    │
  │  exports               │  │                           │
  └────────────────────────┘  └───────────────────────────┘
+
+             ┌───────────────────────────────────────┐
+             │             cargo-context             │
+             │  Git-backed GTM markdown knowledge:   │
+             │  personas, plays, proof, signals…     │
+             └───────────────────────────────────────┘
+           (orthogonal: not part of the workflow flow)
 ```
 
 **Dependency rules in practice:**
@@ -142,6 +150,7 @@ Load for a specific CLI domain.
 - `cargo-gtm` delegates to capability skills via relative paths (`../cargo-orchestration/...`). Capability skills never reference `cargo-gtm`.
 - `cargo-workspace-management` provides auth context for every skill — set it up first.
 - `cargo-storage`, `cargo-connection`, and `cargo-ai` are peer skills that supply UUIDs to `cargo-orchestration`. They don't depend on each other.
+- `cargo-context` is **orthogonal** to the workflow-execution flow. It touches the git-backed GTM knowledge base (markdown/MDX), not the system-of-record data warehouse or workflow runs. Use it for capturing/editing the workspace's prose context — personas, plays, proof, objections, signals — and for inspecting the typed knowledge graph.
 - For SQL queries against the system-of-record, use `cargo-ai storage query execute "<sql>"` (tables as `<datasetSlug>.<modelSlug>`). Load `cargo-storage` to discover dataset and model slugs, and to fetch the DDL when you need column types or the SQL dialect.
 - Before building a workflow node graph, load `cargo-connection` to get `connectorUuid` and `actionSlug`.
 - Before executing a workflow that uses an agent node, load `cargo-ai` to get `agentUuid`.
@@ -259,6 +268,27 @@ Load for a specific CLI domain.
 See `cargo-ai/SKILL.md` for model and temperature guidance by use case.
 
 **References:** `cargo-ai/SKILL.md`
+
+---
+
+### cargo-context
+
+**GTM context repository.** Browse, read, write, and edit the workspace's git-backed knowledge base of typed markdown/MDX files — personas, plays, proof, objections, signals, ICPs, etc. — via the runtime sandbox. Inspect cross-references with the knowledge graph.
+
+**Key concepts:**
+
+- **Context repository** = the GitHub repo backing the workspace's context. Canonical example: [`getcargohq/cargo-workspaces`](https://github.com/getcargohq/cargo-workspaces). Files use `kebab-case.md` names, YAML frontmatter with required `title` + `description`, and `domain/slug` cross-refs (no `.md`).
+- **Runtime sandbox** = a checked-out, executable copy of the context repo. `runtime write` and `runtime edit` push to the default branch; `runtime execute` does **not** push.
+- **Knowledge graph** = the typed graph over every md/mdx file, with frontmatter and outbound cross-refs per node. Built via `cargo-ai context graph get`.
+
+**Critical rules:**
+
+- `runtime write` / `runtime edit` commit and push. `runtime execute` is ephemeral — use it for `grep`/`ls`/inspection, never for persistent changes.
+- `runtime edit --old-string` must match the file content **exactly once**. Read first, copy whitespace verbatim.
+- Every file requires both `title` and `description` in frontmatter — missing values break the knowledge graph.
+- For domains, conventions, and per-domain templates, see `cargo-context/references/conventions.md`.
+
+**References:** `cargo-context/SKILL.md`
 
 ---
 
@@ -443,6 +473,19 @@ The workspace UUID is returned by `cargo-ai whoami` under `workspace.uuid`.
    --sort '[{"columnSlug":"created_at","kind":"desc"}]'
 ```
 
+### 8. Author and audit the workspace's GTM context repo
+
+**Skills needed:** `cargo-context`
+
+```
+1. context runtime browse                          → see the domain layout
+2. context runtime read --path persona/_template.md → grab the template for the target domain
+3. context runtime write --path persona/<slug>.md  → add the entry (frontmatter + body, pushes to default branch)
+4. context graph get | jq …                        → audit cross-refs, find plays missing proof, etc.
+```
+
+See `cargo-context/references/examples/authoring.md` and `cargo-context/references/examples/graph-queries.md` for full recipes.
+
 ---
 
 ## Common gotchas
@@ -458,3 +501,5 @@ The workspace UUID is returned by `cargo-ai whoami` under `workspace.uuid`.
 | Plays vs tools                     | **Play** = reacts to data changes (segment-driven). **Tool** = triggered on demand (manual, API, cron).                                                                                                                                       |
 | Batch data kinds                   | Play workflows accept: `segment`, `change`, `filter`, `recordIds`. Tool workflows accept: `file`, `records`.                                                                                                                                  |
 | Third-party connector rate limits  | Only `kind: "connector"` nodes (Clearbit, HubSpot, etc.) have rate limits — native nodes do not. Errors grow silently as the batch runs. Start at 1 record, then 50, then 500 before full-scale. Add `retry` with backoff to connector nodes. |
+| `context runtime execute` is ephemeral | `context runtime execute` runs commands in the sandbox but **does not push** any file changes. Use `runtime write` / `runtime edit` for persistent edits to the context repo.                                                          |
+| `context runtime edit` must match exactly once | `--old-string` must occur exactly once in the file. Whitespace counts — read the file first and copy the substring verbatim. For multi-spot changes, do multiple targeted edits or use `write` to overwrite the whole file. |

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -36,7 +36,7 @@ The UUID returned by `batch create`. Used to poll batch status (`batch get`), do
 ## C
 
 **capability skill**
-A skill that documents one CLI domain (orchestration, storage, connection, AI, analytics, billing, workspace management). Capability skills are the "standard library" — the agent loads them when it needs the syntax for a specific CLI command. They sit at the repo root alongside the outcome skill (`cargo-gtm`). Capability skills never reference outcome skills (one-way dependency: outcome → capability).
+A skill that documents one CLI domain (orchestration, storage, connection, AI, context, analytics, billing, workspace management). Capability skills are the "standard library" — the agent loads them when it needs the syntax for a specific CLI command. They sit at the repo root alongside the outcome skill (`cargo-gtm`). Capability skills never reference outcome skills (one-way dependency: outcome → capability).
 
 **chat**
 A conversation session between a user and an agent. Created with `ai chat create --agent-uuid <uuid>`. Messages are sent to a chat via `ai message create --chat-uuid <uuid>`.
@@ -84,6 +84,12 @@ An authenticated instance of an integration. For example, a specific HubSpot acc
 **connectorUuid**
 The UUID of a specific authenticated connector. Required for `kind: "connector"` nodes in workflow graphs and for filtering billing metrics.
 
+**context**
+The workspace's git-backed knowledge base of typed markdown/MDX files capturing GTM truth: company narrative, ICPs, personas, JTBDs, plays, proof, objections, signals, mediums, alternatives, clients, insights. Read and written by both humans and agents. Managed via `cargo-context` (`cargo-ai context runtime ...` and `cargo-ai context graph ...`). Distinct from the **system of record** (a connected data warehouse queried with SQL) and from agent **memories** (per-agent mem0 entries).
+
+**context repository**
+The GitHub repository that backs the workspace's context. Files in this repo follow strict conventions: `kebab-case.md` filenames, YAML frontmatter with required `title` and `description`, and `domain/slug` cross-refs without `.md`. The canonical example is [`getcargohq/cargo-workspaces`](https://github.com/getcargohq/cargo-workspaces). See `cargo-context/references/conventions.md` for the full domain list and per-domain templates.
+
 **credit**
 The unit of consumption on Cargo. Workflows consume credits when they execute nodes — particularly connector and agent nodes. Tracked via `cargo-billing`.
 
@@ -129,19 +135,26 @@ The set of activities for finding, qualifying, and engaging prospects: sourcing,
 ## I
 
 **ICP (Ideal Customer Profile)**
-The target prospect description used to filter sourcing and qualification: industry, size band, geography, tech stack, role, funding stage, etc. Every prospecting recipe begins by translating the user's stated ICP into provider filters.
+The target prospect description used to filter sourcing and qualification: industry, size band, geography, tech stack, role, funding stage, etc. Every prospecting recipe begins by translating the user's stated ICP into provider filters. Often captured as a `icp/<slug>.md` file in the context repo.
 
 **ICP fit**
 The degree to which a record matches the ICP. Often expressed as a 0–10 score from a scoring agent (`anthropic.instruct` or similar) over enriched record fields. See `cargo-gtm/guides/writing-outreach.md` for scoring patterns.
 
 **intent signal**
-An observable behavior suggesting a company is ready to buy: hiring for a relevant role, raising funding, adding/removing tech in their stack, posting recent LinkedIn updates, anonymous website visits, recent job changes among employees. Cargo surfaces intent signals via `cargo.enrichBusinessFunding…`, `theirStack.searchJobs`, `waterfall.detectJobChange`, `snitcher.searchSessions`, and others.
+An observable behavior suggesting a company is ready to buy: hiring for a relevant role, raising funding, adding/removing tech in their stack, posting recent LinkedIn updates, anonymous website visits, recent job changes among employees. Cargo surfaces intent signals via `cargo.enrichBusinessFunding…`, `theirStack.searchJobs`, `waterfall.detectJobChange`, `snitcher.searchSessions`, and others. Tracked as `signal/<slug>.md` files in the context repo.
 
 **integration**
 The external service type — e.g. HubSpot, Clearbit, Salesforce. Defines what actions are available. A single integration can have multiple connectors (multiple authenticated accounts). Listed via `connection integration list`.
 
 **integrationSlug**
 The string identifier for an integration type (e.g. `hubspot`, `clearbit`, `salesforce`). Used in `kind: "connector"` node definitions alongside `actionSlug`.
+
+---
+
+## K
+
+**knowledge graph**
+The typed graph of nodes and cross-references derived from every markdown/MDX file in the **context repository**. Built (or loaded from cache) via `cargo-ai context graph get`. Each node carries parsed frontmatter (`title`, `description`) and outbound `domain/slug` references. Used to audit cross-references, discover existing entries, and power downstream agents that need the typed structure of the workspace's context. See `cargo-context/references/examples/graph-queries.md` for ready-to-run queries.
 
 ---
 
@@ -158,7 +171,7 @@ The identifier for an LLM used by an agent or inline agent node. Examples: `gpt-
 A Model Context Protocol server that exposes additional actions to agents. Connected via `cargo-ai`. Once connected, agents can call MCP actions automatically during conversations or workflow runs.
 
 **memory**
-A piece of information an agent stores from a conversation for future reference. Listed via `ai memory list --agent-uuid <uuid>`. Can be cleared with `ai memory remove`.
+A piece of information an agent stores from a conversation for future reference. Listed via `ai memory list --agent-uuid <uuid>`. Can be cleared with `ai memory remove`. Distinct from the **context repository** (workspace-wide, structured, git-backed) and from agent files / RAG resources.
 
 **model**
 A structured data table in the Cargo workspace — e.g. Companies, Contacts, Deals. Has columns, relationships, and an associated SQL table in the system of record. Not to be confused with a language model.
@@ -194,16 +207,19 @@ The terminal node of a workflow / tool / play whose output is the canonical resu
 ## P
 
 **play**
-A segment-driven workflow that reacts automatically to data changes (records added, updated, or removed from a segment). Listed via `orchestration play list`. Triggered via `batch create` (not `run create`).
+A segment-driven workflow that reacts automatically to data changes (records added, updated, or removed from a segment). Listed via `orchestration play list`. Triggered via `batch create` (not `run create`). The strategy behind a play is often captured as `play/<slug>.md` in the context repo (hypothesis, trigger, audience, channel, sequence, proof).
 
 **polling**
 The pattern of repeatedly calling `run get`, `batch get`, or `message get` until the operation reaches a terminal state. See `cargo-orchestration/references/polling.md` for intervals and shell snippets.
 
 **persona**
-A role / title shape that's part of the ICP. Example personas: "Head of RevOps at a B2B SaaS", "Founder at a seed-stage fintech". Used as filters for `salesNavigator.searchLeads`, `peopleDataLabs.searchPeople`, etc.
+A role / title shape that's part of the ICP. Example personas: "Head of RevOps at a B2B SaaS", "Founder at a seed-stage fintech". Used as filters for `salesNavigator.searchLeads`, `peopleDataLabs.searchPeople`, etc. Captured as `persona/<slug>.md` in the context repo with role, KPIs, pains, motivations, preferred channels, and common objections.
 
 **priority stack**
 The 6 default credits-based providers used as the spine of every recipe in `cargo-gtm/`: **salesNavigator** (sourcing), **cargo** native (firmographic + signal intelligence), **waterfall** (multi-source enrichment + verification + job-change signal), **FullEnrich** (premium contact lookup), **theirStack** (tech-stack + hiring intent), **peopleDataLabs** (heavyweight backfill). See `cargo-gtm/SKILL.md` for the full stack reference and per-provider playbooks.
+
+**proof**
+An atomic proof point — one metric, quote, case fact, or benchmark — stored as `proof/<slug>.md` in the context repo. Cross-referenced from plays, objections, and decks. Keep proof entries atomic (one fact per file) so they can be filtered in the knowledge graph.
 
 **prospect**
 A person being marketed or sold to — typically resolved to a `prospect_id` via `cargo.matchProspect`. Distinct from a "lead" (which usually implies an inbound or marketing-qualified context); cargo uses "prospect" generically.
@@ -236,6 +252,9 @@ A single execution of a tool workflow against one record. Created with `orchestr
 **runUuid**
 The UUID of a single workflow run. Used to poll status (`run get`), inspect results, and filter analytics.
 
+**runtime sandbox**
+A checked-out, executable copy of the **context repository** that backs every `cargo-ai context runtime ...` command. `runtime write` and `runtime edit` commit and **push to the default branch**; `runtime execute` runs a shell command in the sandbox but **does not push** any file changes. Use `execute` for inspection (grep, ls, find); use `write`/`edit` for any change that should land in git.
+
 ---
 
 ## S
@@ -247,16 +266,16 @@ A filtered, live view of records in a model. Defined by a filter condition. Used
 The UUID of a segment. Used in `batch create --data '{"kind":"segment","segmentUuid":"..."}'`. Note: `segment fetch` and `segment download` require `--model-uuid`, not `--segment-uuid`.
 
 **slug**
-A human-readable string identifier used throughout the platform. Node slugs identify nodes within a graph (e.g. `enrich_company`). Integration slugs identify integration types (e.g. `clearbit`). Column slugs identify model columns. Slugs use only `[a-zA-Z0-9_]`.
+A human-readable string identifier used throughout the platform. Node slugs identify nodes within a graph (e.g. `enrich_company`). Integration slugs identify integration types (e.g. `clearbit`). Column slugs identify model columns. Slugs use only `[a-zA-Z0-9_]`. In the **context repository**, slugs are kebab-case filenames without the `.md` extension and are referenced as `domain/slug`.
 
 **signal**
-See **intent signal**. In cargo recipes, signals are the basis for segment construction (e.g. "all companies that just raised funding AND are hiring engineers") and outbound timing.
+See **intent signal**. In cargo recipes, signals are the basis for segment construction (e.g. "all companies that just raised funding AND are hiring engineers") and outbound timing. Captured as `signal/<slug>.md` files in the context repo.
 
 **sourcing**
 The activity of finding companies or people matching ICP criteria. Cheapest at-scale options: `salesNavigator.searchLeads` (0.02 cred/record), `salesNavigator.searchAccounts` (0.05). For investor / funding / complex filters: `peopleDataLabs.queryCompanies` (3). For local SMBs: `serper.searchPlaces` (1).
 
 **system of record (SoR)**
-A connected data warehouse (BigQuery, Snowflake, etc.) that Cargo can query via SQL. Queried with `cargo-ai storage query execute "<sql>"` (or `storage query download "<sql>"` for full exports), which references tables as `<datasetSlug>.<modelSlug>` (e.g. `default.companies`). For SoR docs, use `cargo-ai system-of-record client get-documentation`.
+A connected data warehouse (BigQuery, Snowflake, etc.) that Cargo can query via SQL. Queried with `cargo-ai storage query execute "<sql>"` (or `storage query download "<sql>"` for full exports), which references tables as `<datasetSlug>.<modelSlug>` (e.g. `default.companies`). For SoR docs, use `cargo-ai system-of-record client get-documentation`. Distinct from the **context repository** (markdown/MDX knowledge base, not relational data).
 
 ---
 
@@ -266,7 +285,7 @@ A connected data warehouse (BigQuery, Snowflake, etc.) that Cargo can query via 
 The full universe of companies (and optionally contacts at those companies) matching an ICP. Cargo's TAM-build recipe lives at `cargo-gtm/recipes/build-tam.md`, typically producing 100–10,000 company lists.
 
 **template**
-A pre-built blueprint for a workflow node graph (`orchestration template list`) or an AI agent (`ai template list`). Used to bootstrap common patterns without building from scratch.
+A pre-built blueprint for a workflow node graph (`orchestration template list`) or an AI agent (`ai template list`). Used to bootstrap common patterns without building from scratch. In the **context repository**, every domain also ships a `_template.md` documenting the expected sections (read it with `cargo-ai context runtime read --path <domain>/_template.md`).
 
 **temperature**
 A float between `0.0` and `1.0` controlling how deterministic an agent's responses are. `0.0` = fully deterministic; `1.0` = highly creative. Set on `agent create` or `agent update`.
@@ -295,4 +314,4 @@ A DAG of nodes that defines the execution logic for a play or tool. Workflows do
 The UUID of a workflow. The primary key for most orchestration, analytics, and billing commands. Get it from `play list` or `tool list` → `.workflowUuid`.
 
 **workspace**
-The top-level organizational unit in Cargo. All resources (models, agents, workflows, connectors) belong to a workspace. Identified by a `workspaceUuid`. Managed via `cargo-workspace-management`.
+The top-level organizational unit in Cargo. All resources (models, agents, workflows, connectors, the context repository) belong to a workspace. Identified by a `workspaceUuid`. Managed via `cargo-workspace-management`.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Works with Claude Code, Cursor, Windsurf, GitHub Copilot, and any agent that sup
 
 ## What this skill teaches
 
-**Cargo** connects your data models (companies, contacts, deals) to external integrations (CRMs, enrichment providers, AI agents) and runs them as automated workflows. The repo ships eight skills at the root — one **outcome skill** (`cargo-gtm`, the front door for any GTM task) and seven **capability skills** (one per CLI domain).
+**Cargo** connects your data models (companies, contacts, deals) to external integrations (CRMs, enrichment providers, AI agents) and runs them as automated workflows. The repo ships nine skills at the root — one **outcome skill** (`cargo-gtm`, the front door for any GTM task) and eight **capability skills** (one per CLI domain).
 
 ### Outcome — `cargo-gtm`
 
@@ -50,6 +50,7 @@ Load when you need the syntax for a specific CLI domain.
 | **Storage**       | Inspect models and their DDL, create columns, navigate datasets, set relationships between models                                                                  |
 | **Connection**    | Authenticate connectors, discover integration actions and their slugs across 120+ integrations                                                                     |
 | **AI**            | Create and configure agents, upload files for RAG, connect MCP servers, inspect agent memories                                                                     |
+| **Context**       | Browse, read, write, and edit the workspace's git-backed context repo (markdown/MDX GTM knowledge base); run shell commands in its runtime sandbox; inspect the knowledge graph |
 | **Analytics**     | Download run results and outputs, export segment data, monitor error rates and success metrics                                                                     |
 | **Billing**       | Track credit consumption per workflow or connector, check subscription status, view invoices                                                                       |
 | **Workspace**     | Invite users, create and rotate API tokens, organize resources into folders, manage roles                                                                          |
@@ -66,7 +67,7 @@ Prompts that route through `cargo-gtm`:
 - *"Show me everyone hiring data engineers AND running Snowflake."* → `recipes/tech-intent.md`
 - *"What ICP signals differentiate our Closed-Won deals?"* → `recipes/icp-discovery.md`
 
-For ad-hoc CLI work (modify a model, list connectors, query the warehouse), load the matching capability skill directly.
+For ad-hoc CLI work (modify a model, list connectors, query the warehouse, edit the GTM context repo), load the matching capability skill directly.
 
 ## Use cases
 
@@ -101,6 +102,13 @@ The agent fetches the DDL first (to get the exact table name), then writes and e
 The agent creates or finds a configured Cargo agent, sends a message, polls for the response, and surfaces the result.
 
 > "Use the lead researcher agent to find the LinkedIn of every contact added this week."
+
+### Edit the workspace's GTM context
+
+The agent browses, reads, and edits the git-backed context repo (personas, plays, proof, objections, etc.) via the runtime sandbox, and uses the knowledge graph to audit cross-references.
+
+> "Add a persona file for Head of RevOps at mid-market SaaS."
+> "Find every play that references the funding signal but has no proof attached."
 
 ### Monitor workflow health
 

--- a/cargo-context/SKILL.md
+++ b/cargo-context/SKILL.md
@@ -1,0 +1,271 @@
+---
+name: cargo-context
+description: Inspect and edit the workspace's git-backed context repository (the GTM knowledge base of markdown/MDX files) and its runtime sandbox using the Cargo CLI. Use when the user wants to configure which repo backs context, browse/read/write/edit context files, run a command in the sandbox, or inspect the context knowledge graph.
+license: MIT
+compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
+metadata:
+  author: getcargo
+  version: "1.0"
+---
+
+# Cargo CLI — Context
+
+The **context** is a git-backed repository of typed markdown/MDX files that captures a workspace's GTM knowledge (company narrative, ICPs, personas, plays, proof, objections, etc.) and is read/written by both humans and agents. The `cargo-ai context` domain has three subdomains:
+
+- **repository** — configure which GitHub repo backs the workspace's context, and inspect that configuration.
+- **runtime** — browse, read, write, edit, and execute against the workspace's runtime sandbox (a checked-out copy of the context repo). Writes to `write`/`edit` are pushed to the default branch; `execute` runs are **not** pushed.
+- **graph** — build/load the knowledge graph derived from every markdown/MDX file in the context repo.
+
+> The canonical example of a context repository is [`getcargohq/cargo-workspaces`](https://github.com/getcargohq/cargo-workspaces). Read its `README.md` to understand the domain layout and file conventions before writing new entries.
+> For uploading runtime-independent files (CSVs, PDFs) used in batch runs, use [`cargo-workspace-management`](../cargo-workspace-management/SKILL.md) (`cargo-ai workspaceManagement file upload`) instead.
+> For RAG file attachments to agents, use [`cargo-ai`](../cargo-ai/SKILL.md) (`cargo-ai ai file upload`).
+
+## Prerequisites
+
+```bash
+npm install -g @cargo-ai/cli
+cargo-ai login --oauth                                  # browser sign-in (recommended)
+# or: cargo-ai login --token <your-api-token>           # workspace-scoped API token (non-interactive)
+# Pin a default workspace at login (with --oauth)
+cargo-ai login --oauth --workspace-uuid <uuid>
+```
+
+Verify with `cargo-ai whoami`. All commands output JSON to stdout. Without a global install, prefix every command with `npx @cargo-ai/cli` instead of `cargo-ai`.
+
+Failed commands exit non-zero and return `{"errorMessage": "..."}`.
+
+## Discover the context first
+
+Before editing anything, find out which repo is wired up and what's in it:
+
+```bash
+cargo-ai context repository get                 # which GitHub repo + default branch backs context
+cargo-ai context runtime browse                 # list entries at the runtime sandbox root
+cargo-ai context graph get                      # full knowledge graph derived from the repo's md/mdx files
+```
+
+## Quick reference
+
+```bash
+# Repository configuration
+cargo-ai context repository get
+cargo-ai context repository update --source <json> --repository-owner <owner> --repository-name <name> --default-branch <branch>
+
+# Runtime sandbox (checked-out copy of the context repo)
+cargo-ai context runtime browse [--path <path>]
+cargo-ai context runtime read --path <path> [--start-line <n>] [--end-line <n>]
+cargo-ai context runtime write --path <path> --content <content> [--commit-message <message>]
+cargo-ai context runtime edit --path <path> --old-string <old> --new-string <new> [--commit-message <message>]
+cargo-ai context runtime execute --command <command> [--args <json>]
+
+# Knowledge graph
+cargo-ai context graph get
+```
+
+## Repository
+
+The **context repository** is the GitHub repo that backs the workspace's context. Two source kinds are supported:
+
+- `managed` — Cargo provisions and owns the repo.
+- `custom` — point at an existing GitHub repo you own (connected via a Cargo GitHub connector).
+
+```bash
+# Inspect the current configuration (source kind, repository owner/name, default branch)
+cargo-ai context repository get
+
+# Switch to a Cargo-managed repository
+cargo-ai context repository update --source '{"kind":"managed"}'
+
+# Point at your own GitHub repo (via an existing Cargo GitHub connector)
+cargo-ai context repository update \
+  --source '{"kind":"custom","connectorUuid":"<connector-uuid>"}' \
+  --repository-owner <github-owner> \
+  --repository-name <github-repo> \
+  --default-branch main
+```
+
+**Notes:**
+
+- `--source` is JSON. For `custom`, `connectorUuid` must reference an existing GitHub connector — list connectors via `cargo-ai connection connector list`.
+- `--default-branch` is the branch the runtime sandbox writes get pushed to (typically `main`).
+- All four `update` flags are optional; pass only what's changing.
+
+## Runtime sandbox
+
+The **runtime sandbox** is a checked-out, executable copy of the context repository. It's the surface you use to read and modify context files, and to run commands against them.
+
+Two important behaviors to remember:
+
+- **`write` and `edit` push to the default branch** configured via `repository update`. They are not local-only.
+- **`execute` does *not* push.** Changes made to files by a shell command run via `execute` stay in the sandbox and are discarded — use `execute` for builds, tests, or inspection, not for committing edits.
+
+### Browse and read
+
+```bash
+# List entries at the root of the runtime sandbox
+cargo-ai context runtime browse
+
+# List entries under a subpath (e.g. a domain folder like persona/ or play/)
+cargo-ai context runtime browse --path persona
+
+# Read a full file
+cargo-ai context runtime read --path persona/vp-sales-mid-market.md
+
+# Read only a line range (1-indexed, inclusive on both ends)
+cargo-ai context runtime read --path play/inbound-trial-to-paid.md --start-line 1 --end-line 40
+```
+
+### Write a new file
+
+`write` creates (or overwrites) a file and pushes a commit to the default branch.
+
+```bash
+cargo-ai context runtime write \
+  --path persona/vp-sales-mid-market.md \
+  --content "$(cat <<'EOF'
+---
+title: VP of Sales, mid-market
+description: Owns pipeline, quota, and rep productivity at a 200–2,000-person company.
+---
+
+## Role
+- Title: VP of Sales
+- Seniority: Executive
+- Function: Revenue
+- Reports to: CRO or CEO
+
+## KPIs
+- New ARR, win rate, pipeline coverage, rep ramp time
+
+## Pains
+- Pipeline gaps, slow ramp, low rep activity, forecasting drift
+
+## Motivations
+- Hit the number, build a repeatable motion, get visibility
+
+## Day-to-day
+Forecast calls, deal reviews, pipeline reviews, 1:1s with frontline managers.
+
+## Preferred channels
+- medium/linkedin-outbound
+- medium/exec-warm-intro
+
+## Common objections
+- objection/we-already-have-an-ai-sdr
+
+## How we land
+Lead with pipeline-coverage math, not features.
+EOF
+)" \
+  --commit-message "Add VP of Sales mid-market persona"
+```
+
+### Edit an existing file
+
+`edit` replaces a single exact substring. `--old-string` must occur **exactly once** in the file; pass an empty `--new-string` to delete the match.
+
+```bash
+# Replace one specific sentence
+cargo-ai context runtime edit \
+  --path global/positioning.md \
+  --old-string "We help RevOps automate workflows." \
+  --new-string "We help RevOps run AI-native GTM motions." \
+  --commit-message "Refresh positioning one-liner"
+
+# Delete a line (pass empty --new-string)
+cargo-ai context runtime edit \
+  --path persona/vp-sales-mid-market.md \
+  --old-string "\n- Outdated stat: 4.2x pipeline\n" \
+  --new-string ""
+```
+
+For larger restructures, prefer `write` (full-file overwrite) over many sequential `edit` calls.
+
+### Execute a command in the sandbox
+
+`execute` runs a shell command in the sandbox. Useful for inspecting structure or running checks; **changes are not pushed**.
+
+```bash
+# Find every file that cross-references a specific slug
+cargo-ai context runtime execute \
+  --command grep \
+  --args '["-r","-l","persona/vp-sales-mid-market","."]'
+
+# Count entries per domain
+cargo-ai context runtime execute --command ls --args '["-1","persona"]'
+
+# Run a one-shot script (no quotes/escaping needed inside --command beyond JSON for args)
+cargo-ai context runtime execute --command pwd
+```
+
+`--args` is a JSON array of string arguments. Omit it for a no-arg command.
+
+## Context repository structure and conventions
+
+The Cargo context repo is a typed knowledge base. The canonical example — and the source of the conventions below — is [`getcargohq/cargo-workspaces`](https://github.com/getcargohq/cargo-workspaces); read its `README.md` and `_template.md` files in each domain before writing new entries.
+
+### Domains
+
+| Domain | Purpose |
+|---|---|
+| `global/` | Company-level context: mission, voice, positioning, narrative, pricing |
+| `icp/` | Ideal Customer Profile segments |
+| `persona/` | Buyer personas (roles inside an ICP) |
+| `jtbd/` | Jobs-to-be-done framings |
+| `alternative/` | Competitors, substitutes, status quo |
+| `client/` | Customer profiles, case studies, reference accounts |
+| `insight/` | Market insights and observations |
+| `medium/` | Channel playbooks (email, LinkedIn, cold call, etc.) |
+| `objection/` | Objections + responses + proof |
+| `play/` | GTM plays (signal → audience → channel → sequence → outcome) |
+| `proof/` | Atomic proof points (metrics, quotes, case data) |
+| `signal/` | Buying signals and intent triggers |
+
+### File conventions
+
+- **Filename:** `kebab-case.md` (e.g. `vp-sales-mid-market.md`).
+- **Frontmatter:** YAML with `title` and `description`, both required on every file.
+- **Cross-references:** use the `domain/slug` form, **no `.md` extension** (e.g. `persona/vp-sales-mid-market`).
+- **Templates:** each domain ships an `_template.md`. Read it (`cargo-ai context runtime read --path persona/_template.md`) before authoring a new entry.
+
+### Workflow: add a new entry
+
+1. Confirm the target domain and copy its template:
+   ```bash
+   cargo-ai context runtime read --path persona/_template.md
+   ```
+2. `write` a new file at `<domain>/<slug>.md` with `title` + `description` and the body sections filled in.
+3. Add cross-refs (`domain/slug`) where useful — keep them bidirectional when it makes sense.
+4. Rebuild the knowledge graph to verify the new entry and its links:
+   ```bash
+   cargo-ai context graph get
+   ```
+
+## Knowledge graph
+
+`context graph get` builds (or loads from cache) the knowledge graph over every markdown/MDX file in the context repo. Use it to:
+
+- Audit cross-references between domains (e.g. find personas that link to plays with no proof attached).
+- Discover what already exists before writing a new entry (avoid duplicates).
+- Power downstream agents that need the typed structure of the workspace's context.
+
+```bash
+cargo-ai context graph get
+```
+
+The response shape includes the parsed frontmatter and outbound `domain/slug` references for each node — pipe it through `jq` to slice it.
+
+## Help
+
+Every command supports `--help`:
+
+```bash
+cargo-ai context --help
+cargo-ai context repository update --help
+cargo-ai context runtime browse --help
+cargo-ai context runtime read --help
+cargo-ai context runtime write --help
+cargo-ai context runtime edit --help
+cargo-ai context runtime execute --help
+cargo-ai context graph get --help
+```

--- a/cargo-context/SKILL.md
+++ b/cargo-context/SKILL.md
@@ -19,6 +19,11 @@ The **context** is a git-backed repository of typed markdown/MDX files that capt
 > For uploading runtime-independent files (CSVs, PDFs) used in batch runs, use [`cargo-workspace-management`](../cargo-workspace-management/SKILL.md) (`cargo-ai workspaceManagement file upload`) instead.
 > For RAG file attachments to agents, use [`cargo-ai`](../cargo-ai/SKILL.md) (`cargo-ai ai file upload`).
 
+> See `references/conventions.md` for the full context repo structure and per-domain templates.
+> See `references/troubleshooting.md` for common errors and how to fix them.
+> See `references/examples/authoring.md` for end-to-end add / edit / delete recipes.
+> See `references/examples/graph-queries.md` for inspecting the knowledge graph.
+
 ## Prerequisites
 
 ```bash
@@ -168,7 +173,7 @@ cargo-ai context runtime execute --command pwd
 
 ## Context repository structure and conventions
 
-The Cargo context repo is a typed knowledge base. The canonical example — and the source of the conventions below — is [`getcargohq/cargo-workspaces`](https://github.com/getcargohq/cargo-workspaces); read its `README.md` and `_template.md` files in each domain before writing new entries.
+The Cargo context repo is a typed knowledge base. The canonical example — and the source of the conventions below — is [`getcargohq/cargo-workspaces`](https://github.com/getcargohq/cargo-workspaces); read its `README.md` and `_template.md` files in each domain before writing new entries. For the full domain reference, see `references/conventions.md`.
 
 ### Domains
 
@@ -207,6 +212,8 @@ The Cargo context repo is a typed knowledge base. The canonical example — and 
    cargo-ai context graph get
    ```
 
+For full per-domain templates and worked examples, see `references/conventions.md` and `references/examples/authoring.md`.
+
 ## Knowledge graph
 
 `context graph get` builds (or loads from cache) the knowledge graph over every markdown/MDX file in the context repo. Use it to:
@@ -219,7 +226,7 @@ The Cargo context repo is a typed knowledge base. The canonical example — and 
 cargo-ai context graph get
 ```
 
-The response shape includes the parsed frontmatter and outbound `domain/slug` references for each node — pipe it through `jq` to slice it.
+The response includes the parsed frontmatter and outbound `domain/slug` references for each node — pipe it through `jq` to slice it. See `references/examples/graph-queries.md` for ready-to-run queries.
 
 ## Help
 

--- a/cargo-context/SKILL.md
+++ b/cargo-context/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cargo-context
-description: Inspect and edit the workspace's git-backed context repository (the GTM knowledge base of markdown/MDX files) and its runtime sandbox using the Cargo CLI. Use when the user wants to configure which repo backs context, browse/read/write/edit context files, run a command in the sandbox, or inspect the context knowledge graph.
+description: Inspect and edit the workspace's git-backed context repository (the GTM knowledge base of markdown/MDX files) and its runtime sandbox using the Cargo CLI. Use when the user wants to browse/read/write/edit context files, run a command in the sandbox, or inspect the context knowledge graph.
 license: MIT
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 metadata:
@@ -10,10 +10,9 @@ metadata:
 
 # Cargo CLI — Context
 
-The **context** is a git-backed repository of typed markdown/MDX files that captures a workspace's GTM knowledge (company narrative, ICPs, personas, plays, proof, objections, etc.) and is read/written by both humans and agents. The `cargo-ai context` domain has three subdomains:
+The **context** is a git-backed repository of typed markdown/MDX files that captures a workspace's GTM knowledge (company narrative, ICPs, personas, plays, proof, objections, etc.) and is read/written by both humans and agents. The `cargo-ai context` domain has two subdomains you'll use:
 
-- **repository** — configure which GitHub repo backs the workspace's context, and inspect that configuration.
-- **runtime** — browse, read, write, edit, and execute against the workspace's runtime sandbox (a checked-out copy of the context repo). Writes to `write`/`edit` are pushed to the default branch; `execute` runs are **not** pushed.
+- **runtime** — browse, read, write, edit, and execute against the workspace's runtime sandbox (a checked-out copy of the context repo). `write`/`edit` are pushed to the default branch; `execute` runs are **not** pushed.
 - **graph** — build/load the knowledge graph derived from every markdown/MDX file in the context repo.
 
 > The canonical example of a context repository is [`getcargohq/cargo-workspaces`](https://github.com/getcargohq/cargo-workspaces). Read its `README.md` to understand the domain layout and file conventions before writing new entries.
@@ -36,10 +35,9 @@ Failed commands exit non-zero and return `{"errorMessage": "..."}`.
 
 ## Discover the context first
 
-Before editing anything, find out which repo is wired up and what's in it:
+Before editing anything, see what's in the context repo:
 
 ```bash
-cargo-ai context repository get                 # which GitHub repo + default branch backs context
 cargo-ai context runtime browse                 # list entries at the runtime sandbox root
 cargo-ai context graph get                      # full knowledge graph derived from the repo's md/mdx files
 ```
@@ -47,10 +45,6 @@ cargo-ai context graph get                      # full knowledge graph derived f
 ## Quick reference
 
 ```bash
-# Repository configuration
-cargo-ai context repository get
-cargo-ai context repository update --source <json> --repository-owner <owner> --repository-name <name> --default-branch <branch>
-
 # Runtime sandbox (checked-out copy of the context repo)
 cargo-ai context runtime browse [--path <path>]
 cargo-ai context runtime read --path <path> [--start-line <n>] [--end-line <n>]
@@ -62,41 +56,13 @@ cargo-ai context runtime execute --command <command> [--args <json>]
 cargo-ai context graph get
 ```
 
-## Repository
-
-The **context repository** is the GitHub repo that backs the workspace's context. Two source kinds are supported:
-
-- `managed` — Cargo provisions and owns the repo.
-- `custom` — point at an existing GitHub repo you own (connected via a Cargo GitHub connector).
-
-```bash
-# Inspect the current configuration (source kind, repository owner/name, default branch)
-cargo-ai context repository get
-
-# Switch to a Cargo-managed repository
-cargo-ai context repository update --source '{"kind":"managed"}'
-
-# Point at your own GitHub repo (via an existing Cargo GitHub connector)
-cargo-ai context repository update \
-  --source '{"kind":"custom","connectorUuid":"<connector-uuid>"}' \
-  --repository-owner <github-owner> \
-  --repository-name <github-repo> \
-  --default-branch main
-```
-
-**Notes:**
-
-- `--source` is JSON. For `custom`, `connectorUuid` must reference an existing GitHub connector — list connectors via `cargo-ai connection connector list`.
-- `--default-branch` is the branch the runtime sandbox writes get pushed to (typically `main`).
-- All four `update` flags are optional; pass only what's changing.
-
 ## Runtime sandbox
 
 The **runtime sandbox** is a checked-out, executable copy of the context repository. It's the surface you use to read and modify context files, and to run commands against them.
 
 Two important behaviors to remember:
 
-- **`write` and `edit` push to the default branch** configured via `repository update`. They are not local-only.
+- **`write` and `edit` push to the default branch** of the context repo. They are not local-only.
 - **`execute` does *not* push.** Changes made to files by a shell command run via `execute` stay in the sandbox and are discarded — use `execute` for builds, tests, or inspection, not for committing edits.
 
 ### Browse and read
@@ -261,7 +227,6 @@ Every command supports `--help`:
 
 ```bash
 cargo-ai context --help
-cargo-ai context repository update --help
 cargo-ai context runtime browse --help
 cargo-ai context runtime read --help
 cargo-ai context runtime write --help

--- a/cargo-context/references/conventions.md
+++ b/cargo-context/references/conventions.md
@@ -1,0 +1,239 @@
+# Context repo conventions
+
+The conventions below are inherited from the canonical context repository [`getcargohq/cargo-workspaces`](https://github.com/getcargohq/cargo-workspaces). When in doubt, read its `README.md` and the `_template.md` file in the relevant domain.
+
+## Domains
+
+| Domain | Purpose |
+|---|---|
+| `global/` | Company-level context: mission, voice, positioning, narrative, pricing |
+| `icp/` | Ideal Customer Profile segments |
+| `persona/` | Buyer personas (roles inside an ICP) |
+| `jtbd/` | Jobs-to-be-done framings |
+| `alternative/` | Competitors, substitutes, status quo |
+| `client/` | Customer profiles, case studies, reference accounts |
+| `insight/` | Market insights and observations |
+| `medium/` | Channel playbooks (email, LinkedIn, cold call, etc.) |
+| `objection/` | Objections + responses + proof |
+| `play/` | GTM plays (signal → audience → channel → sequence → outcome) |
+| `proof/` | Atomic proof points (metrics, quotes, case data) |
+| `signal/` | Buying signals and intent triggers |
+
+## File conventions
+
+- **Filename:** `kebab-case.md` (e.g. `vp-sales-mid-market.md`). Use ASCII letters, digits, and hyphens only.
+- **Frontmatter:** YAML with `title` and `description` — both required on every file. Empty `description:` will be treated as missing.
+- **Cross-references:** `domain/slug` form, **no `.md` extension** (e.g. `persona/vp-sales-mid-market`).
+- **Templates:** each domain ships an `_template.md`. Read it (`cargo-ai context runtime read --path <domain>/_template.md`) before authoring a new entry.
+- **Bidirectional links:** keep cross-refs symmetric when it makes sense — a `play` that targets a `persona` should appear in the persona's `Preferred channels` or `How we land` sections when relevant.
+
+## How to read the context
+
+Start at `global/` for company context. Walk `icp/` → `persona/` → `jtbd/` to understand the buyer. Use `play/` for outbound motions and `objection/` + `proof/` for live conversations.
+
+## Domain templates
+
+The most commonly authored domains. For domains not shown here (`icp/`, `jtbd/`, `alternative/`, `client/`, `insight/`, `medium/`, `signal/`), read the in-repo `_template.md` directly:
+
+```bash
+cargo-ai context runtime read --path icp/_template.md
+cargo-ai context runtime read --path signal/_template.md
+# ...
+```
+
+### `global/_template.md`
+
+```markdown
+---
+title:
+description:
+---
+
+## Summary
+
+_One-line version._
+
+## Detail
+
+_Full version. Mission, voice, positioning, narrative, pricing — whatever this entry is._
+
+## Source
+
+_Where this comes from. Founder note, brand doc, board deck, prior conversation._
+```
+
+### `persona/_template.md`
+
+```markdown
+---
+title:
+description:
+---
+
+## Role
+
+- Title:
+- Seniority:
+- Function:
+- Reports to:
+
+## KPIs
+
+-
+
+## Pains
+
+-
+
+## Motivations
+
+-
+
+## Day-to-day
+
+_What this person actually does on a Tuesday._
+
+## Preferred channels
+
+_Cross-ref `medium/...`._
+
+-
+
+## Common objections
+
+_Cross-ref `objection/...`._
+
+-
+
+## How we land
+
+_The angle, the pitch, the moment they get it._
+```
+
+### `play/_template.md`
+
+```markdown
+---
+title:
+description:
+---
+
+## Hypothesis
+
+_Why this play should work. The bet._
+
+## Trigger
+
+_Cross-ref `signal/...`._
+
+-
+
+## Audience
+
+_Cross-ref `icp/...` or `persona/...`._
+
+-
+
+## Channel
+
+_Cross-ref `medium/...`._
+
+-
+
+## Sequence
+
+1.
+2.
+3.
+
+## Proof
+
+_Cross-ref `proof/...`._
+
+-
+
+## Success metric
+
+_What we measure. Target._
+
+## Owner
+
+_Role accountable for running this._
+
+## Variants
+
+-
+```
+
+### `proof/_template.md`
+
+```markdown
+---
+title:
+description:
+---
+
+## Type
+
+_metric | quote | case | benchmark | screenshot_
+
+## Content
+
+_The actual proof point. Number, quote, fact._
+
+## Source
+
+_Where it comes from. Customer, study, internal data._
+
+## Client
+
+_Optional. Cross-ref `client/...`._
+
+## Context
+
+_What claim this supports. Why we cite it._
+
+## Use cases
+
+_Where this shows up: objections, plays, posts, decks._
+
+-
+```
+
+### `objection/_template.md`
+
+Objections pair a stated buyer concern with the response and the proof that backs it up:
+
+```markdown
+---
+title:
+description:
+---
+
+## Objection
+
+_The buyer's stated concern, in their own words._
+
+## Response
+
+_Our reframe. Short, calm, specific._
+
+## Proof
+
+_Cross-ref `proof/...`._
+
+-
+
+## Personas
+
+_Cross-ref `persona/...` — who raises this most._
+
+-
+```
+
+## Authoring rules of thumb
+
+- **One concept per file.** If you're tempted to add a second `## Persona` or a second `## Play` heading inside one file, you actually want two files.
+- **Title is a label, description is a hook.** `title` shows up in lists; `description` is the one-line that explains why this entry exists.
+- **Cross-refs over duplication.** If a fact already lives in `proof/...`, link to it from the play or objection rather than re-stating it.
+- **Atomic proof.** Each `proof/` entry is one fact / quote / metric. Bundled proof points break filtering in the knowledge graph.

--- a/cargo-context/references/examples/authoring.md
+++ b/cargo-context/references/examples/authoring.md
@@ -1,0 +1,232 @@
+# Authoring examples
+
+End-to-end recipes for adding, editing, and removing entries in the context repo. All examples assume you're authenticated (`cargo-ai whoami` works) and that the workspace already has a context repository configured.
+
+## Discover before writing
+
+```bash
+# 1. What domains exist?
+cargo-ai context runtime browse
+
+# 2. What's already in the target domain? (avoid duplicates)
+cargo-ai context runtime browse --path persona
+
+# 3. What's the shape of an entry in this domain?
+cargo-ai context runtime read --path persona/_template.md
+```
+
+## Add a persona
+
+```bash
+cargo-ai context runtime write \
+  --path persona/head-of-revops.md \
+  --content "$(cat <<'EOF'
+---
+title: Head of RevOps
+description: Owns the GTM tech stack, data quality, and pipeline reporting at a 200–2,000-person B2B SaaS.
+---
+
+## Role
+
+- Title: Head of RevOps / Director of RevOps
+- Seniority: Director / VP
+- Function: Revenue Operations
+- Reports to: CRO or COO
+
+## KPIs
+
+- Pipeline velocity, forecast accuracy, data freshness, CRM hygiene, lead-to-opp conversion
+
+## Pains
+
+- Stale enrichment, broken CRM workflows, slow rep ramp because the data model is brittle
+- Stitching together 6 point tools that don't talk to each other
+- Manual segment refreshes for plays
+
+## Motivations
+
+- One source of truth across SDR, AE, CS
+- Replace fragile Zapier chains with durable workflows
+- Get out of the way of the frontline
+
+## Day-to-day
+
+Ops standup, reviewing failed syncs, building a new segment for an outbound play, fielding rep requests, and weekly forecast prep with the CRO.
+
+## Preferred channels
+
+_Cross-ref `medium/...`._
+
+- medium/peer-community-slack
+- medium/founder-led-linkedin
+
+## Common objections
+
+_Cross-ref `objection/...`._
+
+- objection/we-already-have-clay
+- objection/we-built-this-in-house
+
+## How we land
+
+Lead with the stack-replacement angle: "one durable workflow runtime that replaces enrichment + scoring + sync." Show, don't tell — run a workflow live against their domain on the demo call.
+EOF
+)" \
+  --commit-message "Add Head of RevOps persona"
+```
+
+## Add a play with cross-refs
+
+```bash
+cargo-ai context runtime write \
+  --path play/funding-triggered-outbound.md \
+  --content "$(cat <<'EOF'
+---
+title: Funding-triggered outbound
+description: Reach out to companies within 14 days of a Series A–C raise with a hiring-and-stack angle.
+---
+
+## Hypothesis
+
+Companies hit a stack-and-headcount inflection right after a raise. If we land in the first two weeks with a stack-replacement angle, we beat the procurement freeze that sets in by week 4.
+
+## Trigger
+
+_Cross-ref `signal/...`._
+
+- signal/series-a-funding-announcement
+- signal/series-b-funding-announcement
+
+## Audience
+
+_Cross-ref `icp/...` or `persona/...`._
+
+- icp/post-series-a-b2b-saas
+- persona/head-of-revops
+
+## Channel
+
+_Cross-ref `medium/...`._
+
+- medium/founder-led-linkedin
+- medium/cold-email-personalized
+
+## Sequence
+
+1. Day 0: LinkedIn connect + congratulations note (no pitch).
+2. Day 3: Personalized email referencing the raise + a single relevant stack-replacement angle.
+3. Day 7: Follow-up with one proof point (cross-ref `proof/customer-x-replaced-three-tools`).
+4. Day 14: Break-up message.
+
+## Proof
+
+_Cross-ref `proof/...`._
+
+- proof/customer-x-replaced-three-tools
+- proof/14-day-time-to-first-workflow
+
+## Success metric
+
+Reply rate ≥ 12% on Day 3 email; meetings booked / 100 contacted ≥ 4.
+
+## Owner
+
+Outbound AE pod lead.
+
+## Variants
+
+- Same play, swap LinkedIn for warm intro when one exists (cross-ref `medium/exec-warm-intro`).
+EOF
+)" \
+  --commit-message "Add funding-triggered outbound play"
+```
+
+## Add a proof point
+
+Keep `proof/` atomic — one metric or quote per file:
+
+```bash
+cargo-ai context runtime write \
+  --path proof/14-day-time-to-first-workflow.md \
+  --content "$(cat <<'EOF'
+---
+title: 14-day time to first workflow
+description: New customers ship their first production workflow within 14 days of signing.
+---
+
+## Type
+
+metric
+
+## Content
+
+Across the last 24 customers (Q1–Q3), median time from contract signature to first production workflow run was 14 days; P90 was 27 days.
+
+## Source
+
+Internal customer success tracker, pulled 2025-10-15.
+
+## Client
+
+_Aggregate across customers — no single cross-ref._
+
+## Context
+
+Used to counter the "another tool we'll never deploy" objection. Pairs well with `objection/we-already-have-clay`.
+
+## Use cases
+
+- objection/we-already-have-clay
+- play/funding-triggered-outbound
+- Sales decks, slide 9 ("Time to value")
+EOF
+)" \
+  --commit-message "Add 14-day time-to-first-workflow proof point"
+```
+
+## Edit a single line
+
+```bash
+cargo-ai context runtime edit \
+  --path global/positioning.md \
+  --old-string "We help RevOps automate workflows." \
+  --new-string "We help RevOps run AI-native GTM motions." \
+  --commit-message "Refresh positioning one-liner"
+```
+
+## Delete a line from a file
+
+```bash
+# Read first to copy the exact line (whitespace must match!)
+cargo-ai context runtime read --path persona/head-of-revops.md --start-line 18 --end-line 22
+
+cargo-ai context runtime edit \
+  --path persona/head-of-revops.md \
+  --old-string "- Stitching together 6 point tools that don't talk to each other\n" \
+  --new-string "" \
+  --commit-message "Drop outdated pain point on Head of RevOps"
+```
+
+## Rename / move an entry
+
+There's no `rename` command. Use `write` at the new path, then delete the old file with `execute` + push by overwriting it with `write` after removing — easier path: write the new file, then leave the old one in place until you're ready to remove it (a follow-up `write` with empty content is not supported; deletes happen via the GitHub UI or via `execute` followed by a manual commit step in the Cargo app).
+
+For most renames, the cleanest sequence is:
+
+1. `write` the new file at the new path.
+2. Update every file that cross-refs the old slug — find them with `execute` + `grep`:
+   ```bash
+   cargo-ai context runtime execute --command grep --args '["-r","-l","persona/old-slug","."]'
+   ```
+3. For each match, `edit` the cross-ref `persona/old-slug` → `persona/new-slug`.
+4. Delete the stale file via the GitHub UI (file the rename in a single PR if your context repo uses PR review).
+
+## Verify your work
+
+```bash
+# Confirm the file is in place
+cargo-ai context runtime read --path persona/head-of-revops.md
+
+# Confirm it lights up in the graph and its cross-refs resolve
+cargo-ai context graph get | jq '.nodes[] | select(.slug == "persona/head-of-revops")'
+```

--- a/cargo-context/references/examples/graph-queries.md
+++ b/cargo-context/references/examples/graph-queries.md
@@ -1,0 +1,118 @@
+# Knowledge-graph queries
+
+`cargo-ai context graph get` returns the typed knowledge graph derived from every markdown/MDX file in the context repo. Pipe it through `jq` to slice it.
+
+> Field names below (`nodes`, `slug`, `frontmatter`, `links`, etc.) are illustrative — run `cargo-ai context graph get | jq '. | keys'` once at the top of your session to confirm the exact shape for your workspace before scripting against it.
+
+## List every node
+
+```bash
+cargo-ai context graph get | jq -r '.nodes[].slug' | sort
+```
+
+## Count entries per domain
+
+```bash
+cargo-ai context graph get \
+  | jq -r '.nodes[].slug' \
+  | awk -F/ '{print $1}' \
+  | sort | uniq -c | sort -rn
+```
+
+## Find every persona
+
+```bash
+cargo-ai context graph get \
+  | jq '.nodes[] | select(.slug | startswith("persona/")) | {slug, title: .frontmatter.title}'
+```
+
+## Find personas that link to a specific play
+
+```bash
+cargo-ai context graph get \
+  | jq --arg target "play/funding-triggered-outbound" '
+      .nodes[]
+      | select(.slug | startswith("persona/"))
+      | select((.links // []) | index($target))
+      | .slug'
+```
+
+## Find dangling cross-references
+
+Nodes referencing a `domain/slug` that doesn't exist in the graph:
+
+```bash
+cargo-ai context graph get | jq '
+  . as $g
+  | ($g.nodes | map(.slug)) as $slugs
+  | $g.nodes[]
+  | .slug as $from
+  | (.links // [])[]
+  | select(. as $t | ($slugs | index($t)) | not)
+  | {from: $from, missing: .}
+'
+```
+
+## Find plays with no proof attached
+
+```bash
+cargo-ai context graph get | jq '
+  .nodes[]
+  | select(.slug | startswith("play/"))
+  | select(
+      ((.links // []) | map(select(startswith("proof/"))) | length) == 0
+    )
+  | .slug
+'
+```
+
+## Find objections with no proof point
+
+Same pattern as plays, scoped to objections:
+
+```bash
+cargo-ai context graph get | jq '
+  .nodes[]
+  | select(.slug | startswith("objection/"))
+  | select(
+      ((.links // []) | map(select(startswith("proof/"))) | length) == 0
+    )
+  | {slug, title: .frontmatter.title}
+'
+```
+
+## Show inbound references to a node
+
+Which files cross-ref `proof/14-day-time-to-first-workflow`?
+
+```bash
+cargo-ai context graph get | jq --arg target "proof/14-day-time-to-first-workflow" '
+  .nodes[]
+  | select((.links // []) | index($target))
+  | .slug
+'
+```
+
+## Audit frontmatter completeness
+
+Files missing `title` or `description`:
+
+```bash
+cargo-ai context graph get | jq '
+  .nodes[]
+  | select((.frontmatter.title // "") == "" or (.frontmatter.description // "") == "")
+  | .slug
+'
+```
+
+## Snapshot the graph to disk
+
+Useful before a bulk edit so you can diff before/after:
+
+```bash
+cargo-ai context graph get > /tmp/graph.before.json
+# ...make edits via context runtime write/edit...
+cargo-ai context graph get > /tmp/graph.after.json
+diff <(jq -r '.nodes[].slug' /tmp/graph.before.json | sort) \
+     <(jq -r '.nodes[].slug' /tmp/graph.after.json | sort)
+```

--- a/cargo-context/references/troubleshooting.md
+++ b/cargo-context/references/troubleshooting.md
@@ -1,0 +1,78 @@
+# Troubleshooting
+
+Common errors and solutions for `cargo-ai context` commands.
+
+## General
+
+**`{"errorMessage": "..."}`**
+All failed commands exit non-zero and return an error JSON. Read the `errorMessage` for the specific issue.
+
+**`Unauthorized` / `403`**
+Your API token may lack the required permissions, or the workspace's context repository isn't configured. Verify with `cargo-ai whoami`; if a context repo hasn't been set up for the workspace, ask an admin (or do it via the Cargo app under workspace settings).
+
+## Runtime — browse / read
+
+**Path not found**
+The path does not exist in the runtime sandbox. Use `cargo-ai context runtime browse --path <parent>` to confirm the file layout before reading. Paths are relative to the repo root, no leading slash (`persona/vp-sales.md`, not `/persona/vp-sales.md`).
+
+**Out-of-range lines**
+`--start-line` and `--end-line` are 1-indexed and inclusive on both ends. If they fall outside the file's line count the read fails. Read the file without a range first to confirm length, or omit one end (e.g. only `--start-line`) to read to EOF.
+
+## Runtime — write
+
+**Push fails / commit not appearing**
+`write` pushes to the context repo's default branch. Pushes fail if the configured GitHub connector lost permissions or the branch was deleted/renamed. Verify the connector via `cargo-ai connection connector list` and check the default-branch setting in the Cargo app under workspace settings.
+
+**No `_template.md` for the domain**
+Some workspaces customize their context repo. If a domain doesn't ship a template, browse the domain (`cargo-ai context runtime browse --path <domain>`) and model the new file after an existing entry.
+
+**Frontmatter rejected by `context graph get`**
+Both `title` and `description` are required on every file. Empty or missing values cause the graph builder to skip the node and any cross-refs to it will dangle. Always set both before pushing.
+
+## Runtime — edit
+
+**`--old-string` not found**
+`--old-string` did not match any substring in the file. Whitespace must match exactly — escape newlines (`\n`) where present, and watch for trailing spaces. Read the file first and copy the substring verbatim.
+
+**`--old-string` matches more than once**
+`edit` requires the match to be unique. Add enough surrounding context to make the match unique (extend with the line before or after), or do multiple targeted edits in sequence.
+
+**Edits not appearing in GitHub**
+`edit` commits and pushes; `execute` does **not** push. If you ran a shell command that modified files (e.g. `sed -i`, redirecting into a file), the change stays in the ephemeral sandbox and is discarded. Use `write` or `edit` for any change that should land in git.
+
+## Runtime — execute
+
+**Command output is empty / unexpected**
+The runtime sandbox starts clean for each call; mutations from prior `execute` calls are not preserved between invocations. Don't rely on state across `execute` runs — chain operations in a single `--command` (e.g. via `sh -c`) instead.
+
+**Side effects not pushed**
+By design, `execute` does not commit. Use `execute` for inspection (`grep`, `ls`, `find`, counting, validation); use `write`/`edit` for any persistent change.
+
+**Argument escaping**
+`--args` is a **JSON array** of strings, not a shell-quoted list. Wrap the whole thing in single quotes so the shell doesn't mangle the JSON:
+
+```bash
+# Correct
+cargo-ai context runtime execute --command grep --args '["-r","vp-sales","."]'
+
+# Wrong — shell will eat the inner double quotes
+cargo-ai context runtime execute --command grep --args ["-r","vp-sales","."]
+```
+
+## Graph
+
+**Stale results after writes**
+`graph get` is cached. After a series of writes, expect a short delay before the graph reflects them. Re-run after a few seconds, or restructure logic so it does not depend on immediately-fresh graph data.
+
+**Broken cross-references**
+If a file references `domain/slug` and that target doesn't exist, the link won't resolve in the graph. Use `cargo-ai context runtime browse --path <domain>` to verify the target exists before writing the reference, or pipe `graph get` through `jq` to enumerate dangling refs (see `references/examples/graph-queries.md`).
+
+## When to escalate
+
+If the CLI errors and `--help` plus the notes above don't get you unstuck — **file a workspace management report** rather than retrying silently. See [`cargo-workspace-management/SKILL.md`](../../cargo-workspace-management/SKILL.md) (Reports section).
+
+```bash
+cargo-ai workspaceManagement report create \
+  --title "context <subcommand> fails with <errorMessage>" \
+  --description "Ran: cargo-ai context ...   Got: {...errorMessage...}   Expected: ..."
+```


### PR DESCRIPTION
## Summary
This PR adds comprehensive documentation for the `cargo-context` SKILL, which provides CLI-based access to inspect and edit a workspace's git-backed context repository (GTM knowledge base) and its runtime sandbox.

## Key Changes
- **New SKILL definition** (`cargo-context/SKILL.md`): Complete reference documentation including:
  - Overview of the context system (runtime sandbox and knowledge graph subdomains)
  - Prerequisites and setup instructions for `@cargo-ai/cli`
  - Quick reference for all available commands
  - Detailed usage examples for runtime operations:
    - Browsing and reading context files
    - Writing new files with proper frontmatter
    - Editing existing files with string replacement
    - Executing shell commands in the sandbox
  - Knowledge graph querying and usage
  - Context repository structure conventions:
    - 12 domain types (global, icp, persona, jtbd, alternative, client, insight, medium, objection, play, proof, signal)
    - File naming and frontmatter requirements
    - Cross-reference conventions
  - Workflow guidance for adding new entries
  - Help command reference

## Notable Details
- Documentation emphasizes the distinction between `write`/`edit` operations (which push to the default branch) and `execute` operations (which do not persist)
- Includes references to the canonical example repository (`getcargohq/cargo-workspaces`) for learning domain conventions
- Provides practical examples for common tasks like creating personas, editing positioning, and querying the knowledge graph
- All commands documented with their full syntax and JSON argument formats

https://claude.ai/code/session_01PKvn9ZH6dFjYjeVQFHSsKt