### PR TITLE
Document orchestration query analytics and refactor storage terminology

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ Load for a specific CLI domain.
 
 | Skill                                                                 | Load when you need to…                                                                             |
 | --------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| [`cargo-orchestration`](#cargo-orchestration)                         | Execute actions, run workflows, trigger batches, chat with agents, query your data warehouse       |
+| [`cargo-orchestration`](#cargo-orchestration)                         | Execute actions, run workflows, trigger batches, chat with agents, query storage with SQL          |
 | [`cargo-analytics`](#cargo-analytics)                                 | Download run results, export segment data, monitor error rates and metrics                         |
 | [`cargo-billing`](#cargo-billing)                                     | Check credit usage, view subscription details, track costs per workflow or connector               |
 | [`cargo-storage`](#cargo-storage)                                     | Inspect or modify data models, columns, datasets, and relationships                                |
@@ -150,8 +150,8 @@ Load for a specific CLI domain.
 - `cargo-gtm` delegates to capability skills via relative paths (`../cargo-orchestration/...`). Capability skills never reference `cargo-gtm`.
 - `cargo-workspace-management` provides auth context for every skill — set it up first.
 - `cargo-storage`, `cargo-connection`, and `cargo-ai` are peer skills that supply UUIDs to `cargo-orchestration`. They don't depend on each other.
-- `cargo-context` is **orthogonal** to the workflow-execution flow. It touches the git-backed GTM knowledge base (markdown/MDX), not the data warehouse or workflow runs. Use it for capturing/editing the workspace's prose context — personas, plays, proof, objections, signals — and for inspecting the typed knowledge graph.
-- For SQL queries against the connected data warehouse, use `cargo-ai storage query execute "<sql>"` (tables as `<datasetSlug>.<modelSlug>`). Load `cargo-storage` to discover dataset and model slugs, and to fetch the DDL when you need column types or the SQL dialect.
+- `cargo-context` is **orthogonal** to the workflow-execution flow. It touches the git-backed GTM knowledge base (markdown/MDX), not storage or workflow runs. Use it for capturing/editing the workspace's prose context — personas, plays, proof, objections, signals — and for inspecting the typed knowledge graph.
+- For SQL queries against storage, use `cargo-ai storage query execute "<sql>"` (tables as `<datasetSlug>.<modelSlug>`). Load `cargo-storage` to discover dataset and model slugs, and to fetch the DDL when you need column types or the SQL dialect.
 - For SQL queries against orchestration runtime tables (`runs`, `batches`, `spans`, `records`) — error rates, per-node failures, time-series — use `cargo-ai orchestration query execute "<sql>"`. Workspace scoping is automatic; tables are referenced without a schema prefix.
 - Before building a workflow node graph, load `cargo-connection` to get `connectorUuid` and `actionSlug`.
 - Before executing a workflow that uses an agent node, load `cargo-ai` to get `agentUuid`.
@@ -193,13 +193,13 @@ Load for a specific CLI domain.
 
 ### cargo-orchestration
 
-**The execution hub.** Execute actions, run workflows, chat with AI agents, query your data warehouse, and fetch segment records.
+**The execution hub.** Execute actions, run workflows, chat with AI agents, query storage with SQL, and fetch segment records.
 
 **Critical rules:**
 
 - See the decision flowchart at the top of `cargo-orchestration/SKILL.md` for when to use `action execute` vs `run create` vs `batch create`.
 - Filter JSON uses `conjonction` (not `conjunction`) — breaks silently if misspelled.
-- Query the data warehouse with `cargo-ai storage query execute "<sql>"` using `<datasetSlug>.<modelSlug>` table names (e.g. `default.companies`). Run `cargo-ai storage model get-ddl <model-uuid>` for column types or SQL dialect.
+- Query storage with `cargo-ai storage query execute "<sql>"` using `<datasetSlug>.<modelSlug>` table names (e.g. `default.companies`). Run `cargo-ai storage model get-ddl <model-uuid>` for column types or SQL dialect.
 - Query orchestration runtime tables with `cargo-ai orchestration query execute "<sql>"` against `runs`, `batches`, `spans`, `records` (no schema prefix; workspace scoping is automatic).
 - All operations are async — poll or pass `--wait-until-finished`. See [Async polling](#async-polling).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,8 +150,9 @@ Load for a specific CLI domain.
 - `cargo-gtm` delegates to capability skills via relative paths (`../cargo-orchestration/...`). Capability skills never reference `cargo-gtm`.
 - `cargo-workspace-management` provides auth context for every skill — set it up first.
 - `cargo-storage`, `cargo-connection`, and `cargo-ai` are peer skills that supply UUIDs to `cargo-orchestration`. They don't depend on each other.
-- `cargo-context` is **orthogonal** to the workflow-execution flow. It touches the git-backed GTM knowledge base (markdown/MDX), not the system-of-record data warehouse or workflow runs. Use it for capturing/editing the workspace's prose context — personas, plays, proof, objections, signals — and for inspecting the typed knowledge graph.
-- For SQL queries against the system-of-record, use `cargo-ai storage query execute "<sql>"` (tables as `<datasetSlug>.<modelSlug>`). Load `cargo-storage` to discover dataset and model slugs, and to fetch the DDL when you need column types or the SQL dialect.
+- `cargo-context` is **orthogonal** to the workflow-execution flow. It touches the git-backed GTM knowledge base (markdown/MDX), not the data warehouse or workflow runs. Use it for capturing/editing the workspace's prose context — personas, plays, proof, objections, signals — and for inspecting the typed knowledge graph.
+- For SQL queries against the connected data warehouse, use `cargo-ai storage query execute "<sql>"` (tables as `<datasetSlug>.<modelSlug>`). Load `cargo-storage` to discover dataset and model slugs, and to fetch the DDL when you need column types or the SQL dialect.
+- For SQL queries against orchestration runtime tables (`runs`, `batches`, `spans`, `records`) — error rates, per-node failures, time-series — use `cargo-ai orchestration query execute "<sql>"`. Workspace scoping is automatic; tables are referenced without a schema prefix.
 - Before building a workflow node graph, load `cargo-connection` to get `connectorUuid` and `actionSlug`.
 - Before executing a workflow that uses an agent node, load `cargo-ai` to get `agentUuid`.
 - After runs complete, load `cargo-analytics` to download results or measure performance. **For action output retrieval, prefer `cargo-ai orchestration run download-outputs` over `run download` — the former returns a signed-URL CSV/JSON of just the output node's data.**
@@ -198,7 +199,8 @@ Load for a specific CLI domain.
 
 - See the decision flowchart at the top of `cargo-orchestration/SKILL.md` for when to use `action execute` vs `run create` vs `batch create`.
 - Filter JSON uses `conjonction` (not `conjunction`) — breaks silently if misspelled.
-- Query the system-of-record with `cargo-ai storage query execute "<sql>"` using `<datasetSlug>.<modelSlug>` table names (e.g. `default.companies`). Run `cargo-ai storage model get-ddl <model-uuid>` for column types or SQL dialect.
+- Query the data warehouse with `cargo-ai storage query execute "<sql>"` using `<datasetSlug>.<modelSlug>` table names (e.g. `default.companies`). Run `cargo-ai storage model get-ddl <model-uuid>` for column types or SQL dialect.
+- Query orchestration runtime tables with `cargo-ai orchestration query execute "<sql>"` against `runs`, `batches`, `spans`, `records` (no schema prefix; workspace scoping is automatic).
 - All operations are async — poll or pass `--wait-until-finished`. See [Async polling](#async-polling).
 
 **References:** `cargo-orchestration/SKILL.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ Load for a specific CLI domain.
 
 | Skill                                                                 | Load when you need to…                                                                             |
 | --------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| [`cargo-orchestration`](#cargo-orchestration)                         | Execute actions, run workflows, trigger batches, chat with agents, query storage with SQL          |
+| [`cargo-orchestration`](#cargo-orchestration)                         | Execute actions, run workflows, trigger batches, chat with agents, query orchestration with SQL (ClickHouse) |
 | [`cargo-analytics`](#cargo-analytics)                                 | Download run results, export segment data, monitor error rates and metrics                         |
 | [`cargo-billing`](#cargo-billing)                                     | Check credit usage, view subscription details, track costs per workflow or connector               |
 | [`cargo-storage`](#cargo-storage)                                     | Inspect or modify data models, columns, datasets, and relationships                                |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,7 @@ Load for a specific CLI domain.
 | [`cargo-orchestration`](#cargo-orchestration)                         | Execute actions, run workflows, trigger batches, chat with agents, query orchestration with SQL (ClickHouse) |
 | [`cargo-analytics`](#cargo-analytics)                                 | Download run results, export segment data, monitor error rates and metrics                         |
 | [`cargo-billing`](#cargo-billing)                                     | Check credit usage, view subscription details, track costs per workflow or connector               |
-| [`cargo-storage`](#cargo-storage)                                     | Inspect or modify data models, columns, datasets, and relationships                                |
+| [`cargo-storage`](#cargo-storage)                                     | Inspect or modify data models, columns, datasets, and relationships; query workspace storage with SQL |
 | [`cargo-connection`](#cargo-connection)                               | Manage connector authentication, discover available integrations and their actions                 |
 | [`cargo-ai`](#cargo-ai)                                               | Create and configure agents, upload files for RAG, manage MCP servers                              |
 | [`cargo-context`](#cargo-context)                                     | Browse/read/write/edit the workspace's git-backed GTM context repo, run commands in its runtime sandbox, inspect the knowledge graph |
@@ -193,14 +193,14 @@ Load for a specific CLI domain.
 
 ### cargo-orchestration
 
-**The execution hub.** Execute actions, run workflows, chat with AI agents, query storage with SQL, and fetch segment records.
+**The execution hub.** Execute actions, run workflows, chat with AI agents, query orchestration runtime tables (`runs`/`batches`/`spans`/`records`) with SQL, and fetch segment records.
 
 **Critical rules:**
 
 - See the decision flowchart at the top of `cargo-orchestration/SKILL.md` for when to use `action execute` vs `run create` vs `batch create`.
 - Filter JSON uses `conjonction` (not `conjunction`) — breaks silently if misspelled.
-- Query storage with `cargo-ai storage query execute "<sql>"` using `<datasetSlug>.<modelSlug>` table names (e.g. `default.companies`). Run `cargo-ai storage model get-ddl <model-uuid>` for column types or SQL dialect.
-- Query orchestration runtime tables with `cargo-ai orchestration query execute "<sql>"` against `runs`, `batches`, `spans`, `records` (no schema prefix; workspace scoping is automatic).
+- Query orchestration runtime tables (ClickHouse) with `cargo-ai orchestration query execute "<sql>"` against `runs`, `batches`, `spans`, `records` (no schema prefix; workspace scoping is automatic).
+- For SQL against workspace storage (Companies, Contacts, …), use `cargo-ai storage query execute "<sql>"` — documented in `cargo-storage`.
 - All operations are async — poll or pass `--wait-until-finished`. See [Async polling](#async-polling).
 
 **References:** `cargo-orchestration/SKILL.md`
@@ -237,11 +237,12 @@ Load for a specific CLI domain.
 
 ### cargo-storage
 
-**Data schema management.** Inspect models, create or update columns, navigate datasets, understand workspace data structure.
+**Data schema management and SQL queries.** Inspect models, create or update columns, navigate datasets, understand workspace data structure, and run SQL against workspace storage.
 
 **Critical rules:**
 
-- Query via `cargo-ai storage query execute "<sql>"` (or `storage query download "<sql>"` for full exports) using `<datasetSlug>.<modelSlug>` table names (e.g. `default.companies`). `model get-ddl` is optional — useful for column types and SQL dialect.
+- Query via `cargo-ai storage query execute "<sql>"` (or `storage query download --query "<sql>"` for full exports) using `<datasetSlug>.<modelSlug>` table names (e.g. `default.companies`). `model get-ddl` is optional — useful for column types and SQL dialect.
+- For SQL against orchestration runtime tables (`runs`/`batches`/`spans`/`records`), use `cargo-ai orchestration query execute "<sql>"` — documented in `cargo-orchestration`.
 - For advanced record queries (filtering, sorting, pagination), use `segmentation segment fetch` from `cargo-orchestration`.
 
 **References:** `cargo-storage/SKILL.md`

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -275,7 +275,7 @@ See **intent signal**. In cargo recipes, signals are the basis for segment const
 The activity of finding companies or people matching ICP criteria. Cheapest at-scale options: `salesNavigator.searchLeads` (0.02 cred/record), `salesNavigator.searchAccounts` (0.05). For investor / funding / complex filters: `peopleDataLabs.queryCompanies` (3). For local SMBs: `serper.searchPlaces` (1).
 
 **system of record (SoR)**
-A connected data warehouse (BigQuery, Snowflake, etc.) that Cargo can query via SQL. Queried with `cargo-ai storage query execute "<sql>"` (or `storage query download "<sql>"` for full exports), which references tables as `<datasetSlug>.<modelSlug>` (e.g. `default.companies`). For SoR docs, use `cargo-ai system-of-record client get-documentation`. Distinct from the **context repository** (markdown/MDX knowledge base, not relational data).
+A connected data warehouse (BigQuery, Snowflake, etc.) that Cargo can query via SQL. Queried with `cargo-ai storage query execute "<sql>"` (or `storage query download --query "<sql>"` for full exports), which references tables as `<datasetSlug>.<modelSlug>` (e.g. `default.companies`). Use `cargo-ai storage model get-ddl <model-uuid>` for column types and SQL dialect. Distinct from the **context repository** (markdown/MDX knowledge base, not relational data) and from the **orchestration query** surface (`cargo-ai orchestration query execute`, which targets the `runs`/`batches`/`spans`/`records` runtime tables).
 
 ---
 

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -85,7 +85,7 @@ An authenticated instance of an integration. For example, a specific HubSpot acc
 The UUID of a specific authenticated connector. Required for `kind: "connector"` nodes in workflow graphs and for filtering billing metrics.
 
 **context**
-The workspace's git-backed knowledge base of typed markdown/MDX files capturing GTM truth: company narrative, ICPs, personas, JTBDs, plays, proof, objections, signals, mediums, alternatives, clients, insights. Read and written by both humans and agents. Managed via `cargo-context` (`cargo-ai context runtime ...` and `cargo-ai context graph ...`). Distinct from the **system of record** (a connected data warehouse queried with SQL) and from agent **memories** (per-agent mem0 entries).
+The workspace's git-backed knowledge base of typed markdown/MDX files capturing GTM truth: company narrative, ICPs, personas, JTBDs, plays, proof, objections, signals, mediums, alternatives, clients, insights. Read and written by both humans and agents. Managed via `cargo-context` (`cargo-ai context runtime ...` and `cargo-ai context graph ...`). Distinct from the **system of record** (Cargo storage queried with SQL) and from agent **memories** (per-agent mem0 entries).
 
 **context repository**
 The GitHub repository that backs the workspace's context. Files in this repo follow strict conventions: `kebab-case.md` filenames, YAML frontmatter with required `title` and `description`, and `domain/slug` cross-refs without `.md`. The canonical example is [`getcargohq/cargo-workspaces`](https://github.com/getcargohq/cargo-workspaces). See `cargo-context/references/conventions.md` for the full domain list and per-domain templates.
@@ -275,7 +275,7 @@ See **intent signal**. In cargo recipes, signals are the basis for segment const
 The activity of finding companies or people matching ICP criteria. Cheapest at-scale options: `salesNavigator.searchLeads` (0.02 cred/record), `salesNavigator.searchAccounts` (0.05). For investor / funding / complex filters: `peopleDataLabs.queryCompanies` (3). For local SMBs: `serper.searchPlaces` (1).
 
 **system of record (SoR)**
-A connected data warehouse (BigQuery, Snowflake, etc.) that Cargo can query via SQL. Queried with `cargo-ai storage query execute "<sql>"` (or `storage query download --query "<sql>"` for full exports), which references tables as `<datasetSlug>.<modelSlug>` (e.g. `default.companies`). Use `cargo-ai storage model get-ddl <model-uuid>` for column types and SQL dialect. Distinct from the **context repository** (markdown/MDX knowledge base, not relational data) and from the **orchestration query** surface (`cargo-ai orchestration query execute`, which targets the `runs`/`batches`/`spans`/`records` runtime tables).
+Cargo's storage layer, backed by a customer-connected database (BigQuery, Snowflake, etc.) that Cargo queries via SQL. Queried with `cargo-ai storage query execute "<sql>"` (or `storage query download --query "<sql>"` for full exports), which references tables as `<datasetSlug>.<modelSlug>` (e.g. `default.companies`). Use `cargo-ai storage model get-ddl <model-uuid>` for column types and SQL dialect. Distinct from the **context repository** (markdown/MDX knowledge base, not relational data) and from the **orchestration query** surface (`cargo-ai orchestration query execute`, which targets the `runs`/`batches`/`spans`/`records` runtime tables).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Load when you need the syntax for a specific CLI domain.
 
 | Domain            | What the agent learns                                                                                                                                              |
 | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Orchestration** | Execute single actions, chain actions into workflows, trigger batches across segments, poll async operations, query storage with SQL, fetch segment data |
-| **Storage**       | Inspect models and their DDL, create columns, navigate datasets, set relationships between models                                                                  |
+| **Orchestration** | Execute single actions, chain actions into workflows, trigger batches across segments, poll async operations, query orchestration runtime tables (`runs`/`batches`/`spans`/`records`) with SQL, fetch segment data |
+| **Storage**       | Inspect models and their DDL, create columns, navigate datasets, set relationships between models, query workspace storage with SQL                              |
 | **Connection**    | Authenticate connectors, discover integration actions and their slugs across 120+ integrations                                                                     |
 | **AI**            | Create and configure agents, upload files for RAG, connect MCP servers, inspect agent memories                                                                     |
 | **Context**       | Browse, read, write, and edit the workspace's git-backed context repo (markdown/MDX GTM knowledge base); run shell commands in its runtime sandbox; inspect the knowledge graph |

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Load when you need the syntax for a specific CLI domain.
 
 | Domain            | What the agent learns                                                                                                                                              |
 | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Orchestration** | Execute single actions, chain actions into workflows, trigger batches across segments, poll async operations, query the data warehouse with SQL, fetch segment data |
+| **Orchestration** | Execute single actions, chain actions into workflows, trigger batches across segments, poll async operations, query storage with SQL, fetch segment data |
 | **Storage**       | Inspect models and their DDL, create columns, navigate datasets, set relationships between models                                                                  |
 | **Connection**    | Authenticate connectors, discover integration actions and their slugs across 120+ integrations                                                                     |
 | **AI**            | Create and configure agents, upload files for RAG, connect MCP servers, inspect agent memories                                                                     |
@@ -67,7 +67,7 @@ Prompts that route through `cargo-gtm`:
 - *"Show me everyone hiring data engineers AND running Snowflake."* → `recipes/tech-intent.md`
 - *"What ICP signals differentiate our Closed-Won deals?"* → `recipes/icp-discovery.md`
 
-For ad-hoc CLI work (modify a model, list connectors, query the warehouse, edit the GTM context repo), load the matching capability skill directly.
+For ad-hoc CLI work (modify a model, list connectors, query storage, edit the GTM context repo), load the matching capability skill directly.
 
 ## Use cases
 
@@ -91,7 +91,7 @@ The agent can construct a full node graph — fetching the connector UUID, looki
 
 > "Build and run a workflow that enriches company domains with waterfall and writes the result back to the Companies model."
 
-### Query your data warehouse
+### Query storage with SQL
 
 The agent fetches the DDL first (to get the exact table name), then writes and executes the SQL query.
 

--- a/cargo-analytics/SKILL.md
+++ b/cargo-analytics/SKILL.md
@@ -60,7 +60,7 @@ cargo-ai segmentation segment download --model-uuid <uuid> --filter '{"conjoncti
 - `run get-metrics` / `run count` — workflow-scoped, predefined aggregations. Best when you already have a `workflowUuid`.
 - `orchestration query execute` — ad-hoc SQL across the entire workspace (`runs`, `batches`, `spans`, `records`). Best for cross-workflow analytics, per-node breakdowns, and time-series.
 - `run download` / `run download-outputs` — per-record output retrieval.
-- `segment download` / `storage query execute` — warehouse data (Companies, Contacts, …).
+- `segment download` / `storage query execute` — storage data (Companies, Contacts, …).
 
 ## Workflow run metrics
 

--- a/cargo-analytics/SKILL.md
+++ b/cargo-analytics/SKILL.md
@@ -51,8 +51,16 @@ cargo-ai storage model list                # all models (uuid, name, slug)
 cargo-ai orchestration run get-metrics --workflow-uuid <uuid>
 cargo-ai orchestration run download --workflow-uuid <uuid> --is-finished
 cargo-ai orchestration run count --workflow-uuid <uuid> --statuses error
+cargo-ai orchestration query execute "SELECT status, count() FROM runs GROUP BY status"
 cargo-ai segmentation segment download --model-uuid <uuid> --filter '{"conjonction":"and","groups":[]}'
 ```
+
+**Picking the right command:**
+
+- `run get-metrics` / `run count` — workflow-scoped, predefined aggregations. Best when you already have a `workflowUuid`.
+- `orchestration query execute` — ad-hoc SQL across the entire workspace (`runs`, `batches`, `spans`, `records`). Best for cross-workflow analytics, per-node breakdowns, and time-series.
+- `run download` / `run download-outputs` — per-record output retrieval.
+- `segment download` / `storage query execute` — warehouse data (Companies, Contacts, …).
 
 ## Workflow run metrics
 
@@ -81,6 +89,32 @@ cargo-ai orchestration run count --workflow-uuid <uuid> --batch-uuid <uuid>
 ```
 
 Supports: `--statuses`, `--batch-uuid`, `--release-uuid`, `--is-finished`, `--created-after`, `--created-before`, `--record-id`, `--record-title`.
+
+For cross-workflow analytics or shapes that `run count` doesn't expose (per-node failure breakdowns, p95 durations, error rate over time), use `orchestration query execute` — see the [Ad-hoc execution analytics](#ad-hoc-execution-analytics-orchestration-query) section.
+
+## Ad-hoc execution analytics (`orchestration query`)
+
+Run SQL against orchestration runtime tables — `runs`, `batches`, `spans`, `records` — for analytics that the canned metrics commands don't cover. Tables are referenced without a schema prefix; workspace scoping is automatic. See `cargo-orchestration/references/queries.md` for schemas and limits.
+
+```bash
+# Error rate across the workspace in the last day
+cargo-ai orchestration query execute \
+  "SELECT countIf(status='error') / count() AS error_rate FROM runs WHERE created_at > now() - INTERVAL 1 DAY"
+
+# Failed runs per workflow this week
+cargo-ai orchestration query execute \
+  "SELECT workflow_uuid, count() AS errors FROM runs WHERE status='error' AND created_at > now() - INTERVAL 7 DAY GROUP BY workflow_uuid ORDER BY errors DESC"
+
+# Per-node failure counts (last 24h)
+cargo-ai orchestration query execute \
+  "SELECT node_slug, count() AS failures FROM spans WHERE execution_status='error' AND execution_started_at > now() - INTERVAL 1 DAY GROUP BY node_slug ORDER BY failures DESC"
+
+# Credit spend by workflow this month
+cargo-ai orchestration query execute \
+  "SELECT workflow_uuid, sum(credits_used_count) AS credits FROM batches WHERE created_at >= toStartOfMonth(now()) GROUP BY workflow_uuid ORDER BY credits DESC"
+```
+
+Read-only and capped: 30s execution time, 10 000 result rows, 10 000 000 rows scanned. Narrow with a `created_at`/`execution_started_at` predicate to stay under the row-scan cap.
 
 ## Downloading run results
 

--- a/cargo-gtm/recipes/icp-discovery.md
+++ b/cargo-gtm/recipes/icp-discovery.md
@@ -12,7 +12,7 @@ Use this skill when the user wants to **discover their real ICP from conversion 
 
 Most prospecting skills are forward-looking ("find me X" / "enrich Y"). ICP discovery is **backward-looking** — analyze what worked, then turn the patterns into filters. It exercises:
 
-- The connected data warehouse (`cargo-ai storage query execute`) to pull Won/Lost segments.
+- Storage (`cargo-ai storage query execute`) to pull Won/Lost segments.
 - Cargo native enrichments (`enrichBusinessFirmographics`, `…Technographics`, `…FundingAndAcquisitions`) to fill comparison signals.
 - LLM analysis (`anthropic.instruct`) to surface non-obvious patterns.
 
@@ -29,7 +29,7 @@ cargo-ai storage dataset list
 cargo-ai storage model get-ddl <deals-model-uuid>
 ```
 
-Pull both segments via `storage query execute` (tables are referenced as `<datasetSlug>.<modelSlug>` and rewritten to the warehouse table under the hood):
+Pull both segments via `storage query execute` (tables are referenced as `<datasetSlug>.<modelSlug>` and rewritten to the underlying storage table under the hood):
 
 ```bash
 # Closed-Won deals + their associated companies

--- a/cargo-gtm/recipes/icp-discovery.md
+++ b/cargo-gtm/recipes/icp-discovery.md
@@ -12,7 +12,7 @@ Use this skill when the user wants to **discover their real ICP from conversion 
 
 Most prospecting skills are forward-looking ("find me X" / "enrich Y"). ICP discovery is **backward-looking** — analyze what worked, then turn the patterns into filters. It exercises:
 
-- The system-of-record (`cargo-ai storage query execute`) to pull Won/Lost segments.
+- The connected data warehouse (`cargo-ai storage query execute`) to pull Won/Lost segments.
 - Cargo native enrichments (`enrichBusinessFirmographics`, `…Technographics`, `…FundingAndAcquisitions`) to fill comparison signals.
 - LLM analysis (`anthropic.instruct`) to surface non-obvious patterns.
 

--- a/cargo-orchestration/SKILL.md
+++ b/cargo-orchestration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cargo-orchestration
-description: Interact with the Cargo platform via CLI. Use when the user wants to execute an action, run a workflow, trigger a batch, message an AI agent, query a data warehouse, fetch segment records, or inspect a model schema.
+description: Interact with the Cargo platform via CLI. Use when the user wants to execute an action, run a workflow, trigger a batch, message an AI agent, query storage with SQL, fetch segment records, or inspect a model schema.
 license: MIT
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 metadata:
@@ -36,7 +36,7 @@ Need to run something?
 > `references/agents.md` — AI agent chat examples
 > `references/nodes.md` — full node creation guide (kinds, native actions, expressions, validation, routing)
 > `references/templates.md` — pre-built workflow templates
-> `references/queries.md` — `storage query` (data warehouse) and `orchestration query` (spans/runs/batches/records) SQL examples
+> `references/queries.md` — `storage query` (workspace storage) and `orchestration query` (spans/runs/batches/records) SQL examples
 > `references/segments.md` — segment fetch and filter examples
 > `references/response-shapes.md` — full JSON response structures
 > `references/filter-syntax.md` — complete filter condition reference
@@ -103,7 +103,7 @@ cargo-ai orchestration batch create --workflow-uuid <uuid> --data '{"kind":"segm
 cargo-ai ai message create --chat-uuid <uuid> --parts '[{"type":"text","text":"..."}]'
 
 # Data
-cargo-ai storage query execute "SELECT * FROM default.companies LIMIT 10"          # warehouse / SoR
+cargo-ai storage query execute "SELECT * FROM default.companies LIMIT 10"          # workspace storage
 cargo-ai orchestration query execute "SELECT count() FROM runs WHERE status='error'" # orchestration history (spans, runs, batches, records)
 cargo-ai segmentation segment fetch --model-uuid <uuid> --filter '{"conjonction":"and","groups":[]}' --fetching-limit 100
 cargo-ai storage model get-ddl <model-uuid>
@@ -248,9 +248,9 @@ cargo-ai orchestration record get-metrics --workflow-uuid <uuid>
 cargo-ai orchestration record cancel --workflow-uuid <uuid> --ids record-id-1,record-id-2
 ```
 
-## Query the data warehouse (storage query)
+## Query storage with SQL (storage query)
 
-Run SQL against your connected data warehouse with `storage query execute`. Tables are referenced as `<datasetSlug>.<modelSlug>` and rewritten to the underlying warehouse table under the hood — no DDL lookup needed for the table name.
+Run SQL against workspace storage with `storage query execute`. Tables are referenced as `<datasetSlug>.<modelSlug>` and rewritten to the underlying storage table under the hood — no DDL lookup needed for the table name.
 
 ```bash
 cargo-ai storage query execute \

--- a/cargo-orchestration/SKILL.md
+++ b/cargo-orchestration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cargo-orchestration
-description: Interact with the Cargo platform via CLI. Use when the user wants to execute an action, run a workflow, trigger a batch, message an AI agent, query storage with SQL, fetch segment records, or inspect a model schema.
+description: Interact with the Cargo platform via CLI. Use when the user wants to execute an action, run a workflow, trigger a batch, message an AI agent, query orchestration runtime tables (runs/batches/spans/records) with SQL, fetch segment records, or inspect a model schema.
 license: MIT
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 metadata:
@@ -36,7 +36,7 @@ Need to run something?
 > `references/agents.md` — AI agent chat examples
 > `references/nodes.md` — full node creation guide (kinds, native actions, expressions, validation, routing)
 > `references/templates.md` — pre-built workflow templates
-> `references/queries.md` — `storage query` (workspace storage) and `orchestration query` (spans/runs/batches/records) SQL examples
+> `references/queries.md` — `orchestration query execute` (ClickHouse: runs/batches/spans/records) SQL examples. For `storage query` (workspace storage), see the `cargo-storage` skill.
 > `references/segments.md` — segment fetch and filter examples
 > `references/response-shapes.md` — full JSON response structures
 > `references/filter-syntax.md` — complete filter condition reference
@@ -103,10 +103,9 @@ cargo-ai orchestration batch create --workflow-uuid <uuid> --data '{"kind":"segm
 cargo-ai ai message create --chat-uuid <uuid> --parts '[{"type":"text","text":"..."}]'
 
 # Data
-cargo-ai storage query execute "SELECT * FROM default.companies LIMIT 10"          # workspace storage
-cargo-ai orchestration query execute "SELECT count() FROM runs WHERE status='error'" # orchestration history (spans, runs, batches, records)
+cargo-ai orchestration query execute "SELECT count() FROM runs WHERE status='error'" # ClickHouse: spans, runs, batches, records
 cargo-ai segmentation segment fetch --model-uuid <uuid> --filter '{"conjonction":"and","groups":[]}' --fetching-limit 100
-cargo-ai storage model get-ddl <model-uuid>
+# For SQL against workspace storage (Companies, Contacts, …), see the cargo-storage skill: `storage query execute`
 ```
 
 ## Polling async operations
@@ -248,18 +247,6 @@ cargo-ai orchestration record get-metrics --workflow-uuid <uuid>
 cargo-ai orchestration record cancel --workflow-uuid <uuid> --ids record-id-1,record-id-2
 ```
 
-## Query storage with SQL (storage query)
-
-Run SQL against workspace storage with `storage query execute`. Tables are referenced as `<datasetSlug>.<modelSlug>` and rewritten to the underlying storage table under the hood — no DDL lookup needed for the table name.
-
-```bash
-cargo-ai storage query execute \
-  "SELECT name, domain FROM default.companies LIMIT 10"
-# → { "rows": [...] } on success; non-zero exit with { "errorMessage": "..." } on error
-```
-
-Get column slugs from `storage column list --model-uuid <uuid>` (or run `storage model get-ddl <model-uuid>` for full schema). Page through large result sets with `LIMIT` / `OFFSET` directly in the SQL. For full exports, use `cargo-ai storage query download --query "<sql>"`. See `references/queries.md` for WHERE clauses, aggregations, joins, date queries, and pagination.
-
 ## Query orchestration history (orchestration query)
 
 Run SQL against orchestration runtime tables — `spans`, `runs`, `batches`, `records` — with `orchestration query execute`. Use this for ad-hoc analytics on workflow execution (error rates, throughput, slowest nodes) without the workflow-scoped filters of `run get-metrics` / `run count`.
@@ -328,5 +315,4 @@ cargo-ai orchestration template list --help
 cargo-ai orchestration node validate --help
 cargo-ai ai message create --help
 cargo-ai orchestration query execute --help
-cargo-ai storage query execute --help
 ```

--- a/cargo-orchestration/SKILL.md
+++ b/cargo-orchestration/SKILL.md
@@ -36,7 +36,7 @@ Need to run something?
 > `references/agents.md` — AI agent chat examples
 > `references/nodes.md` — full node creation guide (kinds, native actions, expressions, validation, routing)
 > `references/templates.md` — pre-built workflow templates
-> `references/queries.md` — `storage query execute` SQL examples
+> `references/queries.md` — `storage query` (data warehouse) and `orchestration query` (spans/runs/batches/records) SQL examples
 > `references/segments.md` — segment fetch and filter examples
 > `references/response-shapes.md` — full JSON response structures
 > `references/filter-syntax.md` — complete filter condition reference
@@ -71,7 +71,6 @@ cargo-ai ai template list                  # all AI agent templates (slug, name,
 cargo-ai storage model list                # all models (uuid, name, slug, columns)
 cargo-ai storage dataset list              # all datasets
 cargo-ai segmentation segment list         # all segments (uuid, name, modelUuid)
-cargo-ai system-of-record sor list         # all systems of record
 cargo-ai connection connector list         # all connectors
 ```
 
@@ -104,7 +103,8 @@ cargo-ai orchestration batch create --workflow-uuid <uuid> --data '{"kind":"segm
 cargo-ai ai message create --chat-uuid <uuid> --parts '[{"type":"text","text":"..."}]'
 
 # Data
-cargo-ai storage query execute "SELECT * FROM default.companies LIMIT 10"
+cargo-ai storage query execute "SELECT * FROM default.companies LIMIT 10"          # warehouse / SoR
+cargo-ai orchestration query execute "SELECT count() FROM runs WHERE status='error'" # orchestration history (spans, runs, batches, records)
 cargo-ai segmentation segment fetch --model-uuid <uuid> --filter '{"conjonction":"and","groups":[]}' --fetching-limit 100
 cargo-ai storage model get-ddl <model-uuid>
 ```
@@ -248,7 +248,7 @@ cargo-ai orchestration record get-metrics --workflow-uuid <uuid>
 cargo-ai orchestration record cancel --workflow-uuid <uuid> --ids record-id-1,record-id-2
 ```
 
-## Query the system of record
+## Query the data warehouse (storage query)
 
 Run SQL against your connected data warehouse with `storage query execute`. Tables are referenced as `<datasetSlug>.<modelSlug>` and rewritten to the underlying warehouse table under the hood — no DDL lookup needed for the table name.
 
@@ -258,7 +258,19 @@ cargo-ai storage query execute \
 # → { "rows": [...] } on success; non-zero exit with { "errorMessage": "..." } on error
 ```
 
-Get column slugs from `storage column list --model-uuid <uuid>` (or run `storage model get-ddl <model-uuid>` for full schema). Page through large result sets with `LIMIT` / `OFFSET` directly in the SQL. For full exports, use `cargo-ai storage query download "<sql>"`. For SoR docs, use `cargo-ai system-of-record client get-documentation`. See `references/queries.md` for WHERE clauses, aggregations, joins, date queries, and pagination.
+Get column slugs from `storage column list --model-uuid <uuid>` (or run `storage model get-ddl <model-uuid>` for full schema). Page through large result sets with `LIMIT` / `OFFSET` directly in the SQL. For full exports, use `cargo-ai storage query download --query "<sql>"`. See `references/queries.md` for WHERE clauses, aggregations, joins, date queries, and pagination.
+
+## Query orchestration history (orchestration query)
+
+Run SQL against orchestration runtime tables — `spans`, `runs`, `batches`, `records` — with `orchestration query execute`. Use this for ad-hoc analytics on workflow execution (error rates, throughput, slowest nodes) without the workflow-scoped filters of `run get-metrics` / `run count`.
+
+```bash
+cargo-ai orchestration query execute "SELECT count() FROM runs WHERE status = 'error'"
+cargo-ai orchestration query execute "SELECT status, count() FROM batches GROUP BY status"
+cargo-ai orchestration query execute "SELECT * FROM spans ORDER BY execution_started_at DESC LIMIT 10"
+```
+
+Tables are referenced without a schema prefix — just `spans`, `runs`, `batches`, or `records`. Workspace scoping is applied automatically. The query is read-only; DDL, table functions, dictionary accessors, and introspection are denied. See `references/queries.md` for the schemas, example queries, and limits.
 
 ## Fetch segment data
 
@@ -315,5 +327,6 @@ cargo-ai orchestration run create --help
 cargo-ai orchestration template list --help
 cargo-ai orchestration node validate --help
 cargo-ai ai message create --help
-cargo-ai system-of-record client --help
+cargo-ai orchestration query execute --help
+cargo-ai storage query execute --help
 ```

--- a/cargo-orchestration/references/queries.md
+++ b/cargo-orchestration/references/queries.md
@@ -1,166 +1,12 @@
-# Query examples
+# Orchestration query examples
 
-Two read-only SQL surfaces are exposed by the CLI:
+Run SQL against orchestration runtime tables — `runs`, `batches`, `spans`, `records` — with `cargo-ai orchestration query execute`. Use this for ad-hoc analytics on workflow execution (error rates, throughput, slowest nodes, per-node failure breakdowns) without the workflow-scoped filters of `run get-metrics` / `run count`.
 
-- **`cargo-ai storage query execute "<sql>"`** — workspace storage (Companies, Contacts, Deals…). Tables are referenced as `<datasetSlug>.<modelSlug>`.
-- **`cargo-ai orchestration query execute "<sql>"`** — orchestration runtime tables (`spans`, `runs`, `batches`, `records`) for execution analytics. Tables are referenced by short name; workspace scoping is applied automatically.
+The backing store is ClickHouse; queries are read-only and exit non-zero with `{"errorMessage": "..."}` on error.
 
-Both are read-only, exit non-zero on error with `{"errorMessage": "..."}`, and return `{"rows": [...]}` on success.
+> For SQL against workspace storage (Companies, Contacts, Deals…), use `cargo-ai storage query execute "<sql>"` — documented in the `cargo-storage` skill (`references/examples/queries.md`).
 
----
-
-## Storage queries
-
-Run SQL against workspace storage with `cargo-ai storage query execute`. Tables are referenced as `<datasetSlug>.<modelSlug>` and rewritten to the underlying storage table under the hood. No DDL lookup is required for the table name — just use the dataset and model slugs.
-
-For column slugs, run `cargo-ai storage column list --model-uuid <uuid>` or `cargo-ai storage model get-ddl <model-uuid>` (the DDL also shows column types and the SQL dialect).
-
-### Basic query flow
-
-```bash
-# 1. Discover the dataset slug and the model slug
-cargo-ai storage dataset list   # → datasets[].slug (e.g. "default")
-cargo-ai storage model list     # → models[].slug   (e.g. "companies")
-
-# 2. Query using <datasetSlug>.<modelSlug> as the table name
-cargo-ai storage query execute \
-  "SELECT name, domain, employee_count FROM default.companies LIMIT 10"
-```
-
-Success response:
-
-```json
-{
-  "rows": [
-    { "name": "Acme Corp", "domain": "acme.com", "employee_count": 500 },
-    { "name": "Globex", "domain": "globex.com", "employee_count": 1200 }
-  ]
-}
-```
-
-Failed commands exit non-zero with `{"errorMessage": "..."}` (or `{"reason": "clientNotFound"|"unknown"}`). See the error handling section below.
-
-### Query with WHERE clauses
-
-```bash
-# Filter by a column
-cargo-ai storage query execute \
-  "SELECT name, domain FROM default.companies WHERE employee_count > 100"
-
-# Multiple conditions
-cargo-ai storage query execute \
-  "SELECT name, domain, revenue FROM default.companies WHERE employee_count > 100 AND country = 'US'"
-
-# LIKE for partial matches
-cargo-ai storage query execute \
-  "SELECT name, domain FROM default.companies WHERE name LIKE '%tech%'"
-
-# NULL checks
-cargo-ai storage query execute \
-  "SELECT name, domain FROM default.companies WHERE email IS NOT NULL"
-```
-
-### Aggregation queries
-
-```bash
-# Count records
-cargo-ai storage query execute \
-  "SELECT COUNT(*) as total FROM default.companies"
-
-# Group by with counts
-cargo-ai storage query execute \
-  "SELECT country, COUNT(*) as count FROM default.companies GROUP BY country ORDER BY count DESC"
-
-# Sum and average
-cargo-ai storage query execute \
-  "SELECT country, SUM(revenue) as total_revenue, AVG(employee_count) as avg_employees FROM default.companies GROUP BY country"
-```
-
-### Pagination
-
-Page through large result sets with SQL `LIMIT` and `OFFSET` clauses. Always include an `ORDER BY` so pages are stable across calls.
-
-```bash
-# First page
-cargo-ai storage query execute \
-  "SELECT * FROM default.companies ORDER BY name LIMIT 100 OFFSET 0"
-
-# Second page
-cargo-ai storage query execute \
-  "SELECT * FROM default.companies ORDER BY name LIMIT 100 OFFSET 100"
-```
-
-### Download full results
-
-For exporting full result sets to a file, use `storage query download`:
-
-```bash
-cargo-ai storage query download \
-  --query "SELECT name, domain, employee_count, revenue FROM default.companies ORDER BY revenue DESC"
-
-# Choose the format (csv default, parquet supported)
-cargo-ai storage query download \
-  --query "SELECT * FROM default.companies" --format parquet
-```
-
-### Query across multiple models
-
-Just join on `<datasetSlug>.<modelSlug>` table references:
-
-```bash
-cargo-ai storage query execute \
-  "SELECT c.name, c.domain, d.stage, d.amount FROM default.companies c JOIN default.deals d ON c._id = d.company_id WHERE d.amount > 10000"
-```
-
-### Common table expressions
-
-```bash
-cargo-ai storage query execute \
-  "WITH recent AS (SELECT * FROM default.companies WHERE created_at >= CURRENT_DATE - INTERVAL '30' DAY) SELECT count(*) FROM recent"
-```
-
-### Date queries
-
-```bash
-# Records created in the last 30 days
-cargo-ai storage query execute \
-  "SELECT name, created_at FROM default.companies WHERE created_at >= DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY)"
-
-# Records in a specific range
-cargo-ai storage query execute \
-  "SELECT name, created_at FROM default.companies WHERE created_at BETWEEN '2025-01-01' AND '2025-03-31'"
-```
-
-### Subqueries
-
-```bash
-# Companies with above-average employee count
-cargo-ai storage query execute \
-  "SELECT name, employee_count FROM default.companies WHERE employee_count > (SELECT AVG(employee_count) FROM default.companies)"
-```
-
-### Error handling
-
-If a query fails, the command exits non-zero. Failure shapes:
-
-```json
-{ "errorMessage": "Table not found: default.nonexistent" }
-```
-
-```json
-{ "reason": "clientNotFound" }
-```
-
-Common causes:
-- Wrong dataset or model slug → re-check with `storage dataset list` and `storage model list`
-- Syntax error → check SQL syntax for your storage SQL dialect (BigQuery vs Snowflake) — `storage model get-ddl` reports `language`
-- `clientNotFound` → no storage client is configured for this workspace
-
----
-
-## Orchestration queries — execution analytics
-
-Run SQL against orchestration runtime tables with `cargo-ai orchestration query execute`. Use this when `run get-metrics` and `run count` are too coarse — for cross-workflow analytics, per-node failure breakdowns, time-series, or arbitrary joins between executions and the records they processed.
+## Basic query flow
 
 ```bash
 cargo-ai orchestration query execute \
@@ -175,7 +21,7 @@ Success response:
 }
 ```
 
-### Tables
+## Tables
 
 Tables are referenced **without** a schema prefix. The query engine scopes every read to your workspace automatically.
 
@@ -188,7 +34,7 @@ Tables are referenced **without** a schema prefix. The query engine scopes every
 
 Common columns: `workspace_uuid`, `workflow_uuid`, `batch_uuid`, `release_uuid`, `status`, `created_at`, `updated_at`, `finished_at`, `credits_used_count`. See the migration files in `apps/backend/src/domains/orchestration/migrations/` for the full schema.
 
-### Example queries
+## Example queries
 
 ```bash
 # Error rate across the whole workspace
@@ -228,7 +74,7 @@ cargo-ai orchestration query execute \
    ORDER BY credits DESC"
 ```
 
-### Common table expressions
+## Common table expressions
 
 ```bash
 cargo-ai orchestration query execute \
@@ -236,21 +82,21 @@ cargo-ai orchestration query execute \
    SELECT status, count() FROM recent GROUP BY status"
 ```
 
-### Limits and restrictions
+## Limits and restrictions
 
 Orchestration queries run as a read-only ClickHouse user with per-query caps:
 
-| Limit                | Value     |
-| -------------------- | --------- |
-| `max_execution_time` | 30s       |
-| `max_result_rows`    | 10 000    |
+| Limit                | Value      |
+| -------------------- | ---------- |
+| `max_execution_time` | 30s        |
+| `max_result_rows`    | 10 000     |
 | `max_rows_to_read`   | 10 000 000 |
-| `max_columns_to_read` | 50       |
-| `max_subquery_depth` | 5         |
+| `max_columns_to_read`| 50         |
+| `max_subquery_depth` | 5          |
 
 DDL, introspection functions, table functions (`merge`, `cluster`, `remote`, `url`, `s3`, `file`, …), dictionary accessors, and the query cache are all denied. Wrap heavy aggregations in time filters (`created_at > now() - INTERVAL N DAY`) to stay under the row-scan cap.
 
-### Error handling
+## Error handling
 
 ```json
 { "errorMessage": "Code: 158. Memory limit exceeded ..." }
@@ -260,16 +106,3 @@ Common causes:
 - Scanned too many rows → narrow the time window with a `created_at`/`execution_started_at` predicate
 - Forbidden function (e.g. `system.tables`, `cluster()`, `url()`) → use only `SELECT` against the four tables above
 - Too many result rows → add a `LIMIT` or aggregate before returning
-
----
-
-## Discovery commands
-
-```bash
-# Discover storage datasets and models
-cargo-ai storage dataset list
-cargo-ai storage model list
-
-# Get the schema of a single model (column types and SQL dialect)
-cargo-ai storage model get-ddl <model-uuid>
-```

--- a/cargo-orchestration/references/queries.md
+++ b/cargo-orchestration/references/queries.md
@@ -2,16 +2,16 @@
 
 Two read-only SQL surfaces are exposed by the CLI:
 
-- **`cargo-ai storage query execute "<sql>"`** — your connected data warehouse (Companies, Contacts, Deals…). Tables are referenced as `<datasetSlug>.<modelSlug>`.
+- **`cargo-ai storage query execute "<sql>"`** — workspace storage (Companies, Contacts, Deals…). Tables are referenced as `<datasetSlug>.<modelSlug>`.
 - **`cargo-ai orchestration query execute "<sql>"`** — orchestration runtime tables (`spans`, `runs`, `batches`, `records`) for execution analytics. Tables are referenced by short name; workspace scoping is applied automatically.
 
 Both are read-only, exit non-zero on error with `{"errorMessage": "..."}`, and return `{"rows": [...]}` on success.
 
 ---
 
-## Storage queries — data warehouse
+## Storage queries
 
-Run SQL against your connected data warehouse with `cargo-ai storage query execute`. Tables are referenced as `<datasetSlug>.<modelSlug>` and rewritten to the underlying warehouse table under the hood. No DDL lookup is required for the table name — just use the dataset and model slugs.
+Run SQL against workspace storage with `cargo-ai storage query execute`. Tables are referenced as `<datasetSlug>.<modelSlug>` and rewritten to the underlying storage table under the hood. No DDL lookup is required for the table name — just use the dataset and model slugs.
 
 For column slugs, run `cargo-ai storage column list --model-uuid <uuid>` or `cargo-ai storage model get-ddl <model-uuid>` (the DDL also shows column types and the SQL dialect).
 
@@ -153,8 +153,8 @@ If a query fails, the command exits non-zero. Failure shapes:
 
 Common causes:
 - Wrong dataset or model slug → re-check with `storage dataset list` and `storage model list`
-- Syntax error → check SQL syntax for your warehouse dialect (BigQuery vs Snowflake) — `storage model get-ddl` reports `language`
-- `clientNotFound` → no warehouse client is configured for this workspace
+- Syntax error → check SQL syntax for your storage SQL dialect (BigQuery vs Snowflake) — `storage model get-ddl` reports `language`
+- `clientNotFound` → no storage client is configured for this workspace
 
 ---
 
@@ -266,7 +266,7 @@ Common causes:
 ## Discovery commands
 
 ```bash
-# Discover warehouse datasets and models
+# Discover storage datasets and models
 cargo-ai storage dataset list
 cargo-ai storage model list
 

--- a/cargo-orchestration/references/queries.md
+++ b/cargo-orchestration/references/queries.md
@@ -1,10 +1,21 @@
-# Storage query examples
+# Query examples
+
+Two read-only SQL surfaces are exposed by the CLI:
+
+- **`cargo-ai storage query execute "<sql>"`** — your connected data warehouse (Companies, Contacts, Deals…). Tables are referenced as `<datasetSlug>.<modelSlug>`.
+- **`cargo-ai orchestration query execute "<sql>"`** — orchestration runtime tables (`spans`, `runs`, `batches`, `records`) for execution analytics. Tables are referenced by short name; workspace scoping is applied automatically.
+
+Both are read-only, exit non-zero on error with `{"errorMessage": "..."}`, and return `{"rows": [...]}` on success.
+
+---
+
+## Storage queries — data warehouse
 
 Run SQL against your connected data warehouse with `cargo-ai storage query execute`. Tables are referenced as `<datasetSlug>.<modelSlug>` and rewritten to the underlying warehouse table under the hood. No DDL lookup is required for the table name — just use the dataset and model slugs.
 
 For column slugs, run `cargo-ai storage column list --model-uuid <uuid>` or `cargo-ai storage model get-ddl <model-uuid>` (the DDL also shows column types and the SQL dialect).
 
-## Basic query flow
+### Basic query flow
 
 ```bash
 # 1. Discover the dataset slug and the model slug
@@ -29,7 +40,7 @@ Success response:
 
 Failed commands exit non-zero with `{"errorMessage": "..."}` (or `{"reason": "clientNotFound"|"unknown"}`). See the error handling section below.
 
-## Query with WHERE clauses
+### Query with WHERE clauses
 
 ```bash
 # Filter by a column
@@ -49,7 +60,7 @@ cargo-ai storage query execute \
   "SELECT name, domain FROM default.companies WHERE email IS NOT NULL"
 ```
 
-## Aggregation queries
+### Aggregation queries
 
 ```bash
 # Count records
@@ -65,7 +76,7 @@ cargo-ai storage query execute \
   "SELECT country, SUM(revenue) as total_revenue, AVG(employee_count) as avg_employees FROM default.companies GROUP BY country"
 ```
 
-## Pagination
+### Pagination
 
 Page through large result sets with SQL `LIMIT` and `OFFSET` clauses. Always include an `ORDER BY` so pages are stable across calls.
 
@@ -79,16 +90,20 @@ cargo-ai storage query execute \
   "SELECT * FROM default.companies ORDER BY name LIMIT 100 OFFSET 100"
 ```
 
-## Download full results
+### Download full results
 
 For exporting full result sets to a file, use `storage query download`:
 
 ```bash
 cargo-ai storage query download \
-  "SELECT name, domain, employee_count, revenue FROM default.companies ORDER BY revenue DESC"
+  --query "SELECT name, domain, employee_count, revenue FROM default.companies ORDER BY revenue DESC"
+
+# Choose the format (csv default, parquet supported)
+cargo-ai storage query download \
+  --query "SELECT * FROM default.companies" --format parquet
 ```
 
-## Query across multiple models
+### Query across multiple models
 
 Just join on `<datasetSlug>.<modelSlug>` table references:
 
@@ -97,26 +112,14 @@ cargo-ai storage query execute \
   "SELECT c.name, c.domain, d.stage, d.amount FROM default.companies c JOIN default.deals d ON c._id = d.company_id WHERE d.amount > 10000"
 ```
 
-## Common table expressions
+### Common table expressions
 
 ```bash
 cargo-ai storage query execute \
   "WITH recent AS (SELECT * FROM default.companies WHERE created_at >= CURRENT_DATE - INTERVAL '30' DAY) SELECT count(*) FROM recent"
 ```
 
-## Get SoR documentation
-
-Useful to understand available tables and warehouse-specific SQL dialect conventions.
-
-```bash
-# List all systems of record
-cargo-ai system-of-record sor list
-
-# Get documentation for a specific SoR (returns plain text, not JSON)
-cargo-ai system-of-record client get-documentation <slug>
-```
-
-## Date queries
+### Date queries
 
 ```bash
 # Records created in the last 30 days
@@ -128,7 +131,7 @@ cargo-ai storage query execute \
   "SELECT name, created_at FROM default.companies WHERE created_at BETWEEN '2025-01-01' AND '2025-03-31'"
 ```
 
-## Subqueries
+### Subqueries
 
 ```bash
 # Companies with above-average employee count
@@ -136,7 +139,7 @@ cargo-ai storage query execute \
   "SELECT name, employee_count FROM default.companies WHERE employee_count > (SELECT AVG(employee_count) FROM default.companies)"
 ```
 
-## Error handling
+### Error handling
 
 If a query fails, the command exits non-zero. Failure shapes:
 
@@ -151,4 +154,122 @@ If a query fails, the command exits non-zero. Failure shapes:
 Common causes:
 - Wrong dataset or model slug → re-check with `storage dataset list` and `storage model list`
 - Syntax error → check SQL syntax for your warehouse dialect (BigQuery vs Snowflake) — `storage model get-ddl` reports `language`
-- `clientNotFound` → no SoR client is configured for this workspace; verify with `system-of-record sor list`
+- `clientNotFound` → no warehouse client is configured for this workspace
+
+---
+
+## Orchestration queries — execution analytics
+
+Run SQL against orchestration runtime tables with `cargo-ai orchestration query execute`. Use this when `run get-metrics` and `run count` are too coarse — for cross-workflow analytics, per-node failure breakdowns, time-series, or arbitrary joins between executions and the records they processed.
+
+```bash
+cargo-ai orchestration query execute \
+  "SELECT count() FROM runs WHERE status = 'error'"
+```
+
+Success response:
+
+```json
+{
+  "rows": [{ "count()": 42 }]
+}
+```
+
+### Tables
+
+Tables are referenced **without** a schema prefix. The query engine scopes every read to your workspace automatically.
+
+| Table     | Use it for                                                                 |
+| --------- | -------------------------------------------------------------------------- |
+| `runs`    | Per-record workflow executions (status, timing, executions array, batch)   |
+| `batches` | Batch-level rows: counts (`runs_count`, `failed_runs_count`), credit usage |
+| `spans`   | Flattened per-node execution rows (one row per node execution)             |
+| `records` | Materialized view over `runs` keyed by record id                           |
+
+Common columns: `workspace_uuid`, `workflow_uuid`, `batch_uuid`, `release_uuid`, `status`, `created_at`, `updated_at`, `finished_at`, `credits_used_count`. See the migration files in `apps/backend/src/domains/orchestration/migrations/` for the full schema.
+
+### Example queries
+
+```bash
+# Error rate across the whole workspace
+cargo-ai orchestration query execute \
+  "SELECT countIf(status='error') / count() AS error_rate FROM runs WHERE created_at > now() - INTERVAL 1 DAY"
+
+# Errors per workflow over the last week
+cargo-ai orchestration query execute \
+  "SELECT workflow_uuid, count() AS errors FROM runs WHERE status='error' AND created_at > now() - INTERVAL 7 DAY GROUP BY workflow_uuid ORDER BY errors DESC"
+
+# Batch status breakdown
+cargo-ai orchestration query execute \
+  "SELECT status, count() FROM batches GROUP BY status"
+
+# Slowest node executions in the last hour
+cargo-ai orchestration query execute \
+  "SELECT node_slug, node_kind, dateDiff('second', execution_started_at, execution_finished_at) AS duration_s
+   FROM spans
+   WHERE execution_finished_at > now() - INTERVAL 1 HOUR
+   ORDER BY duration_s DESC
+   LIMIT 20"
+
+# Per-node failure counts
+cargo-ai orchestration query execute \
+  "SELECT node_slug, count() AS failures
+   FROM spans
+   WHERE execution_status='error' AND execution_started_at > now() - INTERVAL 1 DAY
+   GROUP BY node_slug
+   ORDER BY failures DESC"
+
+# Credit spend by workflow this month
+cargo-ai orchestration query execute \
+  "SELECT workflow_uuid, sum(credits_used_count) AS credits
+   FROM batches
+   WHERE created_at >= toStartOfMonth(now())
+   GROUP BY workflow_uuid
+   ORDER BY credits DESC"
+```
+
+### Common table expressions
+
+```bash
+cargo-ai orchestration query execute \
+  "WITH recent AS (SELECT * FROM runs WHERE created_at > now() - INTERVAL 1 DAY)
+   SELECT status, count() FROM recent GROUP BY status"
+```
+
+### Limits and restrictions
+
+Orchestration queries run as a read-only ClickHouse user with per-query caps:
+
+| Limit                | Value     |
+| -------------------- | --------- |
+| `max_execution_time` | 30s       |
+| `max_result_rows`    | 10 000    |
+| `max_rows_to_read`   | 10 000 000 |
+| `max_columns_to_read` | 50       |
+| `max_subquery_depth` | 5         |
+
+DDL, introspection functions, table functions (`merge`, `cluster`, `remote`, `url`, `s3`, `file`, …), dictionary accessors, and the query cache are all denied. Wrap heavy aggregations in time filters (`created_at > now() - INTERVAL N DAY`) to stay under the row-scan cap.
+
+### Error handling
+
+```json
+{ "errorMessage": "Code: 158. Memory limit exceeded ..." }
+```
+
+Common causes:
+- Scanned too many rows → narrow the time window with a `created_at`/`execution_started_at` predicate
+- Forbidden function (e.g. `system.tables`, `cluster()`, `url()`) → use only `SELECT` against the four tables above
+- Too many result rows → add a `LIMIT` or aggregate before returning
+
+---
+
+## Discovery commands
+
+```bash
+# Discover warehouse datasets and models
+cargo-ai storage dataset list
+cargo-ai storage model list
+
+# Get the schema of a single model (column types and SQL dialect)
+cargo-ai storage model get-ddl <model-uuid>
+```

--- a/cargo-orchestration/references/response-shapes.md
+++ b/cargo-orchestration/references/response-shapes.md
@@ -387,53 +387,6 @@ Poll until `status` is `success`, `error`, or `cancelled`. Note: `batch get` als
 
 The table name in the DDL follows the pattern `datasets_{datasetSlug}.models_{modelSlug}` (or `datasets_{datasetSlug}__models_{modelSlug}` in BigQuery dataset-scoped). Use this name in SoR queries.
 
-## cargo-ai storage query execute
-
-Tables are referenced as `<datasetSlug>.<modelSlug>` and rewritten to the underlying storage table under the hood.
-
-**Success:**
-
-```json
-{
-  "rows": [
-    { "name": "Acme Corp", "domain": "acme.com", "employee_count": 500 },
-    { "name": "Globex", "domain": "globex.com", "employee_count": 1200 }
-  ]
-}
-```
-
-**Failure (non-zero exit):**
-
-```json
-{ "errorMessage": "Table not found: default.nonexistent" }
-```
-
-```json
-{ "reason": "clientNotFound" }
-```
-
-```json
-{ "reason": "unknown" }
-```
-
-## cargo-ai storage query download
-
-Used for full exports. Same table-naming convention as `storage query execute` (`<datasetSlug>.<modelSlug>`). Pass the SQL via `--query`; the response is a signed URL.
-
-**Success:**
-
-```json
-{
-  "url": "https://signed-url-to-csv-or-parquet-file"
-}
-```
-
-**Failure (non-zero exit):**
-
-```json
-{ "errorMessage": "Table not found: default.nonexistent" }
-```
-
 ## cargo-ai orchestration query execute
 
 Tables (`spans`, `runs`, `batches`, `records`) are referenced without a schema prefix; workspace scoping is applied automatically.

--- a/cargo-orchestration/references/response-shapes.md
+++ b/cargo-orchestration/references/response-shapes.md
@@ -418,15 +418,13 @@ Tables are referenced as `<datasetSlug>.<modelSlug>` and rewritten to the underl
 
 ## cargo-ai storage query download
 
-Used for full exports. Same table-naming convention as `storage query execute` (`<datasetSlug>.<modelSlug>`).
+Used for full exports. Same table-naming convention as `storage query execute` (`<datasetSlug>.<modelSlug>`). Pass the SQL via `--query`; the response is a signed URL.
 
 **Success:**
 
 ```json
 {
-  "rows": [
-    { "name": "Acme Corp", "domain": "acme.com", "employee_count": 500 }
-  ]
+  "url": "https://signed-url-to-csv-or-parquet-file"
 }
 ```
 
@@ -436,9 +434,30 @@ Used for full exports. Same table-naming convention as `storage query execute` (
 { "errorMessage": "Table not found: default.nonexistent" }
 ```
 
-## cargo-ai system-of-record client get-documentation
+## cargo-ai orchestration query execute
 
-**Returns plain text (not JSON).** This is the only CLI command that does not return JSON. The output is the SoR documentation string which may include markdown formatting.
+Tables (`spans`, `runs`, `batches`, `records`) are referenced without a schema prefix; workspace scoping is applied automatically.
+
+**Success:**
+
+```json
+{
+  "rows": [
+    { "status": "success", "count()": 1248 },
+    { "status": "error",   "count()": 42 }
+  ]
+}
+```
+
+**Failure (non-zero exit):**
+
+```json
+{ "errorMessage": "Code: 60. Table orchestration.unknown doesn't exist" }
+```
+
+```json
+{ "errorMessage": "Code: 158. Memory limit exceeded ..." }
+```
 
 ## cargo-ai orchestration release list
 

--- a/cargo-orchestration/references/response-shapes.md
+++ b/cargo-orchestration/references/response-shapes.md
@@ -389,7 +389,7 @@ The table name in the DDL follows the pattern `datasets_{datasetSlug}.models_{mo
 
 ## cargo-ai storage query execute
 
-Tables are referenced as `<datasetSlug>.<modelSlug>` and rewritten to the underlying warehouse table under the hood.
+Tables are referenced as `<datasetSlug>.<modelSlug>` and rewritten to the underlying storage table under the hood.
 
 **Success:**
 

--- a/cargo-orchestration/references/troubleshooting.md
+++ b/cargo-orchestration/references/troubleshooting.md
@@ -37,10 +37,21 @@ Common errors and recovery steps for `cargo-orchestration` commands.
 | Symptom                                                   | Cause                                  | Fix                                                                                                |
 | --------------------------------------------------------- | -------------------------------------- | -------------------------------------------------------------------------------------------------- |
 | `errorMessage` with "Table not found"                     | Wrong dataset or model slug            | Verify with `storage dataset list` and `storage model list`. Tables are `<datasetSlug>.<modelSlug>` |
-| `errorMessage` with syntax error                          | SQL dialect mismatch                   | Check whether your SoR is BigQuery, Snowflake, etc. and adjust syntax accordingly                  |
-| `reason: "clientNotFound"`                                | No SoR client configured               | Verify the connection is active; try `system-of-record sor list` to check status                   |
+| `errorMessage` with syntax error                          | SQL dialect mismatch                   | Check whether your warehouse is BigQuery, Snowflake, etc. and adjust syntax accordingly. `storage model get-ddl` reports `language` |
+| `reason: "clientNotFound"`                                | No warehouse client configured         | Verify the workspace has an active warehouse connection                                            |
 | Query returns empty `rows`                                | Filter too restrictive, or wrong model | Try a broader query first (`SELECT * FROM <dataset>.<model> LIMIT 5`)                              |
 | Column not found                                          | Wrong column slug                      | Run `storage column list --model-uuid <uuid>` to get exact slugs                                   |
+
+## Orchestration queries (`orchestration query execute`)
+
+| Symptom                                                  | Cause                                            | Fix                                                                                                            |
+| -------------------------------------------------------- | ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------- |
+| `errorMessage` with "Table … doesn't exist"              | Used a schema-prefixed name                      | Reference tables as `runs`, `batches`, `spans`, `records` — no schema prefix                                   |
+| `errorMessage: "Code: 158. Memory limit exceeded"`       | Scanned too many rows                            | Narrow the time window (`created_at > now() - INTERVAL N DAY`) or aggregate before returning                   |
+| `errorMessage: "Code: 159. Timeout exceeded"`            | Query took longer than 30s                       | Push more work into a `WHERE` filter or reduce columns selected                                                |
+| `errorMessage: "Code: 497. ... ACCESS_DENIED"`           | Used a forbidden function or table               | Only `SELECT` against `runs`/`batches`/`spans`/`records`; no table functions, dictionaries, or introspection   |
+| Query returns empty `rows`                               | Filter too restrictive, or wrong status enum     | Confirm enum values (`status` is `success`/`error`/`pending`/`running`/`cancelled`/…) and broaden the filter   |
+| Result truncated at 10 000 rows                          | Hit `max_result_rows` cap                        | Aggregate (`count`, `GROUP BY`) instead of returning raw rows, or paginate with `LIMIT` + `WHERE created_at`   |
 
 ## Debugging a workflow run
 
@@ -128,6 +139,7 @@ When a run reaches `status: "error"`, follow this sequence:
 | `filter` node stopped execution | Record didn't meet the filter condition | This is expected behavior, not an error — adjust the filter if needed |
 | Null reference in expression | Upstream node returned empty/null | Add a `filter` node before the failing node to skip records with missing data |
 | `errorMessage` on `storage query execute` | Wrong dataset/model slug or SQL syntax error | Verify slugs with `storage dataset list` / `storage model list`; check warehouse dialect (BigQuery vs Snowflake) |
+| `errorMessage` on `orchestration query execute` | Schema-prefixed table name or hit a query cap | Reference tables as `runs`/`batches`/`spans`/`records`; narrow the time window if you hit memory/row caps |
 
 4. **Re-trigger after fixing:** Create a new run with the corrected data or node config.
 5. **For systematic failures:** Use `run download --statuses error` to export all failed records, fix the data, then re-batch with `batch create --data '{"kind":"recordIds",...}'`.

--- a/cargo-orchestration/references/troubleshooting.md
+++ b/cargo-orchestration/references/troubleshooting.md
@@ -32,15 +32,7 @@ Common errors and recovery steps for `cargo-orchestration` commands.
 | `Chat not found`                                                     | Wrong UUID or chat was deleted           | Re-create with `chat create`                                               |
 | `Agent not found`                                                    | Wrong UUID                               | Re-run `agent list` to get current UUIDs                                   |
 
-## Storage queries (`storage query execute`)
-
-| Symptom                                                   | Cause                                  | Fix                                                                                                |
-| --------------------------------------------------------- | -------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `errorMessage` with "Table not found"                     | Wrong dataset or model slug            | Verify with `storage dataset list` and `storage model list`. Tables are `<datasetSlug>.<modelSlug>` |
-| `errorMessage` with syntax error                          | SQL dialect mismatch                   | Check whether your storage backend is BigQuery, Snowflake, etc. and adjust syntax accordingly. `storage model get-ddl` reports `language` |
-| `reason: "clientNotFound"`                                | No storage client configured           | Verify the workspace has an active storage connection                                              |
-| Query returns empty `rows`                                | Filter too restrictive, or wrong model | Try a broader query first (`SELECT * FROM <dataset>.<model> LIMIT 5`)                              |
-| Column not found                                          | Wrong column slug                      | Run `storage column list --model-uuid <uuid>` to get exact slugs                                   |
+> For `storage query execute` / `storage query download` troubleshooting, see the `cargo-storage` skill's `references/troubleshooting.md`.
 
 ## Orchestration queries (`orchestration query execute`)
 
@@ -138,7 +130,6 @@ When a run reaches `status: "error"`, follow this sequence:
 | Agent `maxSteps` exceeded | Agent ran too many tool calls | Increase `--max-steps` on the message, or simplify the agent's task |
 | `filter` node stopped execution | Record didn't meet the filter condition | This is expected behavior, not an error — adjust the filter if needed |
 | Null reference in expression | Upstream node returned empty/null | Add a `filter` node before the failing node to skip records with missing data |
-| `errorMessage` on `storage query execute` | Wrong dataset/model slug or SQL syntax error | Verify slugs with `storage dataset list` / `storage model list`; check storage SQL dialect (BigQuery vs Snowflake) |
 | `errorMessage` on `orchestration query execute` | Schema-prefixed table name or hit a query cap | Reference tables as `runs`/`batches`/`spans`/`records`; narrow the time window if you hit memory/row caps |
 
 4. **Re-trigger after fixing:** Create a new run with the corrected data or node config.

--- a/cargo-orchestration/references/troubleshooting.md
+++ b/cargo-orchestration/references/troubleshooting.md
@@ -37,8 +37,8 @@ Common errors and recovery steps for `cargo-orchestration` commands.
 | Symptom                                                   | Cause                                  | Fix                                                                                                |
 | --------------------------------------------------------- | -------------------------------------- | -------------------------------------------------------------------------------------------------- |
 | `errorMessage` with "Table not found"                     | Wrong dataset or model slug            | Verify with `storage dataset list` and `storage model list`. Tables are `<datasetSlug>.<modelSlug>` |
-| `errorMessage` with syntax error                          | SQL dialect mismatch                   | Check whether your warehouse is BigQuery, Snowflake, etc. and adjust syntax accordingly. `storage model get-ddl` reports `language` |
-| `reason: "clientNotFound"`                                | No warehouse client configured         | Verify the workspace has an active warehouse connection                                            |
+| `errorMessage` with syntax error                          | SQL dialect mismatch                   | Check whether your storage backend is BigQuery, Snowflake, etc. and adjust syntax accordingly. `storage model get-ddl` reports `language` |
+| `reason: "clientNotFound"`                                | No storage client configured           | Verify the workspace has an active storage connection                                              |
 | Query returns empty `rows`                                | Filter too restrictive, or wrong model | Try a broader query first (`SELECT * FROM <dataset>.<model> LIMIT 5`)                              |
 | Column not found                                          | Wrong column slug                      | Run `storage column list --model-uuid <uuid>` to get exact slugs                                   |
 
@@ -138,7 +138,7 @@ When a run reaches `status: "error"`, follow this sequence:
 | Agent `maxSteps` exceeded | Agent ran too many tool calls | Increase `--max-steps` on the message, or simplify the agent's task |
 | `filter` node stopped execution | Record didn't meet the filter condition | This is expected behavior, not an error — adjust the filter if needed |
 | Null reference in expression | Upstream node returned empty/null | Add a `filter` node before the failing node to skip records with missing data |
-| `errorMessage` on `storage query execute` | Wrong dataset/model slug or SQL syntax error | Verify slugs with `storage dataset list` / `storage model list`; check warehouse dialect (BigQuery vs Snowflake) |
+| `errorMessage` on `storage query execute` | Wrong dataset/model slug or SQL syntax error | Verify slugs with `storage dataset list` / `storage model list`; check storage SQL dialect (BigQuery vs Snowflake) |
 | `errorMessage` on `orchestration query execute` | Schema-prefixed table name or hit a query cap | Reference tables as `runs`/`batches`/`spans`/`records`; narrow the time window if you hit memory/row caps |
 
 4. **Re-trigger after fixing:** Create a new run with the corrected data or node config.

--- a/cargo-storage/SKILL.md
+++ b/cargo-storage/SKILL.md
@@ -1,22 +1,23 @@
 ---
 name: cargo-storage
-description: Manage models, datasets, columns, and relationships using the Cargo CLI. Use when the user wants to inspect or modify data models, create or update columns, list datasets, set model relationships, or understand the schema of their Cargo workspace.
+description: Manage models, datasets, columns, and relationships and query workspace storage with SQL using the Cargo CLI. Use when the user wants to inspect or modify data models, create or update columns, list datasets, set model relationships, understand the schema, or run SQL against storage.
 license: MIT
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 metadata:
   author: getcargo
-  version: "1.0"
+  version: "1.1"
 ---
 
 # Cargo CLI — Storage
 
-Data layer management: inspecting and modifying models, datasets, columns, relationships, and records.
+Data layer management: inspecting and modifying models, datasets, columns, relationships, and records, and running SQL queries against workspace storage.
 
 > See `references/response-shapes.md` for full JSON response structures.
 > See `references/troubleshooting.md` for common errors and how to fix them.
 > See `references/examples/models.md` for model CRUD, DDL inspection, and schema discovery examples.
 > See `references/examples/datasets.md` for dataset listing and navigation examples.
 > See `references/examples/columns.md` for column creation and management examples.
+> See `references/examples/queries.md` for `storage query execute` / `storage query download` SQL examples (WHERE, aggregations, joins, pagination, exports).
 
 ## Prerequisites
 
@@ -54,6 +55,8 @@ cargo-ai storage dataset list
 cargo-ai storage column list --model-uuid <uuid>
 cargo-ai storage relationship list --model-uuid <uuid>
 cargo-ai storage record list --model-uuid <uuid>
+cargo-ai storage query execute "SELECT * FROM default.companies LIMIT 10"
+cargo-ai storage query download --query "SELECT * FROM default.companies"
 ```
 
 ## Models
@@ -89,7 +92,7 @@ cargo-ai storage model update --uuid <model-uuid> --name "New Name"
 cargo-ai storage model remove <model-uuid>
 ```
 
-**Querying:** Use `cargo-ai storage query execute "<sql>"` to query storage. Tables are referenced as `<datasetSlug>.<modelSlug>` (e.g. `default.companies`). Run `model get-ddl` for column types and SQL dialect when writing more involved queries. See the `cargo-orchestration` skill for query examples.
+**Querying:** Use `cargo-ai storage query execute "<sql>"` (or `storage query download --query "<sql>"` for full exports) to run SQL against storage. Tables are referenced as `<datasetSlug>.<modelSlug>` (e.g. `default.companies`) and rewritten to the underlying storage table under the hood. See [Query with SQL](#query-with-sql) below.
 
 ## Datasets
 
@@ -155,6 +158,30 @@ cargo-ai storage record list --model-uuid <uuid>
 
 For advanced record queries (filtering, sorting, pagination), use `segmentation segment fetch` from the `cargo-orchestration` skill.
 
+## Query with SQL
+
+Run SQL against workspace storage with `storage query execute`. Tables are referenced as `<datasetSlug>.<modelSlug>` (e.g. `default.companies`) and rewritten to the underlying storage table under the hood — no DDL lookup is needed for the table name.
+
+```bash
+cargo-ai storage query execute \
+  "SELECT name, domain FROM default.companies LIMIT 10"
+# → { "rows": [...] } on success; non-zero exit with { "errorMessage": "..." } on error
+```
+
+For full exports, use `storage query download` — it returns a signed URL to a CSV (default) or Parquet file:
+
+```bash
+cargo-ai storage query download \
+  --query "SELECT name, domain, revenue FROM default.companies ORDER BY revenue DESC"
+
+cargo-ai storage query download \
+  --query "SELECT * FROM default.companies" --format parquet
+```
+
+Get column slugs from `storage column list --model-uuid <uuid>` (or run `storage model get-ddl <model-uuid>` for the full schema and SQL dialect). Page through large result sets with `LIMIT` / `OFFSET` directly in the SQL.
+
+See `references/examples/queries.md` for WHERE clauses, aggregations, joins, date queries, pagination, and the failure shapes returned on error.
+
 ## Help
 
 Every command supports `--help`:
@@ -163,4 +190,6 @@ Every command supports `--help`:
 cargo-ai storage model list --help
 cargo-ai storage column create --help
 cargo-ai storage relationship set --help
+cargo-ai storage query execute --help
+cargo-ai storage query download --help
 ```

--- a/cargo-storage/references/examples/queries.md
+++ b/cargo-storage/references/examples/queries.md
@@ -1,0 +1,155 @@
+# Storage query examples
+
+Run SQL against workspace storage with `cargo-ai storage query execute`. Tables are referenced as `<datasetSlug>.<modelSlug>` and rewritten to the underlying storage table under the hood. No DDL lookup is required for the table name — just use the dataset and model slugs.
+
+For column slugs, run `cargo-ai storage column list --model-uuid <uuid>` or `cargo-ai storage model get-ddl <model-uuid>` (the DDL also shows column types and the SQL dialect).
+
+## Basic query flow
+
+```bash
+# 1. Discover the dataset slug and the model slug
+cargo-ai storage dataset list   # → datasets[].slug (e.g. "default")
+cargo-ai storage model list     # → models[].slug   (e.g. "companies")
+
+# 2. Query using <datasetSlug>.<modelSlug> as the table name
+cargo-ai storage query execute \
+  "SELECT name, domain, employee_count FROM default.companies LIMIT 10"
+```
+
+Success response:
+
+```json
+{
+  "rows": [
+    { "name": "Acme Corp", "domain": "acme.com", "employee_count": 500 },
+    { "name": "Globex", "domain": "globex.com", "employee_count": 1200 }
+  ]
+}
+```
+
+Failed commands exit non-zero with `{"errorMessage": "..."}` (or `{"reason": "clientNotFound"|"unknown"}`). See the error handling section below.
+
+## Query with WHERE clauses
+
+```bash
+# Filter by a column
+cargo-ai storage query execute \
+  "SELECT name, domain FROM default.companies WHERE employee_count > 100"
+
+# Multiple conditions
+cargo-ai storage query execute \
+  "SELECT name, domain, revenue FROM default.companies WHERE employee_count > 100 AND country = 'US'"
+
+# LIKE for partial matches
+cargo-ai storage query execute \
+  "SELECT name, domain FROM default.companies WHERE name LIKE '%tech%'"
+
+# NULL checks
+cargo-ai storage query execute \
+  "SELECT name, domain FROM default.companies WHERE email IS NOT NULL"
+```
+
+## Aggregation queries
+
+```bash
+# Count records
+cargo-ai storage query execute \
+  "SELECT COUNT(*) as total FROM default.companies"
+
+# Group by with counts
+cargo-ai storage query execute \
+  "SELECT country, COUNT(*) as count FROM default.companies GROUP BY country ORDER BY count DESC"
+
+# Sum and average
+cargo-ai storage query execute \
+  "SELECT country, SUM(revenue) as total_revenue, AVG(employee_count) as avg_employees FROM default.companies GROUP BY country"
+```
+
+## Pagination
+
+Page through large result sets with SQL `LIMIT` and `OFFSET` clauses. Always include an `ORDER BY` so pages are stable across calls.
+
+```bash
+# First page
+cargo-ai storage query execute \
+  "SELECT * FROM default.companies ORDER BY name LIMIT 100 OFFSET 0"
+
+# Second page
+cargo-ai storage query execute \
+  "SELECT * FROM default.companies ORDER BY name LIMIT 100 OFFSET 100"
+```
+
+## Download full results
+
+For exporting full result sets to a file, use `storage query download`. The response is a signed URL.
+
+```bash
+cargo-ai storage query download \
+  --query "SELECT name, domain, employee_count, revenue FROM default.companies ORDER BY revenue DESC"
+
+# Choose the format (csv default, parquet supported)
+cargo-ai storage query download \
+  --query "SELECT * FROM default.companies" --format parquet
+```
+
+## Query across multiple models
+
+Join on `<datasetSlug>.<modelSlug>` table references:
+
+```bash
+cargo-ai storage query execute \
+  "SELECT c.name, c.domain, d.stage, d.amount FROM default.companies c JOIN default.deals d ON c._id = d.company_id WHERE d.amount > 10000"
+```
+
+## Common table expressions
+
+```bash
+cargo-ai storage query execute \
+  "WITH recent AS (SELECT * FROM default.companies WHERE created_at >= CURRENT_DATE - INTERVAL '30' DAY) SELECT count(*) FROM recent"
+```
+
+## Date queries
+
+```bash
+# Records created in the last 30 days
+cargo-ai storage query execute \
+  "SELECT name, created_at FROM default.companies WHERE created_at >= DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY)"
+
+# Records in a specific range
+cargo-ai storage query execute \
+  "SELECT name, created_at FROM default.companies WHERE created_at BETWEEN '2025-01-01' AND '2025-03-31'"
+```
+
+## Subqueries
+
+```bash
+# Companies with above-average employee count
+cargo-ai storage query execute \
+  "SELECT name, employee_count FROM default.companies WHERE employee_count > (SELECT AVG(employee_count) FROM default.companies)"
+```
+
+## Error handling
+
+If a query fails, the command exits non-zero. Failure shapes:
+
+```json
+{ "errorMessage": "Table not found: default.nonexistent" }
+```
+
+```json
+{ "reason": "clientNotFound" }
+```
+
+Common causes:
+- Wrong dataset or model slug → re-check with `storage dataset list` and `storage model list`
+- Syntax error → check SQL syntax for your storage SQL dialect (BigQuery vs Snowflake) — `storage model get-ddl` reports `language`
+- `clientNotFound` → no storage client is configured for this workspace
+
+## Discovery commands
+
+```bash
+cargo-ai storage dataset list                  # all datasets (uuid, slug)
+cargo-ai storage model list                    # all models (uuid, name, slug)
+cargo-ai storage model get-ddl <model-uuid>    # column types and SQL dialect
+cargo-ai storage column list --model-uuid <uuid>  # column slugs for a model
+```

--- a/cargo-storage/references/response-shapes.md
+++ b/cargo-storage/references/response-shapes.md
@@ -200,3 +200,50 @@ Kind-specific fields are included alongside the base fields:
   ]
 }
 ```
+
+## cargo-ai storage query execute
+
+Tables are referenced as `<datasetSlug>.<modelSlug>` and rewritten to the underlying storage table under the hood.
+
+**Success:**
+
+```json
+{
+  "rows": [
+    { "name": "Acme Corp", "domain": "acme.com", "employee_count": 500 },
+    { "name": "Globex", "domain": "globex.com", "employee_count": 1200 }
+  ]
+}
+```
+
+**Failure (non-zero exit):**
+
+```json
+{ "errorMessage": "Table not found: default.nonexistent" }
+```
+
+```json
+{ "reason": "clientNotFound" }
+```
+
+```json
+{ "reason": "unknown" }
+```
+
+## cargo-ai storage query download
+
+Used for full exports. Same table-naming convention as `storage query execute` (`<datasetSlug>.<modelSlug>`). Pass the SQL via `--query`; the response is a signed URL.
+
+**Success:**
+
+```json
+{
+  "url": "https://signed-url-to-csv-or-parquet-file"
+}
+```
+
+**Failure (non-zero exit):**
+
+```json
+{ "errorMessage": "Table not found: default.nonexistent" }
+```

--- a/cargo-storage/references/response-shapes.md
+++ b/cargo-storage/references/response-shapes.md
@@ -72,7 +72,7 @@ Same structure as a single item from `model list`, nested under `model`:
 }
 ```
 
-**Key fields:** `ddl` (contains the warehouse-native table name and column names), `language` (SQL dialect).
+**Key fields:** `ddl` (contains the storage-native table name and column names), `language` (SQL dialect).
 
 For `cargo-ai storage query execute`, reference tables as `<datasetSlug>.<modelSlug>` (e.g. `default.companies`).
 

--- a/cargo-storage/references/troubleshooting.md
+++ b/cargo-storage/references/troubleshooting.md
@@ -40,3 +40,13 @@ Common errors and recovery steps for `cargo-storage` commands.
 |---------|-------|-----|
 | `record list` returns empty | No records in the model, or wrong model UUID | Verify with `model list`; check that data has been synced |
 | Need filtered record access | `record list` doesn't support filtering | Use `segmentation segment fetch` from the `cargo-orchestration` skill for filtering, sorting, and pagination |
+
+## Queries (`storage query execute` / `storage query download`)
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `errorMessage` with "Table not found" | Wrong dataset or model slug | Verify with `storage dataset list` and `storage model list`. Tables are `<datasetSlug>.<modelSlug>` |
+| `errorMessage` with syntax error | SQL dialect mismatch | Check whether your storage backend is BigQuery, Snowflake, etc. and adjust syntax accordingly. `storage model get-ddl` reports `language` |
+| `reason: "clientNotFound"` | No storage client configured | Verify the workspace has an active storage connection |
+| Query returns empty `rows` | Filter too restrictive, or wrong model | Try a broader query first (`SELECT * FROM <dataset>.<model> LIMIT 5`) |
+| Column not found | Wrong column slug | Run `storage column list --model-uuid <uuid>` to get exact slugs |

--- a/cargo-storage/references/troubleshooting.md
+++ b/cargo-storage/references/troubleshooting.md
@@ -15,7 +15,7 @@ Common errors and recovery steps for `cargo-storage` commands.
 | Symptom | Cause | Fix |
 |---------|-------|-----|
 | `model get` returns not found | Wrong UUID | Re-run `model list` to get the correct UUID |
-| `model get-ddl` returns empty DDL | Model has no sync connection to the warehouse | Confirm the model has an extractor configured and has synced at least once |
+| `model get-ddl` returns empty DDL | Model has no sync connection to storage | Confirm the model has an extractor configured and has synced at least once |
 | Table not found in `storage query execute` | Wrong dataset or model slug | Verify with `dataset list` and `model list`; tables are referenced as `<datasetSlug>.<modelSlug>` |
 | `model remove` returns an error | Model is referenced by segments, plays, or tools | Remove or update the dependent resources before deleting the model |
 


### PR DESCRIPTION
## Summary

This PR introduces comprehensive documentation for the new `orchestration query execute` command for ad-hoc SQL analytics on execution history, while refactoring storage-related terminology throughout the codebase to be more precise and consistent.

## Key Changes

**New orchestration query documentation:**
- Added full `orchestration query execute` section to `cargo-orchestration/references/queries.md` with table schemas (`runs`, `batches`, `spans`, `records`), example queries (error rates, per-node failures, credit spend), limits (30s timeout, 10k result rows, 10M rows scanned), and error handling
- Added "Ad-hoc execution analytics" section to `cargo-analytics/SKILL.md` with guidance on when to use `orchestration query` vs. `run count` / `run get-metrics`
- Updated `cargo-orchestration/SKILL.md` with orchestration query examples and discovery commands
- Added orchestration query response shapes to `cargo-orchestration/references/response-shapes.md`
- Added orchestration query troubleshooting section to `cargo-orchestration/references/troubleshooting.md`

**Terminology refactoring:**
- Replaced "data warehouse" / "warehouse" with "storage" or "workspace storage" throughout (more accurate for the multi-backend reality)
- Removed references to `system-of-record` commands (`sor list`, `client get-documentation`) — these are no longer part of the public API
- Updated `storage query download` syntax from positional SQL to `--query` flag with optional `--format` parameter
- Clarified that `storage query download` returns a signed URL, not inline rows

**Documentation structure improvements:**
- Reorganized `queries.md` with clear "Storage queries" and "Orchestration queries" sections separated by a divider
- Moved discovery commands to the end of `queries.md` for better flow
- Updated skill descriptions in `AGENTS.md`, `README.md`, and `GLOSSARY.md` to reference "query storage with SQL" instead of "query the data warehouse"
- Improved guidance in `cargo-analytics/SKILL.md` on picking the right command for different analytics needs

## Notable Implementation Details

- Orchestration queries use ClickHouse with strict per-query limits to prevent runaway scans; documentation emphasizes time-window predicates (`created_at > now() - INTERVAL N DAY`) as a best practice
- Both `storage query` and `orchestration query` follow the same success/error response shape (`{"rows": [...]}` / `{"errorMessage": "..."}`)
- Workspace scoping is automatic for orchestration queries (no schema prefix needed); storage queries require explicit `<datasetSlug>.<modelSlug>` references

https://claude.ai/code/session_011D1ThimWJ13d6ZwZXPsmr2