### PR TITLE
Add bootstrap-and-update playbook for context repo setup

### DIFF
--- a/cargo-context/SKILL.md
+++ b/cargo-context/SKILL.md
@@ -77,7 +77,7 @@ Because writes push immediately, **confirm the target workspace before the first
 cargo-ai whoami   # → workspace.uuid, workspace.name
 ```
 
-Read the workspace name back to the user. If the session is for a specific client, make sure `workspace.name` matches before authoring anything — there is no dry-run mode. If you logged in without pinning a workspace, re-run `cargo-ai login --oauth --workspace-uuid <uuid>` (or `--token <workspace-scoped-token>` for non-interactive use).
+Read the workspace name back to the user. If the session is for a specific client, make sure `workspace.name` matches before authoring anything — there is no dry-run mode. If `workspace.name` is generic or ambiguous (e.g. "Main", "Test", a person's name, an internal codename), don't guess — ask the user for the company name and canonical domain (`example.com`) and confirm both before the first write. If you logged in without pinning a workspace, re-run `cargo-ai login --oauth --workspace-uuid <uuid>` (or `--token <workspace-scoped-token>` for non-interactive use).
 
 Edits derived from sales-call analysis should be applied **one at a time with human review**, not batched. Looping an agent over many calls tends to overweight the loudest signal and miss nuance — see `references/examples/bootstrap-and-update.md` for the call-refresh playbook.
 

--- a/cargo-context/SKILL.md
+++ b/cargo-context/SKILL.md
@@ -71,6 +71,14 @@ Two important behaviors to remember:
 - **`write` and `edit` push to the default branch** of the context repo. They are not local-only.
 - **`execute` does *not* push.** Changes made to files by a shell command run via `execute` stay in the sandbox and are discarded — use `execute` for builds, tests, or inspection, not for committing edits.
 
+Because writes push immediately, **confirm the target workspace before the first `write`/`edit`**:
+
+```bash
+cargo-ai whoami   # → workspace.uuid, workspace.name
+```
+
+Read the workspace name back to the user. If the session is for a specific client, make sure `workspace.name` matches before authoring anything — there is no dry-run mode. If you logged in without pinning a workspace, re-run `cargo-ai login --oauth --workspace-uuid <uuid>` (or `--token <workspace-scoped-token>` for non-interactive use).
+
 Edits derived from sales-call analysis should be applied **one at a time with human review**, not batched. Looping an agent over many calls tends to overweight the loudest signal and miss nuance — see `references/examples/bootstrap-and-update.md` for the call-refresh playbook.
 
 ### Browse and read

--- a/cargo-context/SKILL.md
+++ b/cargo-context/SKILL.md
@@ -22,6 +22,7 @@ The **context** is a git-backed repository of typed markdown/MDX files that capt
 > See `references/conventions.md` for the full context repo structure and per-domain templates.
 > See `references/troubleshooting.md` for common errors and how to fix them.
 > See `references/examples/authoring.md` for end-to-end add / edit / delete recipes.
+> See `references/examples/bootstrap-and-update.md` for the bootstrap-from-public-sources + refresh-from-calls playbook.
 > See `references/examples/graph-queries.md` for inspecting the knowledge graph.
 
 ## Prerequisites
@@ -69,6 +70,8 @@ Two important behaviors to remember:
 
 - **`write` and `edit` push to the default branch** of the context repo. They are not local-only.
 - **`execute` does *not* push.** Changes made to files by a shell command run via `execute` stay in the sandbox and are discarded — use `execute` for builds, tests, or inspection, not for committing edits.
+
+Edits derived from sales-call analysis should be applied **one at a time with human review**, not batched. Looping an agent over many calls tends to overweight the loudest signal and miss nuance — see `references/examples/bootstrap-and-update.md` for the call-refresh playbook.
 
 ### Browse and read
 
@@ -213,6 +216,15 @@ The Cargo context repo is a typed knowledge base. The canonical example — and 
    ```
 
 For full per-domain templates and worked examples, see `references/conventions.md` and `references/examples/authoring.md`.
+
+### Workflow: bootstrap and refresh
+
+To stand up a new workspace's context repo from scratch, or to refresh an existing one on a cadence, follow the two-phase playbook in `references/examples/bootstrap-and-update.md`:
+
+1. **Bootstrap (one-time):** scrape public sources in parallel → seed `global/`, `persona/`, `client/`, `proof/`, `objection/`, `signal/` from those digests → open a fresh agent session against the seeded repo.
+2. **Refresh (every 2–4 weeks):** pull the last ~3 months of sales-call transcripts → analyze one at a time, human-in-the-loop → apply a repetition threshold before promoting any claim to context → validate by generating sequence permutations → diff the graph before/after and retire stale entries.
+
+The repetition threshold (how many calls a claim must appear in before it lands in context) is documented in `references/conventions.md`.
 
 ## Knowledge graph
 

--- a/cargo-context/references/conventions.md
+++ b/cargo-context/references/conventions.md
@@ -237,3 +237,8 @@ _Cross-ref `persona/...` — who raises this most._
 - **Title is a label, description is a hook.** `title` shows up in lists; `description` is the one-line that explains why this entry exists.
 - **Cross-refs over duplication.** If a fact already lives in `proof/...`, link to it from the play or objection rather than re-stating it.
 - **Atomic proof.** Each `proof/` entry is one fact / quote / metric. Bundled proof points break filtering in the knowledge graph.
+- **Repetition threshold for call-derived claims.** A single sales call is anecdote, not evidence. Before promoting an objection / pain / missed-proof claim from call analysis into the context repo, require it to surface across multiple calls. Suggested defaults:
+  - Call-rich workspaces (≥ 50 transcripts / quarter): **3 occurrences**.
+  - Medium volume: **2 occurrences**.
+  - New / call-poor workspaces (< 10 transcripts): **1 occurrence**, and cite the source in the file body.
+  The threshold applies to claims, not to facts a call directly confirms (a named customer, a verbatim quote, a competitor explicitly mentioned). See `examples/bootstrap-and-update.md` for the full refresh loop.

--- a/cargo-context/references/examples/bootstrap-and-update.md
+++ b/cargo-context/references/examples/bootstrap-and-update.md
@@ -13,7 +13,7 @@ cargo-ai whoami
 # → user.email, workspace.uuid, workspace.name
 ```
 
-Read back the `workspace.name` to the human and confirm it matches the company you intend to harden context for. If you logged in without pinning a workspace, re-login with the right one:
+Read back the `workspace.name` to the human and confirm it matches the company you intend to harden context for. **If the name is generic or ambiguous** — `"Main"`, `"Test"`, a person's name, an internal codename, anything that doesn't unambiguously identify the company — stop and ask: "What's the company name and canonical domain (e.g. `acme.com`)?" Workspace names are user-set and frequently don't match the customer-facing brand; the domain is the disambiguator. If you logged in without pinning a workspace, re-login with the right one:
 
 ```bash
 cargo-ai login --oauth --workspace-uuid <uuid>

--- a/cargo-context/references/examples/bootstrap-and-update.md
+++ b/cargo-context/references/examples/bootstrap-and-update.md
@@ -4,6 +4,29 @@ The repeatable playbook for building and refreshing a workspace's context repo f
 
 The phases are deliberately separated. Bootstrapping from public data gets you to a baseline fast; call-driven refinement is where the quality lives. Step 5 (turning a single call into context edits) cannot be safely automated end-to-end — keep a human in the loop on every edit.
 
+## Before you start — confirm the target workspace
+
+Each Cargo workspace maps to one company. `runtime write` and `runtime edit` push to **that workspace's** context repo immediately, so the first thing to do is confirm you're pointed at the right one. This matters most for consultants and operators managing several client workspaces.
+
+```bash
+cargo-ai whoami
+# → user.email, workspace.uuid, workspace.name
+```
+
+Read back the `workspace.name` to the human and confirm it matches the company you intend to harden context for. If you logged in without pinning a workspace, re-login with the right one:
+
+```bash
+cargo-ai login --oauth --workspace-uuid <uuid>
+# or, non-interactive:
+cargo-ai login --token <workspace-scoped-token>
+```
+
+Capture three things before the first scrape kicks off — every sub-agent and every threshold decision downstream depends on them:
+
+- **Company name + canonical domain** — what the public-source scrapers will target.
+- **Workspace UUID** — so every CLI call lands in the right repo. If you're working across multiple clients in one session, prefix the workspace name in your notes for every claim you record.
+- **Call volume estimate** — drives the repetition threshold in step 5b (call-rich → 3, medium → 2, call-poor → 1). Get this from the user, or by sampling the call source (Gong / Chorus / etc.).
+
 ## Phase 1 — Bootstrap from public sources
 
 Goal: seed every domain with enough public information that a fresh agent session can hold a coherent conversation about the company.

--- a/cargo-context/references/examples/bootstrap-and-update.md
+++ b/cargo-context/references/examples/bootstrap-and-update.md
@@ -1,0 +1,111 @@
+# Bootstrap and update a context repo
+
+The repeatable playbook for building and refreshing a workspace's context repo from real data. Two phases: a one-time **bootstrap** from public sources, then a **refresh loop** driven by sales-call analysis. Use this when standing up a new workspace, or as a periodic rehydration (recommended cadence: every 2–4 weeks).
+
+The phases are deliberately separated. Bootstrapping from public data gets you to a baseline fast; call-driven refinement is where the quality lives. Step 5 (turning a single call into context edits) cannot be safely automated end-to-end — keep a human in the loop on every edit.
+
+## Phase 1 — Bootstrap from public sources
+
+Goal: seed every domain with enough public information that a fresh agent session can hold a coherent conversation about the company.
+
+### 1. Scrape public sources in parallel
+
+Hand off research to sub-agents. Suggested sources per workspace:
+
+- Website (home, product, pricing, customers, careers)
+- Blog and changelog
+- Job posts (signals about org structure, hiring intent, tooling)
+- Review sites (G2, Capterra) — surfaces objections and competitor mentions
+- Reddit / Hacker News / niche communities — surfaces unprompted voice-of-customer
+- News (funding announcements, leadership changes, launches)
+
+Have each sub-agent return a structured digest (key claims + source URL), not raw scraped text. The digests are what get distilled into context files in step 2.
+
+### 2. Seed the context repo with public data
+
+For each digest, write to the matching domain. Read the template before authoring:
+
+```bash
+cargo-ai context runtime read --path global/_template.md
+cargo-ai context runtime read --path persona/_template.md
+cargo-ai context runtime read --path alternative/_template.md
+```
+
+Then `runtime write` one file per concept. Typical bootstrap coverage:
+
+| Source | Lands in |
+|---|---|
+| Website home / about | `global/positioning.md`, `global/narrative.md`, `global/mission.md` |
+| Pricing page | `global/pricing.md` |
+| Careers / job posts | `persona/...`, `signal/hiring-intent-...` |
+| Customer page | `client/...`, `proof/...` |
+| Blog / launches | `insight/...`, `proof/...` |
+| Review sites | `objection/...`, `alternative/...` |
+| Reddit / HN | `objection/...`, `insight/...` |
+| News / funding | `signal/...` |
+
+Keep `proof/` atomic — one metric or quote per file. Skip anything you cannot source; a thin context beats a fabricated one.
+
+### 3. Start a fresh session with the seeded context
+
+Once the bootstrap commit lands, open a new agent session so the seeded files load clean (rather than mixed with scratch context from Phase 1). Verify with:
+
+```bash
+cargo-ai context runtime browse
+cargo-ai context graph get | jq '.nodes | length'
+```
+
+## Phase 2 — Refresh from real calls
+
+Goal: replace assumptions with evidence. Public sources tell you what the company *says*; calls tell you what prospects *do*.
+
+### 4. Pull the last ~3 months of sales calls
+
+Export transcripts from Gong / Chorus / Fathom / etc. Three months is a good default — long enough to see patterns, short enough that the language is current. For low-volume workspaces, take what you have.
+
+### 5. Analyze one call at a time, human in the loop
+
+For each call:
+
+1. Have an agent summarize the call against the existing context: which personas were on the call, which objections came up, which proof points were referenced or missed, which signals would have flagged this account.
+2. The agent proposes edits — new `objection/...`, updated `persona/...` pains, additional `proof/...` quotes, etc.
+3. A human approves each edit before it lands via `runtime write` or `runtime edit`.
+
+Do **not** batch this. An agent processing 30 calls in a loop overweights the loudest objection and underweights nuance.
+
+### 5b. Apply a repetition threshold
+
+A single call's claim is anecdote. Before promoting a claim into context, require it to surface across multiple calls:
+
+| Workspace volume | Threshold |
+|---|---|
+| Call-rich (≥ 50 transcripts / quarter) | **3 occurrences** before commit |
+| Medium volume | **2 occurrences** |
+| New / call-poor (< 10 transcripts) | **1 occurrence** — note the source in the file body |
+
+Track candidates in a scratch doc (or draft `insight/` entries) until they cross the threshold. The threshold applies to *claims* — objections, pains, missed proof points. It does not apply to direct facts a call confirms (a customer name, a quote attributable to one named person, a competitor explicitly mentioned).
+
+### 6. Validate by generating sequences
+
+Before treating the context as production-ready, run permutations through the workspace's sequence-generating play or agent and read the outputs. Useful permutations:
+
+- A persona + a play + an objection
+- Two different personas with the same play
+- A play with and without a specific proof point
+
+If the generated sequences read like a different company between permutations, the context has internal contradictions. Find them by walking the knowledge graph for orphans and conflicting cross-refs — see `graph-queries.md` for queries that catch the common cases.
+
+### 7. Push to production
+
+`runtime write` and `runtime edit` already push to the default branch — there is no separate deploy step. "Push to production" here means flipping downstream agents and plays to read from the refreshed context. If your workspace pins a specific branch or commit, update the pin now.
+
+### 8. Repeat every 2–4 weeks
+
+Re-run Phase 2 on a cadence. Re-run Phase 1 only when something changes materially in public sources (rebrand, new pricing, new persona launch). On each refresh:
+
+- Snapshot `cargo-ai context graph get` before and after, then diff to see what moved.
+- Retire context not referenced in the last two cycles — staleness is the failure mode, not coverage gaps.
+
+## What not to automate
+
+Full automation of steps 5 / 5b does not reach acceptable quality in practice. The nuance lives in three decisions: which claim is worth committing, which file it belongs in, and whether an existing file should be edited or a new one created. Keep a human on each of those.


### PR DESCRIPTION
## Summary

Adds comprehensive documentation for the two-phase workflow to bootstrap and maintain a workspace's context repository: an initial one-time bootstrap from public sources, followed by a recurring refresh loop driven by sales-call analysis.

## Changes

- **New guide:** `cargo-context/references/examples/bootstrap-and-update.md`
  - Phase 1: Bootstrap from public sources (scraping, seeding context files, validation)
  - Phase 2: Refresh from sales calls (call analysis, human-in-the-loop edits, repetition thresholds)
  - Repetition threshold table (call-rich: 3 occurrences, medium: 2, call-poor: 1)
  - Validation via sequence generation and knowledge graph inspection
  - Explicit guidance on what not to automate (claim selection, file placement, edit decisions)

- **Updated `SKILL.md`:**
  - Added reference to the new bootstrap-and-update playbook in the overview section
  - Added workspace confirmation guidance before first `write`/`edit` (with `cargo-ai whoami` example)
  - Added warning against batching call-driven edits; linked to the playbook for the proper workflow
  - Added new "Workflow: bootstrap and refresh" subsection under the context repo section with high-level phase summary

- **Updated `references/conventions.md`:**
  - Added repetition threshold guidance as a new bullet point in the conventions section
  - Specified thresholds by workspace volume (call-rich, medium, call-poor)
  - Clarified that thresholds apply to claims, not direct facts
  - Cross-referenced the full playbook in `examples/bootstrap-and-update.md`

## Implementation notes

The playbook emphasizes human-in-the-loop decision-making for call-driven context edits and introduces a repetition threshold to distinguish anecdote from evidence. The threshold is calibrated by call volume to balance quality (high-volume workspaces require 3 occurrences) with practicality (new workspaces accept 1 occurrence with source attribution).

https://claude.ai/code/session_01Kb4cSJJF1PxdYaPrZZJXzR