### PR TITLE
Update ClawHub publish workflow for cargo-ai org

### DIFF
--- a/.github/workflows/clawhub-publish.yml
+++ b/.github/workflows/clawhub-publish.yml
@@ -1,6 +1,8 @@
 name: Publish to ClawHub
 
 on:
+  push:
+    branches: [main]
   release:
     types: [published]
   workflow_dispatch:

--- a/.github/workflows/clawhub-publish.yml
+++ b/.github/workflows/clawhub-publish.yml
@@ -18,7 +18,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     env:
-      CLAWHUB_OWNER: getcargohq
+      CLAWHUB_OWNER: cargo-ai
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
Updated the ClawHub publish workflow to reflect organizational changes and add automatic publishing on main branch pushes.

## Key Changes
- Changed `CLAWHUB_OWNER` from `getcargohq` to `cargo-ai`
- Added automatic publishing trigger on pushes to the `main` branch (in addition to existing release and manual triggers)

## Details
The workflow now publishes to ClawHub in three scenarios:
1. On push to main branch (new)
2. On release publication (existing)
3. On manual workflow dispatch (existing)

This ensures that the latest changes on main are continuously published to the new `cargo-ai` ClawHub organization.

https://claude.ai/code/session_01RYFpAu59pUGDfxCr6ZTbq2