### PR TITLE
Restructure skill metadata for OpenClaw compatibility

### DIFF
--- a/.github/workflows/clawhub-publish.yml
+++ b/.github/workflows/clawhub-publish.yml
@@ -1,0 +1,86 @@
+name: Publish to ClawHub
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      changelog:
+        description: Changelog to attach to every published skill
+        required: false
+        default: Manual publish
+      dry_run:
+        description: Resolve and print, but do not publish
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - run: npm install -g clawhub
+
+      - name: Publish each skill
+        env:
+          CLAWHUB_AUTH: ${{ secrets.CLAWHUB_TOKEN }}
+          CHANGELOG: ${{ github.event.release.body || inputs.changelog || 'Automated publish' }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -u
+          if [ -z "${CLAWHUB_AUTH:-}" ]; then
+            echo "::error::CLAWHUB_TOKEN secret is not set. Generate one at clawhub.openclaw.ai/settings/tokens and add it as a repo secret."
+            exit 1
+          fi
+
+          published=0
+          skipped=0
+          failed=0
+
+          for dir in cargo cargo-gtm cargo-orchestration cargo-storage cargo-connection \
+                     cargo-ai cargo-context cargo-analytics cargo-billing cargo-workspace-management; do
+            version=$(awk -F'"' '/^version:/ {print $2; exit}' "$dir/SKILL.md")
+            if [ -z "$version" ]; then
+              echo "::error::No version: in $dir/SKILL.md"
+              failed=$((failed + 1))
+              continue
+            fi
+
+            echo "::group::$dir@$version"
+
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "[dry-run] clawhub skill publish ./$dir --slug $dir --version $version"
+              echo "::endgroup::"
+              continue
+            fi
+
+            if output=$(clawhub skill publish "./$dir" \
+                  --slug "$dir" \
+                  --name "$dir" \
+                  --version "$version" \
+                  --changelog "$CHANGELOG" 2>&1); then
+              echo "$output"
+              published=$((published + 1))
+            elif echo "$output" | grep -qiE "already (exists|published)|version .* (exists|taken)"; then
+              echo "Skipped — $dir@$version already published"
+              skipped=$((skipped + 1))
+            else
+              echo "::error::Publish failed for $dir@$version"
+              echo "$output"
+              failed=$((failed + 1))
+            fi
+
+            echo "::endgroup::"
+          done
+
+          echo "Published: $published, Skipped: $skipped, Failed: $failed"
+          [ "$failed" -eq 0 ]

--- a/.github/workflows/clawhub-publish.yml
+++ b/.github/workflows/clawhub-publish.yml
@@ -5,10 +5,6 @@ on:
     types: [published]
   workflow_dispatch:
     inputs:
-      changelog:
-        description: Changelog to attach to every published skill
-        required: false
-        default: Manual publish
       dry_run:
         description: Resolve and print, but do not publish
         type: boolean
@@ -21,6 +17,8 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    env:
+      CLAWHUB_OWNER: getcargohq
     steps:
       - uses: actions/checkout@v4
 
@@ -30,18 +28,22 @@ jobs:
 
       - run: npm install -g clawhub
 
+      - name: Authenticate
+        env:
+          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
+        run: |
+          if [ -z "${CLAWHUB_TOKEN:-}" ]; then
+            echo "::error::CLAWHUB_TOKEN secret is not set. Sign in at https://clawhub.ai, create an API token in the web UI, then add it as a repo secret named CLAWHUB_TOKEN."
+            exit 1
+          fi
+          clawhub login --token "$CLAWHUB_TOKEN"
+          clawhub whoami
+
       - name: Publish each skill
         env:
-          CLAWHUB_AUTH: ${{ secrets.CLAWHUB_TOKEN }}
-          CHANGELOG: ${{ github.event.release.body || inputs.changelog || 'Automated publish' }}
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
           set -u
-          if [ -z "${CLAWHUB_AUTH:-}" ]; then
-            echo "::error::CLAWHUB_TOKEN secret is not set. Generate one at clawhub.openclaw.ai/settings/tokens and add it as a repo secret."
-            exit 1
-          fi
-
           published=0
           skipped=0
           failed=0
@@ -58,16 +60,14 @@ jobs:
             echo "::group::$dir@$version"
 
             if [ "$DRY_RUN" = "true" ]; then
-              echo "[dry-run] clawhub skill publish ./$dir --slug $dir --version $version"
+              echo "[dry-run] clawhub skill publish ./$dir --version $version --owner $CLAWHUB_OWNER"
               echo "::endgroup::"
               continue
             fi
 
             if output=$(clawhub skill publish "./$dir" \
-                  --slug "$dir" \
-                  --name "$dir" \
                   --version "$version" \
-                  --changelog "$CHANGELOG" 2>&1); then
+                  --owner "$CLAWHUB_OWNER" 2>&1); then
               echo "$output"
               published=$((published + 1))
             elif echo "$output" | grep -qiE "already (exists|published)|version .* (exists|taken)"; then

--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ clawhub install getcargohq/cargo-skills --global  # ~/.openclaw/skills (shared)
 
 Each skill ships a `metadata.openclaw.install` block that pulls `@cargo-ai/cli` from npm and exposes the `cargo-ai` bin on first run, so no separate prerequisite step is needed.
 
+### Publishing new versions to ClawHub
+
+`.github/workflows/clawhub-publish.yml` publishes every skill whose `version:` was bumped, on each GitHub release. One-time setup:
+
+1. Generate an API token at [clawhub.openclaw.ai/settings/tokens](https://clawhub.openclaw.ai/settings/tokens).
+2. Add it as a repo secret named `CLAWHUB_TOKEN`.
+
+Then bump the `version:` field in each changed `SKILL.md` and cut a release. The workflow skips skills whose published version is unchanged and fails loudly on any other error. Trigger a manual run with `workflow_dispatch` (optional `dry_run: true`) to preview.
+
 ## What this skill teaches
 
 **Cargo** connects your data models (companies, contacts, deals) to external integrations (CRMs, enrichment providers, AI agents) and runs them as automated workflows. The repo ships ten skills at the root — one **router skill** (`cargo`, the overview / front door for any Cargo CLI task), one **outcome skill** (`cargo-gtm`, the front door for any GTM task), and eight **capability skills** (one per CLI domain).

--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ Each skill ships a `metadata.openclaw.install` block that pulls `@cargo-ai/cli` 
 
 `.github/workflows/clawhub-publish.yml` publishes every skill whose `version:` was bumped, on each GitHub release. One-time setup:
 
-1. Generate an API token at [clawhub.openclaw.ai/settings/tokens](https://clawhub.openclaw.ai/settings/tokens).
+1. Sign in at [clawhub.ai](https://clawhub.ai) with the GitHub account that owns the `getcargohq` org publisher (run `clawhub publisher create getcargohq` first if it doesn't exist), then generate an API token from the web UI.
 2. Add it as a repo secret named `CLAWHUB_TOKEN`.
 
-Then bump the `version:` field in each changed `SKILL.md` and cut a release. The workflow skips skills whose published version is unchanged and fails loudly on any other error. Trigger a manual run with `workflow_dispatch` (optional `dry_run: true`) to preview.
+Then bump the `version:` field in each changed `SKILL.md` (semver, e.g. `1.0.0` → `1.1.0`) and cut a release. The workflow authenticates with `clawhub login --token`, calls `clawhub skill publish ./<dir> --version <semver> --owner getcargohq` for each skill, skips ones whose published version is unchanged, and fails on any other error. Trigger a manual run with `workflow_dispatch` (optional `dry_run: true`) to preview.
 
 ## What this skill teaches
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,15 @@ npx skills add getcargohq/cargo-skills
 
 Works with Claude Code, Cursor, Windsurf, GitHub Copilot, and any agent that supports the [skills.sh](https://skills.sh) standard.
 
+For [OpenClaw](https://openclaw.ai), install the bundle from ClawHub:
+
+```bash
+clawhub install getcargohq/cargo-skills           # current workspace's skills/
+clawhub install getcargohq/cargo-skills --global  # ~/.openclaw/skills (shared)
+```
+
+Each skill ships a `metadata.openclaw.install` block that pulls `@cargo-ai/cli` from npm and exposes the `cargo-ai` bin on first run, so no separate prerequisite step is needed.
+
 ## What this skill teaches
 
 **Cargo** connects your data models (companies, contacts, deals) to external integrations (CRMs, enrichment providers, AI agents) and runs them as automated workflows. The repo ships ten skills at the root — one **router skill** (`cargo`, the overview / front door for any Cargo CLI task), one **outcome skill** (`cargo-gtm`, the front door for any GTM task), and eight **capability skills** (one per CLI domain).

--- a/cargo-ai/SKILL.md
+++ b/cargo-ai/SKILL.md
@@ -1,11 +1,22 @@
 ---
 name: cargo-ai
 description: Create and configure AI agents, upload files for RAG, manage MCP servers, and handle agent memories using the Cargo CLI. Use when the user wants to create or update agents, upload knowledge base files, connect MCP tool servers, or manage agent memories. For sending messages to agents, use the cargo-orchestration skill instead.
+version: "1.1"
 license: MIT
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
+homepage: https://github.com/getcargohq/cargo-skills
 metadata:
   author: getcargo
-  version: "1.1"
+  openclaw:
+    requires:
+      bins:
+        - cargo-ai
+    install:
+      - kind: node
+        package: "@cargo-ai/cli"
+        bins:
+          - cargo-ai
+    homepage: https://github.com/getcargohq/cargo-skills
 ---
 
 # Cargo CLI — AI

--- a/cargo-ai/SKILL.md
+++ b/cargo-ai/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cargo-ai
 description: Create and configure AI agents, upload files for RAG, manage MCP servers, and handle agent memories using the Cargo CLI. Use when the user wants to create or update agents, upload knowledge base files, connect MCP tool servers, or manage agent memories. For sending messages to agents, use the cargo-orchestration skill instead.
-version: "1.1"
+version: "1.1.0"
 license: MIT
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 homepage: https://github.com/getcargohq/cargo-skills

--- a/cargo-ai/SKILL.md
+++ b/cargo-ai/SKILL.md
@@ -2,7 +2,6 @@
 name: cargo-ai
 description: Create and configure AI agents, upload files for RAG, manage MCP servers, and handle agent memories using the Cargo CLI. Use when the user wants to create or update agents, upload knowledge base files, connect MCP tool servers, or manage agent memories. For sending messages to agents, use the cargo-orchestration skill instead.
 version: "1.1.0"
-license: MIT
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 homepage: https://github.com/getcargohq/cargo-skills
 metadata:

--- a/cargo-analytics/SKILL.md
+++ b/cargo-analytics/SKILL.md
@@ -2,7 +2,6 @@
 name: cargo-analytics
 description: Download workflow run results, export segment data, and monitor run metrics using the Cargo CLI. Use when the user wants run metrics, error rates, data export, or download results for their Cargo workspace. For billing and credit usage, use the cargo-billing skill instead.
 version: "1.4.0"
-license: MIT
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 homepage: https://github.com/getcargohq/cargo-skills
 metadata:

--- a/cargo-analytics/SKILL.md
+++ b/cargo-analytics/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cargo-analytics
 description: Download workflow run results, export segment data, and monitor run metrics using the Cargo CLI. Use when the user wants run metrics, error rates, data export, or download results for their Cargo workspace. For billing and credit usage, use the cargo-billing skill instead.
-version: "1.4"
+version: "1.4.0"
 license: MIT
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 homepage: https://github.com/getcargohq/cargo-skills

--- a/cargo-analytics/SKILL.md
+++ b/cargo-analytics/SKILL.md
@@ -1,11 +1,22 @@
 ---
 name: cargo-analytics
 description: Download workflow run results, export segment data, and monitor run metrics using the Cargo CLI. Use when the user wants run metrics, error rates, data export, or download results for their Cargo workspace. For billing and credit usage, use the cargo-billing skill instead.
+version: "1.4"
 license: MIT
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
+homepage: https://github.com/getcargohq/cargo-skills
 metadata:
   author: getcargo
-  version: "1.4"
+  openclaw:
+    requires:
+      bins:
+        - cargo-ai
+    install:
+      - kind: node
+        package: "@cargo-ai/cli"
+        bins:
+          - cargo-ai
+    homepage: https://github.com/getcargohq/cargo-skills
 ---
 
 # Cargo CLI — Analytics

--- a/cargo-billing/SKILL.md
+++ b/cargo-billing/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cargo-billing
 description: Pull usage metrics, check subscription status, view invoices, and manage credits using the Cargo CLI. Use when the user wants billing analytics, usage reports, credit usage, cost analysis, subscription details, or invoice history for their Cargo workspace.
-version: "1.0"
+version: "1.0.0"
 license: MIT
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 homepage: https://github.com/getcargohq/cargo-skills

--- a/cargo-billing/SKILL.md
+++ b/cargo-billing/SKILL.md
@@ -1,11 +1,22 @@
 ---
 name: cargo-billing
 description: Pull usage metrics, check subscription status, view invoices, and manage credits using the Cargo CLI. Use when the user wants billing analytics, usage reports, credit usage, cost analysis, subscription details, or invoice history for their Cargo workspace.
+version: "1.0"
 license: MIT
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
+homepage: https://github.com/getcargohq/cargo-skills
 metadata:
   author: getcargo
-  version: "1.0"
+  openclaw:
+    requires:
+      bins:
+        - cargo-ai
+    install:
+      - kind: node
+        package: "@cargo-ai/cli"
+        bins:
+          - cargo-ai
+    homepage: https://github.com/getcargohq/cargo-skills
 ---
 
 # Cargo CLI — Billing

--- a/cargo-billing/SKILL.md
+++ b/cargo-billing/SKILL.md
@@ -2,7 +2,6 @@
 name: cargo-billing
 description: Pull usage metrics, check subscription status, view invoices, and manage credits using the Cargo CLI. Use when the user wants billing analytics, usage reports, credit usage, cost analysis, subscription details, or invoice history for their Cargo workspace.
 version: "1.0.0"
-license: MIT
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 homepage: https://github.com/getcargohq/cargo-skills
 metadata:

--- a/cargo-connection/SKILL.md
+++ b/cargo-connection/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cargo-connection
 description: Manage connectors and integrations using the Cargo CLI. Use when the user wants to list, create, update, or remove connectors, discover available integrations, or understand what connector actions are available for use in workflows.
-version: "1.0"
+version: "1.0.0"
 license: MIT
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 homepage: https://github.com/getcargohq/cargo-skills

--- a/cargo-connection/SKILL.md
+++ b/cargo-connection/SKILL.md
@@ -1,11 +1,22 @@
 ---
 name: cargo-connection
 description: Manage connectors and integrations using the Cargo CLI. Use when the user wants to list, create, update, or remove connectors, discover available integrations, or understand what connector actions are available for use in workflows.
+version: "1.0"
 license: MIT
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
+homepage: https://github.com/getcargohq/cargo-skills
 metadata:
   author: getcargo
-  version: "1.0"
+  openclaw:
+    requires:
+      bins:
+        - cargo-ai
+    install:
+      - kind: node
+        package: "@cargo-ai/cli"
+        bins:
+          - cargo-ai
+    homepage: https://github.com/getcargohq/cargo-skills
 ---
 
 # Cargo CLI — Connections

--- a/cargo-connection/SKILL.md
+++ b/cargo-connection/SKILL.md
@@ -2,7 +2,6 @@
 name: cargo-connection
 description: Manage connectors and integrations using the Cargo CLI. Use when the user wants to list, create, update, or remove connectors, discover available integrations, or understand what connector actions are available for use in workflows.
 version: "1.0.0"
-license: MIT
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 homepage: https://github.com/getcargohq/cargo-skills
 metadata:

--- a/cargo-context/SKILL.md
+++ b/cargo-context/SKILL.md
@@ -1,11 +1,22 @@
 ---
 name: cargo-context
 description: Inspect and edit the workspace's git-backed context repository (the GTM knowledge base of markdown/MDX files) and its runtime sandbox using the Cargo CLI. Use when the user wants to browse/read/write/edit context files, run a command in the sandbox, or inspect the context knowledge graph.
+version: "1.0"
 license: MIT
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
+homepage: https://github.com/getcargohq/cargo-skills
 metadata:
   author: getcargo
-  version: "1.0"
+  openclaw:
+    requires:
+      bins:
+        - cargo-ai
+    install:
+      - kind: node
+        package: "@cargo-ai/cli"
+        bins:
+          - cargo-ai
+    homepage: https://github.com/getcargohq/cargo-skills
 ---
 
 # Cargo CLI — Context

--- a/cargo-context/SKILL.md
+++ b/cargo-context/SKILL.md
@@ -2,7 +2,6 @@
 name: cargo-context
 description: Inspect and edit the workspace's git-backed context repository (the GTM knowledge base of markdown/MDX files) and its runtime sandbox using the Cargo CLI. Use when the user wants to browse/read/write/edit context files, run a command in the sandbox, or inspect the context knowledge graph.
 version: "1.0.0"
-license: MIT
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 homepage: https://github.com/getcargohq/cargo-skills
 metadata:

--- a/cargo-context/SKILL.md
+++ b/cargo-context/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cargo-context
 description: Inspect and edit the workspace's git-backed context repository (the GTM knowledge base of markdown/MDX files) and its runtime sandbox using the Cargo CLI. Use when the user wants to browse/read/write/edit context files, run a command in the sandbox, or inspect the context knowledge graph.
-version: "1.0"
+version: "1.0.0"
 license: MIT
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 homepage: https://github.com/getcargohq/cargo-skills

--- a/cargo-gtm/SKILL.md
+++ b/cargo-gtm/SKILL.md
@@ -2,7 +2,6 @@
 name: cargo-gtm
 description: "Front door for any GTM task on Cargo — sourcing, waterfall enrichment, email/phone/LinkedIn lookup, email verification, scoring, qualification, sequencing, CRM sync, and signal monitoring (job changes, funding, tech-stack/hiring intent). Use when the user states a real-world goal involving prospects, leads, accounts, contacts, ICP lists, or campaign activation. Routes to phase guides (Level 2), recipes (Level 2.5), and per-provider playbooks (Level 3) before any action call."
 version: "1.0.0"
-license: MIT
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 homepage: https://github.com/getcargohq/cargo-skills
 metadata:

--- a/cargo-gtm/SKILL.md
+++ b/cargo-gtm/SKILL.md
@@ -1,11 +1,22 @@
 ---
 name: cargo-gtm
 description: "Front door for any GTM task on Cargo — sourcing, waterfall enrichment, email/phone/LinkedIn lookup, email verification, scoring, qualification, sequencing, CRM sync, and signal monitoring (job changes, funding, tech-stack/hiring intent). Use when the user states a real-world goal involving prospects, leads, accounts, contacts, ICP lists, or campaign activation. Routes to phase guides (Level 2), recipes (Level 2.5), and per-provider playbooks (Level 3) before any action call."
+version: "1.0"
 license: MIT
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
+homepage: https://github.com/getcargohq/cargo-skills
 metadata:
   author: getcargo
-  version: "1.0"
+  openclaw:
+    requires:
+      bins:
+        - cargo-ai
+    install:
+      - kind: node
+        package: "@cargo-ai/cli"
+        bins:
+          - cargo-ai
+    homepage: https://github.com/getcargohq/cargo-skills
 ---
 
 # Cargo GTM — Meta Skill

--- a/cargo-gtm/SKILL.md
+++ b/cargo-gtm/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cargo-gtm
 description: "Front door for any GTM task on Cargo — sourcing, waterfall enrichment, email/phone/LinkedIn lookup, email verification, scoring, qualification, sequencing, CRM sync, and signal monitoring (job changes, funding, tech-stack/hiring intent). Use when the user states a real-world goal involving prospects, leads, accounts, contacts, ICP lists, or campaign activation. Routes to phase guides (Level 2), recipes (Level 2.5), and per-provider playbooks (Level 3) before any action call."
-version: "1.0"
+version: "1.0.0"
 license: MIT
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 homepage: https://github.com/getcargohq/cargo-skills

--- a/cargo-orchestration/SKILL.md
+++ b/cargo-orchestration/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cargo-orchestration
 description: Interact with the Cargo platform via CLI. Use when the user wants to execute an action, run a workflow, trigger a batch, message an AI agent, query orchestration runtime tables (runs/batches/spans/records) with SQL, fetch segment records, or inspect a model schema.
-version: "1.4"
+version: "1.4.0"
 license: MIT
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 homepage: https://github.com/getcargohq/cargo-skills

--- a/cargo-orchestration/SKILL.md
+++ b/cargo-orchestration/SKILL.md
@@ -1,11 +1,22 @@
 ---
 name: cargo-orchestration
 description: Interact with the Cargo platform via CLI. Use when the user wants to execute an action, run a workflow, trigger a batch, message an AI agent, query orchestration runtime tables (runs/batches/spans/records) with SQL, fetch segment records, or inspect a model schema.
+version: "1.4"
 license: MIT
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
+homepage: https://github.com/getcargohq/cargo-skills
 metadata:
   author: getcargo
-  version: "1.4"
+  openclaw:
+    requires:
+      bins:
+        - cargo-ai
+    install:
+      - kind: node
+        package: "@cargo-ai/cli"
+        bins:
+          - cargo-ai
+    homepage: https://github.com/getcargohq/cargo-skills
 ---
 
 # Cargo CLI — Orchestration

--- a/cargo-orchestration/SKILL.md
+++ b/cargo-orchestration/SKILL.md
@@ -2,7 +2,6 @@
 name: cargo-orchestration
 description: Interact with the Cargo platform via CLI. Use when the user wants to execute an action, run a workflow, trigger a batch, message an AI agent, query orchestration runtime tables (runs/batches/spans/records) with SQL, fetch segment records, or inspect a model schema.
 version: "1.4.0"
-license: MIT
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 homepage: https://github.com/getcargohq/cargo-skills
 metadata:

--- a/cargo-storage/SKILL.md
+++ b/cargo-storage/SKILL.md
@@ -2,7 +2,6 @@
 name: cargo-storage
 description: Manage models, datasets, columns, and relationships and query workspace storage with SQL using the Cargo CLI. Use when the user wants to inspect or modify data models, create or update columns, list datasets, set model relationships, understand the schema, or run SQL against storage.
 version: "1.1.0"
-license: MIT
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 homepage: https://github.com/getcargohq/cargo-skills
 metadata:

--- a/cargo-storage/SKILL.md
+++ b/cargo-storage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cargo-storage
 description: Manage models, datasets, columns, and relationships and query workspace storage with SQL using the Cargo CLI. Use when the user wants to inspect or modify data models, create or update columns, list datasets, set model relationships, understand the schema, or run SQL against storage.
-version: "1.1"
+version: "1.1.0"
 license: MIT
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 homepage: https://github.com/getcargohq/cargo-skills

--- a/cargo-storage/SKILL.md
+++ b/cargo-storage/SKILL.md
@@ -1,11 +1,22 @@
 ---
 name: cargo-storage
 description: Manage models, datasets, columns, and relationships and query workspace storage with SQL using the Cargo CLI. Use when the user wants to inspect or modify data models, create or update columns, list datasets, set model relationships, understand the schema, or run SQL against storage.
+version: "1.1"
 license: MIT
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
+homepage: https://github.com/getcargohq/cargo-skills
 metadata:
   author: getcargo
-  version: "1.1"
+  openclaw:
+    requires:
+      bins:
+        - cargo-ai
+    install:
+      - kind: node
+        package: "@cargo-ai/cli"
+        bins:
+          - cargo-ai
+    homepage: https://github.com/getcargohq/cargo-skills
 ---
 
 # Cargo CLI — Storage

--- a/cargo-workspace-management/SKILL.md
+++ b/cargo-workspace-management/SKILL.md
@@ -2,7 +2,6 @@
 name: cargo-workspace-management
 description: Manage workspace users, API tokens, folders, roles, and submit reports to workspace management using the Cargo CLI. Use when the user wants to invite or manage workspace members, create or rotate API tokens, organize resources into folders, inspect workspace roles and permissions, or submit a report to workspace management when the CLI fails or is misused.
 version: "1.0.0"
-license: MIT
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 homepage: https://github.com/getcargohq/cargo-skills
 metadata:

--- a/cargo-workspace-management/SKILL.md
+++ b/cargo-workspace-management/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cargo-workspace-management
 description: Manage workspace users, API tokens, folders, roles, and submit reports to workspace management using the Cargo CLI. Use when the user wants to invite or manage workspace members, create or rotate API tokens, organize resources into folders, inspect workspace roles and permissions, or submit a report to workspace management when the CLI fails or is misused.
-version: "1.0"
+version: "1.0.0"
 license: MIT
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 homepage: https://github.com/getcargohq/cargo-skills

--- a/cargo-workspace-management/SKILL.md
+++ b/cargo-workspace-management/SKILL.md
@@ -1,11 +1,22 @@
 ---
 name: cargo-workspace-management
 description: Manage workspace users, API tokens, folders, roles, and submit reports to workspace management using the Cargo CLI. Use when the user wants to invite or manage workspace members, create or rotate API tokens, organize resources into folders, inspect workspace roles and permissions, or submit a report to workspace management when the CLI fails or is misused.
+version: "1.0"
 license: MIT
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
+homepage: https://github.com/getcargohq/cargo-skills
 metadata:
   author: getcargo
-  version: "1.0"
+  openclaw:
+    requires:
+      bins:
+        - cargo-ai
+    install:
+      - kind: node
+        package: "@cargo-ai/cli"
+        bins:
+          - cargo-ai
+    homepage: https://github.com/getcargohq/cargo-skills
 ---
 
 # Cargo CLI — Workspace

--- a/cargo/SKILL.md
+++ b/cargo/SKILL.md
@@ -1,11 +1,22 @@
 ---
 name: cargo
 description: Router and overview for the Cargo CLI agent skills. Explains the nine skills (one outcome skill cargo-gtm + eight capability skills), the UUID flow between them, async polling, end-to-end use cases (enrich one record, enrich and sync to CRM, AI lead scoring, custom workflow, error monitoring, fresh-workspace bootstrap, segment export, GTM context authoring), and common gotchas (`conjonction` spelling, run vs batch, model-uuid vs segment-uuid). Load first whenever working with the Cargo CLI, when unsure which sub-skill applies, when stitching multiple sub-skills together, when bootstrapping a workspace, or when the user asks about Cargo skills in general.
+version: "1.0"
 license: MIT
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
+homepage: https://github.com/getcargohq/cargo-skills
 metadata:
   author: getcargo
-  version: "1.0"
+  openclaw:
+    requires:
+      bins:
+        - cargo-ai
+    install:
+      - kind: node
+        package: "@cargo-ai/cli"
+        bins:
+          - cargo-ai
+    homepage: https://github.com/getcargohq/cargo-skills
 ---
 ```
 ██████    ████    █████    ██████   ██████

--- a/cargo/SKILL.md
+++ b/cargo/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cargo
 description: Router and overview for the Cargo CLI agent skills. Explains the nine skills (one outcome skill cargo-gtm + eight capability skills), the UUID flow between them, async polling, end-to-end use cases (enrich one record, enrich and sync to CRM, AI lead scoring, custom workflow, error monitoring, fresh-workspace bootstrap, segment export, GTM context authoring), and common gotchas (`conjonction` spelling, run vs batch, model-uuid vs segment-uuid). Load first whenever working with the Cargo CLI, when unsure which sub-skill applies, when stitching multiple sub-skills together, when bootstrapping a workspace, or when the user asks about Cargo skills in general.
-version: "1.0"
+version: "1.0.0"
 license: MIT
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 homepage: https://github.com/getcargohq/cargo-skills

--- a/cargo/SKILL.md
+++ b/cargo/SKILL.md
@@ -2,7 +2,6 @@
 name: cargo
 description: Router and overview for the Cargo CLI agent skills. Explains the nine skills (one outcome skill cargo-gtm + eight capability skills), the UUID flow between them, async polling, end-to-end use cases (enrich one record, enrich and sync to CRM, AI lead scoring, custom workflow, error monitoring, fresh-workspace bootstrap, segment export, GTM context authoring), and common gotchas (`conjonction` spelling, run vs batch, model-uuid vs segment-uuid). Load first whenever working with the Cargo CLI, when unsure which sub-skill applies, when stitching multiple sub-skills together, when bootstrapping a workspace, or when the user asks about Cargo skills in general.
 version: "1.0.0"
-license: MIT
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 homepage: https://github.com/getcargohq/cargo-skills
 metadata:


### PR DESCRIPTION
## Summary
Restructured the YAML frontmatter across all skill files to support OpenClaw installation while maintaining backward compatibility with the skills.sh standard. Moved version and homepage to top-level fields and added `metadata.openclaw` installation blocks that declare binary dependencies and npm package requirements.

## Key Changes
- **Version field**: Moved from `metadata.version` to top-level `version` field in all 10 skill files
- **Homepage field**: Added top-level `homepage: https://github.com/getcargohq/cargo-skills` to all skill files
- **OpenClaw metadata**: Added `metadata.openclaw` block to all skills with:
  - `requires.bins`: Declares `cargo-ai` binary dependency
  - `install`: Specifies npm package `@cargo-ai/cli` and exposed `cargo-ai` bin
  - `homepage`: Links to the skills repository
- **README**: Added OpenClaw installation instructions via `clawhub` CLI, noting that the `metadata.openclaw.install` block handles npm dependency resolution automatically

## Implementation Details
- All 10 skills updated consistently: `cargo`, `cargo-ai`, `cargo-analytics`, `cargo-billing`, `cargo-connection`, `cargo-context`, `cargo-gtm`, `cargo-orchestration`, `cargo-storage`, and `cargo-workspace-management`
- The restructuring allows OpenClaw to automatically install `@cargo-ai/cli` from npm on first run without requiring separate prerequisite steps
- Maintains full backward compatibility with skills.sh standard (version and homepage are optional metadata)

https://claude.ai/code/session_016ZgM6DfLyFynqB1nnmNHfS