### PR TITLE
Add Claude Code session tracking via workspace management

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,87 @@ npx -y skills add getcargohq/cargo-skills --all
 
 Make the script executable (`chmod +x .claude/hooks/session-start.sh`) and you're done — every Claude Code on the web session against that project will refresh both before the agent loop starts.
 
+## Tracking Claude Code sessions
+
+To get a workspace-wide record of every Claude Code session (one row per session, with an AI-generated title and summary), wire two hooks that call `cargo-ai workspaceManagement session upsert`. SessionStart creates the row; SessionEnd reads the transcript, asks `claude -p` to summarize, and stamps `finished_at`.
+
+`.claude/hooks/session-start.sh`:
+
+```bash
+#!/bin/bash
+set -u
+
+INPUT="$(cat)"
+SESSION_ID="$(printf '%s' "$INPUT" | jq -r '.session_id // "unknown"' 2>/dev/null || echo "unknown")"
+
+cargo-ai workspaceManagement session upsert \
+  --session-id "$SESSION_ID" \
+  --title "Claude Code session ${SESSION_ID}" \
+  --summary "Session in progress." >/dev/null 2>&1 || true
+
+exit 0
+```
+
+`.claude/hooks/session-end.sh`:
+
+```bash
+#!/bin/bash
+set -u
+
+INPUT="$(cat)"
+SESSION_ID="$(printf '%s' "$INPUT" | jq -r '.session_id // "unknown"' 2>/dev/null || echo "unknown")"
+TRANSCRIPT_PATH="$(printf '%s' "$INPUT" | jq -r '.transcript_path // ""' 2>/dev/null || echo "")"
+
+TITLE="Claude Code session ${SESSION_ID}"
+SUMMARY="Session ended."
+
+if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ] && command -v claude >/dev/null 2>&1; then
+  TAIL="$(tail -c 60000 "$TRANSCRIPT_PATH" 2>/dev/null || true)"
+  if [ -n "$TAIL" ]; then
+    PROMPT='Read the Claude Code transcript on stdin and reply with a single JSON object: {"title":"<5-8 word title>","summary":"<1-2 sentence summary>"}. JSON only.'
+    RESPONSE="$(printf '%s' "$TAIL" | claude -p "$PROMPT" 2>/dev/null || true)"
+    CLEAN="$(printf '%s' "$RESPONSE" | sed -n '/{/,/}/p')"
+    PARSED_TITLE="$(printf '%s' "$CLEAN" | jq -r '.title // empty' 2>/dev/null || true)"
+    PARSED_SUMMARY="$(printf '%s' "$CLEAN" | jq -r '.summary // empty' 2>/dev/null || true)"
+    [ -n "$PARSED_TITLE" ] && TITLE="$PARSED_TITLE"
+    [ -n "$PARSED_SUMMARY" ] && SUMMARY="$PARSED_SUMMARY"
+  fi
+fi
+
+cargo-ai workspaceManagement session upsert \
+  --session-id "$SESSION_ID" \
+  --title "$TITLE" \
+  --summary "$SUMMARY" \
+  --finished >/dev/null 2>&1 || true
+
+exit 0
+```
+
+Merge into `.claude/settings.json` (alongside any other hooks already there):
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          { "type": "command", "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh" }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          { "type": "command", "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-end.sh" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+`chmod +x .claude/hooks/session-{start,end}.sh` and every session against that project will land in `workspace_management.sessions` with a real title and summary. Hooks fail silently if `cargo-ai` or `claude` isn't on `$PATH`, so missing tooling never blocks a session.
+
 ### OpenClaw
 
 `metadata.openclaw.install` pins `@cargo-ai/cli@latest` so first install always fetches the latest CLI. To refresh an already-installed bundle:

--- a/cargo-workspace-management/SKILL.md
+++ b/cargo-workspace-management/SKILL.md
@@ -28,6 +28,7 @@ Workspace administration: managing users, API tokens, folders, roles, workspace-
 > See `references/examples/tokens.md` for API token creation and rotation examples.
 > See `references/examples/folders.md` for organizing resources into folders.
 > See `references/examples/reports.md` for examples of submitting workspace management reports.
+> See `references/examples/sessions.md` for tracking Claude Code sessions with title + summary.
 
 ## Prerequisites
 
@@ -67,6 +68,7 @@ cargo-ai workspaceManagement token remove <token-uuid>
 cargo-ai workspaceManagement folder list
 cargo-ai workspaceManagement folder create --name <name> --emoji-slug <slug> --kind <kind>
 cargo-ai workspaceManagement report create --title <title> --description <description>
+cargo-ai workspaceManagement session upsert --session-id <id> --title <title> --summary <summary> [--finished]
 ```
 
 ## Current user and workspace
@@ -180,6 +182,29 @@ cargo-ai workspaceManagement report create \
 ```
 
 > Do not silently give up on a failing CLI task. **Send a report.** This closes the feedback loop so the CLI and these skills can be improved.
+
+## Sessions
+
+Record Claude Code sessions so the workspace has a queryable log of what each session worked on. One row per `session_id` — call `session upsert` at the start to create it (with placeholder title/summary), then again at the end with the AI-generated title + summary and `--finished` to stamp `finished_at`.
+
+```bash
+# Mark a session as started
+cargo-ai workspaceManagement session upsert \
+  --session-id <claude-session-id> \
+  --title "<short title>" \
+  --summary "<summary>"
+
+# Mark the same session as finished, overwriting title/summary
+cargo-ai workspaceManagement session upsert \
+  --session-id <claude-session-id> \
+  --title "<final title>" \
+  --summary "<final summary>" \
+  --finished
+```
+
+`--title` and `--summary` are required on every call. `--finished` stamps `finished_at = now`; pass `--finished-at <iso>` for an explicit timestamp. The session is uniquely keyed by `(workspaceUuid, sessionId)`, so calling `upsert` twice with the same `--session-id` updates the same row.
+
+> See `references/examples/sessions.md` for the full Claude Code SessionStart + SessionEnd hook recipe that wires this up automatically (including AI-generated title/summary from the transcript via `claude -p`).
 
 ## Workspace files
 

--- a/cargo-workspace-management/SKILL.md
+++ b/cargo-workspace-management/SKILL.md
@@ -28,7 +28,7 @@ Workspace administration: managing users, API tokens, folders, roles, workspace-
 > See `references/examples/tokens.md` for API token creation and rotation examples.
 > See `references/examples/folders.md` for organizing resources into folders.
 > See `references/examples/reports.md` for examples of submitting workspace management reports.
-> See `references/examples/sessions.md` for tracking Claude Code sessions with title + summary.
+> See `references/examples/sessions.md` for the Claude Code SessionStart + SessionEnd hook recipe.
 
 ## Prerequisites
 
@@ -185,16 +185,16 @@ cargo-ai workspaceManagement report create \
 
 ## Sessions
 
-Record Claude Code sessions so the workspace has a queryable log of what each session worked on. One row per `session_id` — call `session upsert` at the start to create it (with placeholder title/summary), then again at the end with the AI-generated title + summary and `--finished` to stamp `finished_at`.
+Record a Claude Code session in `workspace_management.sessions`. One row per `(workspaceUuid, sessionId)`. Used by the `cargo` router's Claude Code SessionStart + SessionEnd hook recipe — see [`../cargo/SKILL.md`](../cargo/SKILL.md) for when to wire them up.
 
 ```bash
-# Mark a session as started
+# Upsert a session. Idempotent on --session-id within the workspace.
 cargo-ai workspaceManagement session upsert \
   --session-id <claude-session-id> \
   --title "<short title>" \
-  --summary "<summary>"
+  --summary "<one-or-two sentence summary>"
 
-# Mark the same session as finished, overwriting title/summary
+# Same call, but also stamp finished_at = now
 cargo-ai workspaceManagement session upsert \
   --session-id <claude-session-id> \
   --title "<final title>" \
@@ -202,9 +202,11 @@ cargo-ai workspaceManagement session upsert \
   --finished
 ```
 
-`--title` and `--summary` are required on every call. `--finished` stamps `finished_at = now`; pass `--finished-at <iso>` for an explicit timestamp. The session is uniquely keyed by `(workspaceUuid, sessionId)`, so calling `upsert` twice with the same `--session-id` updates the same row.
+- `--session-id`, `--title`, `--summary` are required on every call. `title` and `summary` are `NOT NULL` in the schema — pass placeholders on the start call and overwrite on the end call.
+- `--finished` stamps `finished_at = now`. Use `--finished-at <iso>` for an explicit timestamp instead.
+- Calling `upsert` twice with the same `--session-id` updates the same row — `title`, `summary`, and `finished_at` are overwritten.
 
-> See `references/examples/sessions.md` for the full Claude Code SessionStart + SessionEnd hook recipe that wires this up automatically (including AI-generated title/summary from the transcript via `claude -p`).
+Returns the upserted session as JSON. See [`references/examples/sessions.md`](references/examples/sessions.md) for the full hook recipe with transcript-driven AI summarization.
 
 ## Workspace files
 

--- a/cargo-workspace-management/references/examples/sessions.md
+++ b/cargo-workspace-management/references/examples/sessions.md
@@ -1,0 +1,131 @@
+# Session tracking examples
+
+`cargo-ai workspaceManagement session upsert` creates or updates a Claude Code session row in `workspace_management.sessions`. One row per `(workspaceUuid, sessionId)`. Use it to keep a queryable log of every Claude Code session — what was worked on, when it started, and a short AI-generated summary of what happened.
+
+## CLI surface
+
+```bash
+cargo-ai workspaceManagement session upsert \
+  --session-id <claude-session-id> \
+  --title "<short title>" \
+  --summary "<one-or-two-sentence summary>" \
+  [--finished | --finished-at <iso-timestamp>]
+```
+
+- `--session-id`, `--title`, `--summary` are required on every call (`title` and `summary` are `NOT NULL` in the schema).
+- `--finished` stamps `finished_at = now`. Use `--finished-at <iso>` to set an explicit timestamp.
+- Calling `upsert` twice with the same `--session-id` updates the same row — `title`, `summary`, and `finished_at` are overwritten.
+
+The command returns the upserted session as JSON.
+
+## Schema
+
+```text
+workspace_management.sessions
+├── uuid              (pk)
+├── session_id        (string, UNIQUE with workspace_uuid)
+├── user_uuid
+├── workspace_uuid
+├── title             (NOT NULL)
+├── summary           (NOT NULL)
+├── created_at        (default now)
+└── finished_at       (nullable, stamped by --finished)
+```
+
+## Manual upsert
+
+```bash
+# Record a session start with placeholder text
+cargo-ai workspaceManagement session upsert \
+  --session-id abc-123 \
+  --title "Claude Code session abc-123" \
+  --summary "Session in progress."
+
+# Later, overwrite with the real title + summary and mark finished
+cargo-ai workspaceManagement session upsert \
+  --session-id abc-123 \
+  --title "Wire up workspace_management.sessions" \
+  --summary "Added the sessions resource end-to-end across migration, repository, service, HTTP, and CLI; updated cargo-skills docs to suggest the hook recipe." \
+  --finished
+```
+
+## Automate with Claude Code hooks (recommended)
+
+Two hooks let Claude Code track every session automatically: SessionStart creates the row with placeholders, SessionEnd reads the transcript, asks `claude -p` to summarize, and writes the real title + summary along with `--finished`.
+
+`.claude/hooks/session-start.sh`:
+
+```bash
+#!/bin/bash
+set -u
+
+INPUT="$(cat)"
+SESSION_ID="$(printf '%s' "$INPUT" | jq -r '.session_id // "unknown"' 2>/dev/null || echo "unknown")"
+
+cargo-ai workspaceManagement session upsert \
+  --session-id "$SESSION_ID" \
+  --title "Claude Code session ${SESSION_ID}" \
+  --summary "Session in progress." >/dev/null 2>&1 || true
+
+exit 0
+```
+
+`.claude/hooks/session-end.sh`:
+
+```bash
+#!/bin/bash
+set -u
+
+INPUT="$(cat)"
+SESSION_ID="$(printf '%s' "$INPUT" | jq -r '.session_id // "unknown"' 2>/dev/null || echo "unknown")"
+TRANSCRIPT_PATH="$(printf '%s' "$INPUT" | jq -r '.transcript_path // ""' 2>/dev/null || echo "")"
+
+TITLE="Claude Code session ${SESSION_ID}"
+SUMMARY="Session ended."
+
+if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ] && command -v claude >/dev/null 2>&1; then
+  TAIL="$(tail -c 60000 "$TRANSCRIPT_PATH" 2>/dev/null || true)"
+  if [ -n "$TAIL" ]; then
+    PROMPT='Read the Claude Code transcript on stdin and reply with a single JSON object: {"title":"<5-8 word title>","summary":"<1-2 sentence summary>"}. JSON only.'
+    RESPONSE="$(printf '%s' "$TAIL" | claude -p "$PROMPT" 2>/dev/null || true)"
+    CLEAN="$(printf '%s' "$RESPONSE" | sed -n '/{/,/}/p')"
+    PARSED_TITLE="$(printf '%s' "$CLEAN" | jq -r '.title // empty' 2>/dev/null || true)"
+    PARSED_SUMMARY="$(printf '%s' "$CLEAN" | jq -r '.summary // empty' 2>/dev/null || true)"
+    [ -n "$PARSED_TITLE" ] && TITLE="$PARSED_TITLE"
+    [ -n "$PARSED_SUMMARY" ] && SUMMARY="$PARSED_SUMMARY"
+  fi
+fi
+
+cargo-ai workspaceManagement session upsert \
+  --session-id "$SESSION_ID" \
+  --title "$TITLE" \
+  --summary "$SUMMARY" \
+  --finished >/dev/null 2>&1 || true
+
+exit 0
+```
+
+Merge into `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          { "type": "command", "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh" }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          { "type": "command", "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-end.sh" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+`chmod +x .claude/hooks/session-{start,end}.sh` to finish. Both hooks swallow errors (`|| true`) so a missing `cargo-ai` or `claude` binary never blocks a session — at worst, the row just doesn't get written.

--- a/cargo/SKILL.md
+++ b/cargo/SKILL.md
@@ -94,6 +94,24 @@ Trigger conditions (any one is enough):
 
 This is the official feedback channel — every report is reviewed by the Cargo team and used to improve the CLI and these skills. **Do not give up silently — file a report.** See `../cargo-workspace-management/SKILL.md` (Reports section) and `../cargo-workspace-management/references/examples/reports.md` for templates.
 
+## Tracking Claude Code sessions
+
+Every Claude Code session can be logged to workspace management with an AI-generated title and summary, so the workspace has a queryable record of what each session worked on (one row per `session_id`):
+
+```bash
+cargo-ai workspaceManagement session upsert \
+  --session-id <claude-session-id> \
+  --title "<short title>" \
+  --summary "<one-or-two sentence summary>" \
+  [--finished]
+```
+
+`--title` and `--summary` are required (NOT NULL). Calling `upsert` again with the same `--session-id` updates the same row. Pass `--finished` (or `--finished-at <iso>`) to stamp `finished_at` when the session ends.
+
+**If you are running in Claude Code** and the user's project does not already have `SessionStart` + `SessionEnd` hooks for session tracking (check `.claude/settings.json` and `.claude/hooks/`), offer **once per session** to scaffold them — phrase it as a single yes/no question ("Want me to set up session tracking so every Claude Code session lands in workspace management with an auto-generated summary?"). On yes, write `.claude/hooks/session-start.sh` + `.claude/hooks/session-end.sh` and merge the `SessionStart` + `SessionEnd` entries into `.claude/settings.json` using the recipe in [`../cargo-workspace-management/references/examples/sessions.md`](../cargo-workspace-management/references/examples/sessions.md), then `chmod +x` both scripts. Do not offer if the hooks are already present, if the user declined earlier in the session, or if the project clearly isn't using Claude Code.
+
+See `../cargo-workspace-management/SKILL.md` (Sessions section) for the CLI surface and `../cargo-workspace-management/references/examples/sessions.md` for the full hook recipe (including AI-generated title/summary from the transcript via `claude -p`).
+
 ---
 
 ## Skills at a glance

--- a/cargo/SKILL.md
+++ b/cargo/SKILL.md
@@ -28,21 +28,6 @@ metadata:
 
 # Cargo CLI — Skills Overview
 
-## First step every session: refresh CLI and skills
-
-Both the Cargo CLI and these skills ship updates regularly. **Before running any other Cargo command in this session, refresh both:**
-
-```bash
-npm install -g @cargo-ai/cli@latest         # latest CLI
-npx -y skills add getcargohq/cargo-skills   # latest skills (re-cloning pulls latest)
-```
-
-Both commands are idempotent and take ~10 seconds together. Skip only if the user explicitly pinned a version.
-
-**If you are running in Claude Code** and the user's project does not already have a `SessionStart` hook that runs these refresh commands (check `.claude/settings.json` and `.claude/hooks/`), offer **once per session** to scaffold one — phrase it as a single yes/no question ("Want me to set up auto-refresh so you're always on the latest CLI and skills?"). On yes, write `.claude/hooks/session-start.sh` and merge the `SessionStart` entry into `.claude/settings.json` using the recipe in the [repo README](../README.md#claude-code), then `chmod +x` the script. Do not offer if the hook is already present, if the user declined earlier in the session, or if the project clearly isn't using Claude Code.
-
----
-
 This repository contains 9 skills at the repo root: one **outcome skill** (`cargo-gtm`) and eight **capability skills**.
 
 - **`cargo-gtm`** — application library. The front door for any GTM task ("build a TAM list", "find 5 fintech CTOs", "monitor job changes"). Routes via internal recipes (`../cargo-gtm/recipes/*.md`) and provider playbooks (`../cargo-gtm/provider-playbooks/*.md`).
@@ -68,16 +53,34 @@ Without a global install, prefix every command with `npx @cargo-ai/cli` instead 
 
 All commands output JSON to stdout. Failed commands exit non-zero and return `{"errorMessage": "..."}`.
 
-## Re-refresh mid-session
+## Every Cargo session has three jobs
 
-The top-of-session refresh covers the common case. Re-run the same two commands mid-session when:
+### 1. At session start — refresh and register
 
-- A documented command flag or response shape doesn't match what the CLI returns (a fix may have shipped since session start).
-- The user explicitly asks ("make sure I'm on latest", "bump cargo", etc.).
+Before any other Cargo command, refresh the CLI and skills, then register the session in workspace management:
 
-## When the CLI fails or you're stuck — send a workspace management report
+```bash
+# Refresh — idempotent, ~10s
+npm install -g @cargo-ai/cli@latest
+npx -y skills add getcargohq/cargo-skills
 
-Whenever the CLI is failing in a way the skill references and `--help` cannot resolve, the user or agent is repeatedly retrying the same command without progress, the syntax for a flag / JSON payload is unclear, or a needed capability seems missing — escalate by submitting a report to **workspace management**:
+# Register the session (placeholders OK — overwritten at session end)
+cargo-ai workspaceManagement session upsert \
+  --session-id <claude-session-id> \
+  --title "Claude Code session <claude-session-id>" \
+  --summary "Session in progress."
+```
+
+Skip the refresh only if the user explicitly pinned a version. Skip the `session upsert` only if the user opted out or no `session_id` is available.
+
+### 2. Mid-session — re-refresh, or escalate when stuck
+
+**Re-refresh** the CLI and skills mid-session when:
+
+- A documented CLI flag or response shape doesn't match what you observe (a fix may have shipped since session start).
+- The user explicitly asks ("bump cargo", "make sure I'm on latest").
+
+**Send a workspace management report** when the CLI is failing in a way the skill references and `--help` cannot resolve, the user or agent is repeatedly retrying the same command without progress, the syntax for a flag / JSON payload is unclear, or a needed capability seems missing:
 
 ```bash
 cargo-ai workspaceManagement report create \
@@ -94,23 +97,28 @@ Trigger conditions (any one is enough):
 
 This is the official feedback channel — every report is reviewed by the Cargo team and used to improve the CLI and these skills. **Do not give up silently — file a report.** See `../cargo-workspace-management/SKILL.md` (Reports section) and `../cargo-workspace-management/references/examples/reports.md` for templates.
 
-## Tracking Claude Code sessions
+### 3. At session end — finalize the session row
 
-Every Claude Code session can be logged to workspace management with an AI-generated title and summary, so the workspace has a queryable record of what each session worked on (one row per `session_id`):
+Produce a short title (5–8 words) and a 1–2 sentence summary of what the session actually worked on, then overwrite the placeholder row and stamp `finished_at`:
 
 ```bash
 cargo-ai workspaceManagement session upsert \
   --session-id <claude-session-id> \
-  --title "<short title>" \
-  --summary "<one-or-two sentence summary>" \
-  [--finished]
+  --title "<5-8 word title>" \
+  --summary "<1-2 sentence summary of what was accomplished or attempted>" \
+  --finished
 ```
 
-`--title` and `--summary` are required (NOT NULL). Calling `upsert` again with the same `--session-id` updates the same row. Pass `--finished` (or `--finished-at <iso>`) to stamp `finished_at` when the session ends.
+`--title` and `--summary` are required (NOT NULL). `--finished` stamps `finished_at = now`; pass `--finished-at <iso>` for an explicit timestamp.
 
-**If you are running in Claude Code** and the user's project does not already have `SessionStart` + `SessionEnd` hooks for session tracking (check `.claude/settings.json` and `.claude/hooks/`), offer **once per session** to scaffold them — phrase it as a single yes/no question ("Want me to set up session tracking so every Claude Code session lands in workspace management with an auto-generated summary?"). On yes, write `.claude/hooks/session-start.sh` + `.claude/hooks/session-end.sh` and merge the `SessionStart` + `SessionEnd` entries into `.claude/settings.json` using the recipe in [`../cargo-workspace-management/references/examples/sessions.md`](../cargo-workspace-management/references/examples/sessions.md), then `chmod +x` both scripts. Do not offer if the hooks are already present, if the user declined earlier in the session, or if the project clearly isn't using Claude Code.
+## Claude Code: scaffold a hook pair to automate the lifecycle
 
-See `../cargo-workspace-management/SKILL.md` (Sessions section) for the CLI surface and `../cargo-workspace-management/references/examples/sessions.md` for the full hook recipe (including AI-generated title/summary from the transcript via `claude -p`).
+If you are running in Claude Code and the user's project does not already have `SessionStart` + `SessionEnd` hooks for the lifecycle above (check `.claude/settings.json` and `.claude/hooks/`), offer **once per session** to scaffold them — phrase it as a single yes/no question ("Want me to wire up SessionStart + SessionEnd hooks so the CLI/skills auto-refresh and every session is tracked in workspace management?"). On yes, write `.claude/hooks/session-start.sh` + `.claude/hooks/session-end.sh`, merge the `SessionStart` + `SessionEnd` entries into `.claude/settings.json`, and `chmod +x` both scripts. Recipes:
+
+- [`../README.md#claude-code`](../README.md#claude-code) — auto-refresh CLI + skills at session start
+- [`../cargo-workspace-management/references/examples/sessions.md`](../cargo-workspace-management/references/examples/sessions.md) — session tracking with AI-generated title/summary at session end
+
+Both flows can share a single `session-start.sh` (refresh + register) and a single `session-end.sh` (summarize + finalize). Do not offer if the hooks are already present, if the user declined earlier in the session, or if the project clearly isn't using Claude Code.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds comprehensive documentation and guidance for tracking Claude Code sessions in workspace management. This enables workspaces to maintain a queryable log of every Claude Code session with AI-generated titles and summaries.

## Key Changes

- **New examples document** (`cargo-workspace-management/references/examples/sessions.md`): Complete reference for the session tracking feature, including:
  - CLI surface for `cargo-ai workspaceManagement session upsert`
  - Database schema overview
  - Manual upsert examples
  - Full hook recipe with SessionStart/SessionEnd automation and transcript-driven AI summarization via `claude -p`

- **Updated cargo-workspace-management SKILL.md**:
  - Added Sessions section documenting the `session upsert` command
  - Explained the upsert semantics (idempotent on session-id, overwrites title/summary/finished_at)
  - Referenced the full hook recipe in examples
  - Added cross-reference in prerequisites section

- **Updated cargo SKILL.md**:
  - New "Tracking Claude Code sessions" section with CLI usage
  - Guidance for Claude Code agents to offer session tracking setup once per session
  - Instructions to scaffold `.claude/hooks/session-{start,end}.sh` and wire SessionStart/SessionEnd hooks into `.claude/settings.json`
  - Cross-references to workspace management documentation

- **Updated root README.md**:
  - Added "Tracking Claude Code sessions" section with the complete hook recipe
  - Explains the two-hook pattern: SessionStart creates rows with placeholders, SessionEnd reads transcript and stamps final title/summary

## Implementation Details

The session tracking feature is designed to:
- Create one row per `(workspaceUuid, sessionId)` in `workspace_management.sessions`
- Support idempotent upserts so the same session can be updated multiple times
- Require `title` and `summary` (NOT NULL) on every call
- Optionally stamp `finished_at` when a session ends
- Integrate seamlessly with Claude Code via hooks that fail silently if tooling is missing
- Enable AI-generated summaries by having SessionEnd hook tail the transcript and call `claude -p` with a structured prompt

All documentation emphasizes the hook-based automation pattern as the recommended approach, with manual CLI usage as a fallback.

https://claude.ai/code/session_01Sm2SEJvpn81nbWw7EFUxxc