### PR TITLE
Add skill-bundle linter, shared prerequisites, and changelog

### DIFF
--- a/.github/scripts/skills-lint.mjs
+++ b/.github/scripts/skills-lint.mjs
@@ -1,0 +1,309 @@
+#!/usr/bin/env node
+// Skill bundle linter.
+//
+// Validates the repository invariants that consumers of these skills rely on:
+//   - Every SKILL.md has the required frontmatter fields and parses cleanly.
+//   - Every internal markdown link (`(./...)`, `(../...)`, `(referenced/path.md)`)
+//     resolves to a file that actually exists in the repo.
+//   - Every fenced JSON code block parses as valid JSON.
+//   - Every `cargo-ai` bash example references one of the known top-level domains.
+//   - Versions follow MAJOR.MINOR.PATCH and are non-empty.
+//
+// The script reads every file under the repo root that is either named SKILL.md
+// or lives under a `references/`, `recipes/`, `guides/`, `provider-playbooks/`,
+// or `agents/` directory beside a SKILL.md. Findings are printed grouped by file.
+// Exit code is 1 on any error finding, 0 otherwise. Warnings do not fail the run.
+
+import { readFileSync, readdirSync, statSync, existsSync } from "node:fs";
+import { join, relative, resolve, dirname, basename } from "node:path";
+
+const repoRoot = resolve(process.argv[2] || ".");
+
+const SKILL_DIRS = [
+  "cargo",
+  "cargo-gtm",
+  "cargo-orchestration",
+  "cargo-storage",
+  "cargo-connection",
+  "cargo-ai",
+  "cargo-context",
+  "cargo-analytics",
+  "cargo-billing",
+  "cargo-workspace-management",
+];
+
+const REQUIRED_FRONTMATTER_FIELDS = [
+  "name",
+  "description",
+  "version",
+  "compatibility",
+];
+
+// Top-level cargo-ai command domains. Update if a new domain ships.
+const KNOWN_CLI_DOMAINS = new Set([
+  "ai",
+  "billing",
+  "connection",
+  "context",
+  "orchestration",
+  "segmentation",
+  "storage",
+  "whoami",
+  "login",
+  "logout",
+  "workspaceManagement",
+  "--help",
+  "--version",
+]);
+
+const findings = []; // { file, line, severity: "error"|"warn", message }
+
+function err(file, line, message) {
+  findings.push({ file, line, severity: "error", message });
+}
+function warn(file, line, message) {
+  findings.push({ file, line, severity: "warn", message });
+}
+
+function* walk(dir) {
+  for (const entry of readdirSync(dir)) {
+    if (entry.startsWith(".") || entry === "node_modules") continue;
+    const p = join(dir, entry);
+    const s = statSync(p);
+    if (s.isDirectory()) yield* walk(p);
+    else if (entry.endsWith(".md") || entry.endsWith(".mdx")) yield p;
+  }
+}
+
+function parseFrontmatter(content, file) {
+  if (!content.startsWith("---\n")) {
+    return null;
+  }
+  const end = content.indexOf("\n---", 4);
+  if (end < 0) {
+    err(file, 1, "Frontmatter block is not terminated by `---`.");
+    return null;
+  }
+  const body = content.slice(4, end);
+  // Permissive line-based parse — sufficient for the flat key:value frontmatter
+  // we use. We do not need full YAML semantics, just to confirm presence.
+  const fields = {};
+  let i = 0;
+  for (const rawLine of body.split("\n")) {
+    i++;
+    if (!rawLine.trim() || rawLine.trimStart().startsWith("#")) continue;
+    // top-level keys are unindented `key: value` lines
+    if (/^[A-Za-z][A-Za-z0-9_-]*:/.test(rawLine)) {
+      const colon = rawLine.indexOf(":");
+      const key = rawLine.slice(0, colon).trim();
+      const value = rawLine.slice(colon + 1).trim();
+      fields[key] = value;
+    }
+  }
+  return { fields, bodyStart: end + 4 };
+}
+
+function validateFrontmatter(file, content) {
+  const result = parseFrontmatter(content, file);
+  if (!result) {
+    if (basename(file) === "SKILL.md") {
+      err(file, 1, "SKILL.md is missing required `---` frontmatter block.");
+    }
+    return;
+  }
+  if (basename(file) !== "SKILL.md") return;
+
+  for (const field of REQUIRED_FRONTMATTER_FIELDS) {
+    if (!(field in result.fields)) {
+      err(file, 1, `Frontmatter is missing required field \`${field}\`.`);
+    }
+  }
+  const version = (result.fields.version || "").replace(/^"|"$/g, "");
+  if (version && !/^\d+\.\d+\.\d+$/.test(version)) {
+    err(file, 1, `Frontmatter \`version\` must be MAJOR.MINOR.PATCH (got "${version}").`);
+  }
+  const name = (result.fields.name || "").replace(/^"|"$/g, "");
+  const expectedName = file.split("/").slice(-2, -1)[0];
+  if (name && name !== expectedName) {
+    err(
+      file,
+      1,
+      `Frontmatter \`name: ${name}\` does not match its directory \`${expectedName}\`.`
+    );
+  }
+}
+
+function extractFencedBlocks(content) {
+  const blocks = [];
+  const lines = content.split("\n");
+  let i = 0;
+  while (i < lines.length) {
+    const m = lines[i].match(/^```(\w+)?\s*$/);
+    if (m) {
+      const lang = (m[1] || "").toLowerCase();
+      const startLine = i + 1;
+      const buf = [];
+      i++;
+      while (i < lines.length && !lines[i].startsWith("```")) {
+        buf.push(lines[i]);
+        i++;
+      }
+      blocks.push({ lang, startLine, content: buf.join("\n") });
+      i++; // consume closing fence
+      continue;
+    }
+    i++;
+  }
+  return blocks;
+}
+
+function validateJsonBlocks(file, content) {
+  for (const block of extractFencedBlocks(content)) {
+    if (block.lang !== "json") continue;
+    const text = block.content.trim();
+    if (!text) continue;
+    // Documentation patterns we deliberately don't try to parse:
+    //   - ellipsis placeholders (`...`, `…`) inside the block,
+    //   - template / mustache expressions (`{{nodes.x.y}}`),
+    //   - angle-bracket placeholders (`<uuid>`, `<slug>`),
+    //   - inline `// comment` lines (multiple sibling examples).
+    if (
+      text.includes("...") ||
+      text.includes("…") ||
+      text.includes("{{") ||
+      /<[a-zA-Z][^>\n]*>/.test(text) ||
+      /^\s*\/\//m.test(text)
+    ) {
+      continue;
+    }
+    // Skip JSON fragments that show a single key:value pair without the
+    // enclosing object (common when documenting one field of a larger shape).
+    if (!/^\s*[{[]/.test(text)) {
+      continue;
+    }
+    // Many reference docs enumerate multiple sibling JSON objects, one per
+    // line, in a single fenced block. Try the block as a single document
+    // first; on failure, try parsing each non-empty line independently.
+    try {
+      JSON.parse(text);
+      continue;
+    } catch (e) {
+      const lines = text.split("\n").map((l) => l.trim()).filter(Boolean);
+      if (lines.length > 1 && lines.every((l) => {
+        try { JSON.parse(l); return true; } catch { return false; }
+      })) {
+        continue;
+      }
+      err(
+        file,
+        block.startLine,
+        `Fenced \`\`\`json block does not parse: ${e.message}`
+      );
+    }
+  }
+}
+
+function validateBashBlocks(file, content) {
+  for (const block of extractFencedBlocks(content)) {
+    if (block.lang !== "bash" && block.lang !== "sh" && block.lang !== "shell") continue;
+    const lines = block.content.split("\n");
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i].trim();
+      if (!line || line.startsWith("#")) continue;
+      // Look at every `cargo-ai <token>` invocation. The next token must be
+      // a known domain (or a flag like `--help`).
+      const re = /(?:^|[\s|;`$(])cargo-ai\s+([A-Za-z][A-Za-z0-9_-]*)/g;
+      let m;
+      while ((m = re.exec(lines[i])) !== null) {
+        const token = m[1];
+        if (!KNOWN_CLI_DOMAINS.has(token)) {
+          warn(
+            file,
+            block.startLine + i,
+            `\`cargo-ai ${token}\` references an unknown top-level domain — update the linter or fix the example.`
+          );
+        }
+      }
+    }
+  }
+}
+
+function validateInternalLinks(file, content) {
+  // Match markdown links: [text](target). Skip URLs (http(s)://, mailto:),
+  // pure anchors (#foo), and template placeholders.
+  const re = /\[([^\]]*)\]\(([^)]+)\)/g;
+  let m;
+  const fileDir = dirname(file);
+  while ((m = re.exec(content)) !== null) {
+    const target = m[2].trim();
+    if (!target) continue;
+    if (/^[a-z]+:\/\//i.test(target)) continue;
+    if (target.startsWith("mailto:")) continue;
+    if (target.startsWith("#")) continue;
+    // strip trailing anchor and query
+    const cleaned = target.split("#")[0].split("?")[0];
+    if (!cleaned) continue;
+    // Resolve relative to the file's directory.
+    const absTarget = resolve(fileDir, cleaned);
+    if (!existsSync(absTarget)) {
+      // Compute line number of the link
+      const upto = content.slice(0, m.index);
+      const line = upto.split("\n").length;
+      err(file, line, `Broken internal link: \`${target}\` — no file at ${relative(repoRoot, absTarget)}`);
+    }
+  }
+}
+
+function lintFile(file) {
+  const content = readFileSync(file, "utf8");
+  if (basename(file) === "SKILL.md") {
+    validateFrontmatter(file, content);
+  }
+  validateJsonBlocks(file, content);
+  validateBashBlocks(file, content);
+  validateInternalLinks(file, content);
+}
+
+function main() {
+  for (const dir of SKILL_DIRS) {
+    const skillRoot = join(repoRoot, dir);
+    if (!existsSync(skillRoot)) {
+      err(`${dir}/`, 0, `Listed skill directory \`${dir}/\` does not exist in the repo.`);
+      continue;
+    }
+    if (!existsSync(join(skillRoot, "SKILL.md"))) {
+      err(`${dir}/`, 0, `\`${dir}/SKILL.md\` is missing.`);
+    }
+    for (const f of walk(skillRoot)) {
+      lintFile(f);
+    }
+  }
+  // Also lint top-level docs.
+  for (const top of ["README.md", "AGENTS.md", "CHANGELOG.md", "CLAUDE.md"]) {
+    const p = join(repoRoot, top);
+    if (existsSync(p)) lintFile(p);
+  }
+
+  const errors = findings.filter((f) => f.severity === "error");
+  const warnings = findings.filter((f) => f.severity === "warn");
+
+  const byFile = new Map();
+  for (const f of findings) {
+    if (!byFile.has(f.file)) byFile.set(f.file, []);
+    byFile.get(f.file).push(f);
+  }
+  for (const [file, items] of byFile) {
+    process.stdout.write(`\n${relative(repoRoot, file)}\n`);
+    for (const item of items) {
+      const tag = item.severity === "error" ? "ERROR" : "warn ";
+      process.stdout.write(`  ${tag} L${item.line}  ${item.message}\n`);
+    }
+  }
+
+  process.stdout.write(
+    `\nSummary: ${errors.length} error(s), ${warnings.length} warning(s).\n`
+  );
+  process.exit(errors.length > 0 ? 1 : 0);
+}
+
+main();

--- a/.github/workflows/skills-lint.yml
+++ b/.github/workflows/skills-lint.yml
@@ -1,0 +1,24 @@
+name: skills-lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Validate SKILL.md frontmatter, JSON snippets, internal links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Run skill-bundle linter
+        run: node .github/scripts/skills-lint.mjs .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,80 @@
+# Changelog
+
+All notable changes to the skills in this repository are tracked here. Each skill is versioned independently via the `version:` field in its `SKILL.md` frontmatter. ClawHub publish skips skills whose published version is unchanged, so bumping the field is what ships a new release.
+
+The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow [SemVer](https://semver.org/):
+
+- **MAJOR** — breaking changes to the commands, flags, or response shapes documented in the skill (the agent has to relearn something).
+- **MINOR** — new commands, new sections, new recipes/examples, or non-breaking restructures.
+- **PATCH** — copy edits, link fixes, clarifications, and other no-behavior changes.
+
+## [Unreleased]
+
+### Repository-wide
+
+- **Shared prerequisites reference.** Extracted the duplicated install / login / output-conventions block from every capability skill into [`cargo/references/prerequisites.md`](cargo/references/prerequisites.md). Each capability skill now links to it instead of redefining ~16 lines of boilerplate. No behavior change for agents — the canonical setup is the same — but a single place to keep it correct.
+- **CHANGELOG.** This file. Per-skill version bumps are now recorded here so consumers can see what changed between two pinned versions.
+- **CI skill-lint.** Added [`.github/workflows/skills-lint.yml`](.github/workflows/skills-lint.yml) and [`.github/scripts/skills-lint.mjs`](.github/scripts/skills-lint.mjs). Runs on every push and PR; validates SKILL.md frontmatter shape, JSON snippets inside fenced code blocks, internal markdown links, and that bash examples reference real `cargo-ai` domains. Catches drift before it reaches users.
+
+### `cargo` → 1.1.0
+
+- Add `references/prerequisites.md` — the canonical setup block linked from every capability skill.
+- Skill graph table now deep-links each row to the target `SKILL.md` (in addition to the existing in-page recap anchor). Cuts one navigation hop for agents jumping from the router into a capability skill.
+- No command, flag, or response-shape changes.
+
+### `cargo-ai` → 1.1.1
+
+- Prerequisites section trimmed to a one-line pointer at `cargo/references/prerequisites.md`. No command surface change.
+
+### `cargo-analytics` → 1.4.1
+
+- Prerequisites section trimmed to a one-line pointer at `cargo/references/prerequisites.md`. No command surface change.
+
+### `cargo-billing` → 1.0.1
+
+- Prerequisites section trimmed to a one-line pointer; admin-scope requirement is now stated directly under the new Prerequisites note instead of in a separate paragraph.
+
+### `cargo-connection` → 1.1.0
+
+- Moved the "Key concepts" section above Prerequisites so the integration-vs-connector distinction is in scope before the agent reaches the command list.
+- Tightened the `integration get <slug>` vs `native-integration get` comparison table to use ✓/✗ markers for third-party vs built-in action scope, making it harder to mis-route a HubSpot/Salesforce lookup to `native-integration get`.
+- Prerequisites section trimmed to a one-line pointer.
+
+### `cargo-context` → 1.0.1
+
+- Prerequisites section trimmed to a one-line pointer. Kept the inline reminder that `runtime write` and `runtime edit` push commits, so confirming `workspace.name` first is non-negotiable.
+
+### `cargo-orchestration` → 1.4.1
+
+- Prerequisites section trimmed to a one-line pointer at `cargo/references/prerequisites.md`. No command surface change.
+
+### `cargo-storage` → 1.1.1
+
+- Prerequisites section trimmed to a one-line pointer at `cargo/references/prerequisites.md`. No command surface change.
+
+### `cargo-workspace-management` → 1.0.1
+
+- Prerequisites section trimmed to a one-line pointer; the admin-vs-non-admin split is now stated directly under the new Prerequisites note.
+
+### `cargo-gtm` → 1.0.0 (unchanged)
+
+- No changes in this cycle. `cargo-gtm` does not duplicate the install/login boilerplate (it delegates to capability skills), so the shared-prerequisites refactor doesn't touch it.
+
+## Historical baseline (pre-CHANGELOG)
+
+Versions present at the time this file was introduced, captured for posterity:
+
+| Skill                        | Version |
+| ---------------------------- | ------- |
+| `cargo`                      | 1.0.0   |
+| `cargo-gtm`                  | 1.0.0   |
+| `cargo-orchestration`        | 1.4.0   |
+| `cargo-storage`              | 1.1.0   |
+| `cargo-connection`           | 1.0.0   |
+| `cargo-ai`                   | 1.1.0   |
+| `cargo-context`              | 1.0.0   |
+| `cargo-analytics`            | 1.4.0   |
+| `cargo-billing`              | 1.0.0   |
+| `cargo-workspace-management` | 1.0.0   |
+
+Pre-history changes can be reconstructed from `git log -- <dir>/SKILL.md`.

--- a/cargo-ai/SKILL.md
+++ b/cargo-ai/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cargo-ai
 description: Create and configure AI agents, upload files for RAG, manage MCP servers, and handle agent memories using the Cargo CLI. Use when the user wants to create or update agents, upload knowledge base files, connect MCP tool servers, or manage agent memories. For sending messages to agents, use the cargo-orchestration skill instead.
-version: "1.1.0"
+version: "1.1.1"
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 homepage: https://github.com/getcargohq/cargo-skills
 metadata:
@@ -33,17 +33,7 @@ Agent resource management: creating and configuring agents, uploading files for 
 
 ## Prerequisites
 
-```bash
-npm install -g @cargo-ai/cli
-cargo-ai login --oauth                                  # browser sign-in (recommended)
-# or: cargo-ai login --token <your-api-token>           # workspace-scoped API token (non-interactive)
-# Pin a default workspace at login (with --oauth)
-cargo-ai login --oauth --workspace-uuid <uuid>
-```
-
-Verify with `cargo-ai whoami`. All commands output JSON to stdout. Without a global install, prefix every command with `npx @cargo-ai/cli` instead of `cargo-ai`.
-
-Failed commands exit non-zero and return `{"errorMessage": "..."}`.
+See [`../cargo/references/prerequisites.md`](../cargo/references/prerequisites.md) for install, login (`--oauth` / `--token`), JSON output conventions, and error shapes. Verify the session with `cargo-ai whoami` before running any of the commands below.
 
 ## Discover resources first
 

--- a/cargo-analytics/SKILL.md
+++ b/cargo-analytics/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cargo-analytics
 description: Download workflow run results, export segment data, and monitor run metrics using the Cargo CLI. Use when the user wants run metrics, error rates, data export, or download results for their Cargo workspace. For billing and credit usage, use the cargo-billing skill instead.
-version: "1.4.0"
+version: "1.4.1"
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 homepage: https://github.com/getcargohq/cargo-skills
 metadata:
@@ -30,17 +30,7 @@ Measurement and export: monitoring run metrics, downloading run and batch result
 
 ## Prerequisites
 
-```bash
-npm install -g @cargo-ai/cli
-cargo-ai login --oauth                                  # browser sign-in (recommended)
-# or: cargo-ai login --token <your-api-token>           # workspace-scoped API token (non-interactive)
-# Pin a default workspace at login (with --oauth)
-cargo-ai login --oauth --workspace-uuid <uuid>
-```
-
-Verify with `cargo-ai whoami`. All commands output JSON to stdout. Without a global install, prefix every command with `npx @cargo-ai/cli` instead of `cargo-ai`.
-
-Failed commands exit non-zero and return `{"errorMessage": "..."}`.
+See [`../cargo/references/prerequisites.md`](../cargo/references/prerequisites.md) for install, login (`--oauth` / `--token`), JSON output conventions, and error shapes. Verify the session with `cargo-ai whoami` before running any of the commands below.
 
 ## Discover resources first
 

--- a/cargo-billing/SKILL.md
+++ b/cargo-billing/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cargo-billing
 description: Pull usage metrics, check subscription status, view invoices, and manage credits using the Cargo CLI. Use when the user wants billing analytics, usage reports, credit usage, cost analysis, subscription details, or invoice history for their Cargo workspace.
-version: "1.0.0"
+version: "1.0.1"
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 homepage: https://github.com/getcargohq/cargo-skills
 metadata:
@@ -28,19 +28,9 @@ Billing and credit management: pulling usage metrics, checking subscription stat
 
 ## Prerequisites
 
-```bash
-npm install -g @cargo-ai/cli
-cargo-ai login --oauth                                  # browser sign-in (recommended)
-# or: cargo-ai login --token <your-api-token>           # workspace-scoped API token (non-interactive)
-# Pin a default workspace at login (with --oauth)
-cargo-ai login --oauth --workspace-uuid <uuid>
-```
+See [`../cargo/references/prerequisites.md`](../cargo/references/prerequisites.md) for install, login (`--oauth` / `--token`), JSON output conventions, and error shapes. Verify the session with `cargo-ai whoami` before running any of the commands below.
 
-Verify with `cargo-ai whoami`. All commands output JSON to stdout. Without a global install, prefix every command with `npx @cargo-ai/cli` instead of `cargo-ai`.
-
-Failed commands exit non-zero and return `{"errorMessage": "..."}`.
-
-**Note:** Billing commands require a token with admin access to the workspace.
+**Admin-only:** every command in this skill requires a token with admin access on the workspace. Non-admin tokens return `{"errorMessage":"forbidden"}`.
 
 ## Discover resources first
 

--- a/cargo-connection/SKILL.md
+++ b/cargo-connection/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cargo-connection
 description: Manage connectors and integrations using the Cargo CLI. Use when the user wants to list, create, update, or remove connectors, discover available integrations, or understand what connector actions are available for use in workflows.
-version: "1.0.0"
+version: "1.1.0"
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 homepage: https://github.com/getcargohq/cargo-skills
 metadata:
@@ -28,25 +28,15 @@ Connector and integration management: listing connectors, discovering available 
 > See `references/examples/integrations.md` for listing available integrations and OAuth flows.
 > For third-party connector rate limit handling and retry config in workflows, see `cargo-orchestration/references/polling.md` and `cargo-orchestration/references/troubleshooting.md`. Native integrations do not have rate limits.
 
-## Prerequisites
-
-```bash
-npm install -g @cargo-ai/cli
-cargo-ai login --oauth                                  # browser sign-in (recommended)
-# or: cargo-ai login --token <your-api-token>           # workspace-scoped API token (non-interactive)
-# Pin a default workspace at login (with --oauth)
-cargo-ai login --oauth --workspace-uuid <uuid>
-```
-
-Verify with `cargo-ai whoami`. All commands output JSON to stdout. Without a global install, prefix every command with `npx @cargo-ai/cli` instead of `cargo-ai`.
-
-Failed commands exit non-zero and return `{"errorMessage": "..."}`.
-
 ## Key concepts
 
 **Integration:** The external service type (e.g. HubSpot, Clearbit, Salesforce). Integrations define what actions are available.
 
 **Connector:** An authenticated instance of an integration. One integration can have multiple connectors (e.g. two different HubSpot accounts). Connectors are what you reference in workflow node graphs.
+
+## Prerequisites
+
+See [`../cargo/references/prerequisites.md`](../cargo/references/prerequisites.md) for install, login (`--oauth` / `--token`), JSON output conventions, and error shapes. Verify the session with `cargo-ai whoami` before running any of the commands below.
 
 ## Discover resources first
 
@@ -62,12 +52,12 @@ cargo-ai connection native-integration get                # built-in Cargo actio
 
 These two commands return **different sets of actions** and are not interchangeable:
 
-| Command | What it returns | When to use |
-|---|---|---|
-| `integration get <slug>` | Actions specific to a third-party service (e.g. HubSpot contact CRUD, deal management, Salesforce queries) | When you need service-specific actions to use in a connector node — **use this for HubSpot, Salesforce, Clearbit, etc.** |
-| `native-integration get` | Generic built-in Cargo actions (e.g. HTTP requests, data transforms, internal utilities) | When you need Cargo-native capabilities that don't belong to any specific third-party connector |
+| Command | Third-party service actions (HubSpot, Salesforce, Clearbit, …) | Built-in Cargo actions (HTTP, transforms, utilities) | When to use |
+|---|---|---|---|
+| `integration get <slug>` | ✓ | ✗ | You need actions for a specific third-party service — **use this for HubSpot, Salesforce, Clearbit, etc.** |
+| `native-integration get` | ✗ | ✓ | You need Cargo-native capabilities that don't belong to any specific third-party connector |
 
-**Example:** To find HubSpot-specific actions, use `integration get hubspot` — not `native-integration get`. The latter will only return generic actions unrelated to HubSpot.
+**Example:** To find HubSpot-specific actions, use `integration get hubspot` — `native-integration get` will not return them.
 
 ## Quick reference
 

--- a/cargo-context/SKILL.md
+++ b/cargo-context/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cargo-context
 description: Inspect and edit the workspace's git-backed context repository (the GTM knowledge base of markdown/MDX files) and its runtime sandbox using the Cargo CLI. Use when the user wants to browse/read/write/edit context files, run a command in the sandbox, or inspect the context knowledge graph.
-version: "1.0.0"
+version: "1.0.1"
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 homepage: https://github.com/getcargohq/cargo-skills
 metadata:
@@ -38,17 +38,7 @@ The **context** is a git-backed repository of typed markdown/MDX files that capt
 
 ## Prerequisites
 
-```bash
-npm install -g @cargo-ai/cli
-cargo-ai login --oauth                                  # browser sign-in (recommended)
-# or: cargo-ai login --token <your-api-token>           # workspace-scoped API token (non-interactive)
-# Pin a default workspace at login (with --oauth)
-cargo-ai login --oauth --workspace-uuid <uuid>
-```
-
-Verify with `cargo-ai whoami`. All commands output JSON to stdout. Without a global install, prefix every command with `npx @cargo-ai/cli` instead of `cargo-ai`.
-
-Failed commands exit non-zero and return `{"errorMessage": "..."}`.
+See [`../cargo/references/prerequisites.md`](../cargo/references/prerequisites.md) for install, login (`--oauth` / `--token`), JSON output conventions, and error shapes. Verify the session with `cargo-ai whoami` before running any of the commands below — `runtime write` and `runtime edit` push commits to the workspace's context repo, so confirming `workspace.name` first is non-negotiable.
 
 ## Discover the context first
 

--- a/cargo-orchestration/SKILL.md
+++ b/cargo-orchestration/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cargo-orchestration
 description: Interact with the Cargo platform via CLI. Use when the user wants to execute an action, run a workflow, trigger a batch, message an AI agent, query orchestration runtime tables (runs/batches/spans/records) with SQL, fetch segment records, or inspect a model schema.
-version: "1.4.0"
+version: "1.4.1"
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 homepage: https://github.com/getcargohq/cargo-skills
 metadata:
@@ -55,17 +55,7 @@ Need to run something?
 
 ## Prerequisites
 
-```bash
-npm install -g @cargo-ai/cli
-cargo-ai login --oauth                                  # browser sign-in (recommended)
-# or: cargo-ai login --token <your-api-token>           # workspace-scoped API token (non-interactive)
-# Pin a default workspace at login (with --oauth)
-cargo-ai login --oauth --workspace-uuid <uuid>
-```
-
-Verify with `cargo-ai whoami`. All commands output JSON to stdout. Without a global install, prefix every command with `npx @cargo-ai/cli` instead of `cargo-ai`.
-
-Failed commands exit non-zero and return `{"errorMessage": "..."}`.
+See [`../cargo/references/prerequisites.md`](../cargo/references/prerequisites.md) for install, login (`--oauth` / `--token`), JSON output conventions, and error shapes. Verify the session with `cargo-ai whoami` before running any of the commands below.
 
 ## Discover resources first
 

--- a/cargo-storage/SKILL.md
+++ b/cargo-storage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cargo-storage
 description: Manage models, datasets, columns, and relationships and query workspace storage with SQL using the Cargo CLI. Use when the user wants to inspect or modify data models, create or update columns, list datasets, set model relationships, understand the schema, or run SQL against storage.
-version: "1.1.0"
+version: "1.1.1"
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 homepage: https://github.com/getcargohq/cargo-skills
 metadata:
@@ -31,17 +31,7 @@ Data layer management: inspecting and modifying models, datasets, columns, relat
 
 ## Prerequisites
 
-```bash
-npm install -g @cargo-ai/cli
-cargo-ai login --oauth                                  # browser sign-in (recommended)
-# or: cargo-ai login --token <your-api-token>           # workspace-scoped API token (non-interactive)
-# Pin a default workspace at login (with --oauth)
-cargo-ai login --oauth --workspace-uuid <uuid>
-```
-
-Verify with `cargo-ai whoami`. All commands output JSON to stdout. Without a global install, prefix every command with `npx @cargo-ai/cli` instead of `cargo-ai`.
-
-Failed commands exit non-zero and return `{"errorMessage": "..."}`.
+See [`../cargo/references/prerequisites.md`](../cargo/references/prerequisites.md) for install, login (`--oauth` / `--token`), JSON output conventions, and error shapes. Verify the session with `cargo-ai whoami` before running any of the commands below.
 
 ## Discover resources first
 

--- a/cargo-workspace-management/SKILL.md
+++ b/cargo-workspace-management/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cargo-workspace-management
 description: Manage workspace users, API tokens, folders, roles, and submit reports to workspace management using the Cargo CLI. Use when the user wants to invite or manage workspace members, create or rotate API tokens, organize resources into folders, inspect workspace roles and permissions, or submit a report to workspace management when the CLI fails or is misused.
-version: "1.0.0"
+version: "1.0.1"
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 homepage: https://github.com/getcargohq/cargo-skills
 metadata:
@@ -31,19 +31,9 @@ Workspace administration: managing users, API tokens, folders, roles, workspace-
 
 ## Prerequisites
 
-```bash
-npm install -g @cargo-ai/cli
-cargo-ai login --oauth                                  # browser sign-in (recommended)
-# or: cargo-ai login --token <your-api-token>           # workspace-scoped API token (non-interactive)
-# Pin a default workspace at login (with --oauth)
-cargo-ai login --oauth --workspace-uuid <uuid>
-```
+See [`../cargo/references/prerequisites.md`](../cargo/references/prerequisites.md) for install, login (`--oauth` / `--token`), JSON output conventions, and error shapes. Verify the session with `cargo-ai whoami` before running any of the commands below.
 
-Verify with `cargo-ai whoami`. All commands output JSON to stdout. Without a global install, prefix every command with `npx @cargo-ai/cli` instead of `cargo-ai`.
-
-Failed commands exit non-zero and return `{"errorMessage": "..."}`.
-
-**Note:** Most workspace management commands require a token with admin access.
+**Admin-only:** user, role, and token writes require a token with admin access on the workspace. Folder writes and `report create` work with non-admin tokens.
 
 ## Discover resources first
 

--- a/cargo/SKILL.md
+++ b/cargo/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cargo
 description: Router and overview for the Cargo CLI agent skills. Explains the nine skills (one outcome skill cargo-gtm + eight capability skills), the UUID flow between them, async polling, end-to-end use cases (enrich one record, enrich and sync to CRM, AI lead scoring, custom workflow, error monitoring, fresh-workspace bootstrap, segment export, GTM context authoring), and common gotchas (`conjonction` spelling, run vs batch, model-uuid vs segment-uuid). Load first whenever working with the Cargo CLI, when unsure which sub-skill applies, when stitching multiple sub-skills together, when bootstrapping a workspace, or when the user asks about Cargo skills in general.
-version: "1.0.0"
+version: "1.1.0"
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 homepage: https://github.com/getcargohq/cargo-skills
 metadata:
@@ -66,7 +66,7 @@ cargo-ai whoami
 
 Without a global install, prefix every command with `npx @cargo-ai/cli` instead of `cargo-ai`.
 
-All commands output JSON to stdout. Failed commands exit non-zero and return `{"errorMessage": "..."}`.
+All commands output JSON to stdout. Failed commands exit non-zero and return `{"errorMessage": "..."}`. For the full setup conventions that every capability skill links to (token scopes, async polling, admin-only commands), see [`references/prerequisites.md`](references/prerequisites.md).
 
 ## Re-refresh mid-session
 
@@ -102,24 +102,24 @@ This is the official feedback channel — every report is reviewed by the Cargo 
 
 Load when the user states a real-world goal.
 
-| Skill                                     | Load when you need to…                                                                             |
-| ----------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| [`cargo-gtm`](#cargo-gtm)                 | Any GTM task — sourcing, enrichment, verification, scoring, sequencing, CRM sync, signal monitoring (job changes, funding, tech-stack/hiring intent). Routes via recipes (`recipes/`), guides (`guides/`), and provider playbooks (`provider-playbooks/`). |
+| Skill                                                       | Load when you need to…                                                                             |
+| ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| [`cargo-gtm`](../cargo-gtm/SKILL.md) ([recap](#cargo-gtm))  | Any GTM task — sourcing, enrichment, verification, scoring, sequencing, CRM sync, signal monitoring (job changes, funding, tech-stack/hiring intent). Routes via recipes (`recipes/`), guides (`guides/`), and provider playbooks (`provider-playbooks/`). |
 
 ### Capability skills
 
-Load for a specific CLI domain.
+Load for a specific CLI domain. The first link in each row jumps to the actual SKILL.md; the parenthetical jumps to the recap on this page.
 
-| Skill                                                                 | Load when you need to…                                                                             |
-| --------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| [`cargo-orchestration`](#cargo-orchestration)                         | Execute actions, run workflows, trigger batches, chat with agents, query orchestration with SQL (ClickHouse) |
-| [`cargo-analytics`](#cargo-analytics)                                 | Download run results, export segment data, monitor error rates and metrics                         |
-| [`cargo-billing`](#cargo-billing)                                     | Check credit usage, view subscription details, track costs per workflow or connector               |
-| [`cargo-storage`](#cargo-storage)                                     | Inspect or modify data models, columns, datasets, and relationships; query workspace storage with SQL |
-| [`cargo-connection`](#cargo-connection)                               | Manage connector authentication, discover available integrations and their actions                 |
-| [`cargo-ai`](#cargo-ai)                                               | Create and configure agents, upload files for RAG, manage MCP servers                              |
-| [`cargo-context`](#cargo-context)                                     | Browse/read/write/edit the workspace's git-backed GTM context repo, run commands in its runtime sandbox, inspect the knowledge graph |
-| [`cargo-workspace-management`](#cargo-workspace-management)           | Invite users, create API tokens, organize folders, manage roles, report CLI issues to management   |
+| Skill                                                                                                       | Load when you need to…                                                                             |
+| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| [`cargo-orchestration`](../cargo-orchestration/SKILL.md) ([recap](#cargo-orchestration))                    | Execute actions, run workflows, trigger batches, chat with agents, query orchestration with SQL (ClickHouse) |
+| [`cargo-analytics`](../cargo-analytics/SKILL.md) ([recap](#cargo-analytics))                                | Download run results, export segment data, monitor error rates and metrics                         |
+| [`cargo-billing`](../cargo-billing/SKILL.md) ([recap](#cargo-billing))                                      | Check credit usage, view subscription details, track costs per workflow or connector               |
+| [`cargo-storage`](../cargo-storage/SKILL.md) ([recap](#cargo-storage))                                      | Inspect or modify data models, columns, datasets, and relationships; query workspace storage with SQL |
+| [`cargo-connection`](../cargo-connection/SKILL.md) ([recap](#cargo-connection))                             | Manage connector authentication, discover available integrations and their actions                 |
+| [`cargo-ai`](../cargo-ai/SKILL.md) ([recap](#cargo-ai))                                                     | Create and configure agents, upload files for RAG, manage MCP servers                              |
+| [`cargo-context`](../cargo-context/SKILL.md) ([recap](#cargo-context))                                      | Browse/read/write/edit the workspace's git-backed GTM context repo, run commands in its runtime sandbox, inspect the knowledge graph |
+| [`cargo-workspace-management`](../cargo-workspace-management/SKILL.md) ([recap](#cargo-workspace-management)) | Invite users, create API tokens, organize folders, manage roles, report CLI issues to management   |
 
 ---
 

--- a/cargo/references/prerequisites.md
+++ b/cargo/references/prerequisites.md
@@ -1,0 +1,59 @@
+# Cargo CLI — prerequisites
+
+The same install, login, and runtime conventions apply to every Cargo skill in this bundle. Each capability skill links here instead of duplicating the boilerplate. Load the [`cargo` router skill](../SKILL.md) first if you haven't already — it covers session refresh and skill routing.
+
+## Install
+
+```bash
+npm install -g @cargo-ai/cli
+```
+
+Without a global install, prefix every command with `npx @cargo-ai/cli` instead of `cargo-ai`.
+
+## Authenticate
+
+```bash
+cargo-ai login --oauth                                  # browser sign-in (recommended)
+# or: cargo-ai login --token <your-api-token>           # workspace-scoped API token (non-interactive)
+# Pin a default workspace at login (with --oauth)
+cargo-ai login --oauth --workspace-uuid <uuid>
+```
+
+`--oauth` runs the OAuth 2.0 Device Authorization Flow — no client setup. For CI / scripts, use `--token` with a workspace-scoped API token from **Settings > API**. Token values are shown only once; store immediately in a secrets manager.
+
+## Verify
+
+```bash
+cargo-ai whoami
+# → { "user": { "uuid": ..., "email": ... }, "workspace": { "uuid": ..., "name": ... } }
+```
+
+Always confirm `workspace.name` before any write — there is no dry-run mode for destructive commands. If the active workspace is wrong, re-run `cargo-ai login --oauth --workspace-uuid <uuid>` (or `--token <workspace-scoped-token>` for non-interactive use).
+
+## Output conventions
+
+- All commands output **JSON to stdout**.
+- Successful commands exit `0`.
+- Failed commands exit non-zero and return `{"errorMessage": "..."}` — read this field for the cause.
+- Async commands (`run create`, `batch create`, `message create`, `action execute`, `action execute-batch`) return a UUID and a status that starts as `pending` / `running`. Pass `--wait-until-finished` to block, or poll the matching `get` command. See [`cargo-orchestration/references/polling.md`](../../cargo-orchestration/references/polling.md) for intervals and retry guidance.
+
+## Admin-only commands
+
+Some domains require a token with **admin access** on the workspace:
+
+- All of `cargo-billing` (usage metrics, subscription, invoices).
+- Most of `cargo-workspace-management` (users, roles, tokens — folder and report writes work with non-admin tokens).
+
+If a command returns `{"errorMessage":"forbidden"}` or `unauthorized`, the token likely lacks admin scope. Re-issue with an admin user, or ask a workspace admin to run the command.
+
+## When the CLI fails
+
+Whenever a CLI command misbehaves, a documented flag is missing, or you've retried the same command twice without progress, file a workspace management report:
+
+```bash
+cargo-ai workspaceManagement report create \
+  --title "<one-line summary>" \
+  --description "<command(s) tried, errorMessage, expected vs actual, relevant UUIDs>"
+```
+
+This is the official feedback channel — every report is reviewed by the Cargo team. See [`cargo-workspace-management/SKILL.md`](../../cargo-workspace-management/SKILL.md) (Reports section) for the full template.


### PR DESCRIPTION
## Summary

This PR introduces three major improvements to the skill bundle:

1. **Skill-bundle linter** — A new CI validation script that catches documentation drift before it reaches users
2. **Shared prerequisites reference** — Extracted duplicated install/login/output-conventions boilerplate into a single canonical document
3. **CHANGELOG** — Tracks per-skill version bumps and notable changes

## Key Changes

### New Files

- **`.github/scripts/skills-lint.mjs`** — Comprehensive linter that validates:
  - SKILL.md frontmatter shape (required fields: `name`, `description`, `version`, `compatibility`)
  - Version format (MAJOR.MINOR.PATCH)
  - JSON snippets inside fenced code blocks parse cleanly
  - Internal markdown links resolve to existing files
  - Bash examples reference known `cargo-ai` top-level domains
  - Grouped error/warning output with line numbers

- **`.github/workflows/skills-lint.yml`** — CI workflow that runs the linter on every push and PR

- **`CHANGELOG.md`** — Documents all notable changes across the skill bundle, organized by skill with SemVer guidance (MAJOR/MINOR/PATCH definitions)

- **`cargo/references/prerequisites.md`** — Canonical setup guide covering:
  - Install (`npm install -g @cargo-ai/cli`)
  - Authentication (`--oauth` / `--token` flows)
  - Verification (`cargo-ai whoami`)
  - Output conventions (JSON, exit codes, async polling)
  - Admin-only command scopes
  - Feedback channel (workspace management reports)

### Modified Files

All capability skills (`cargo-ai`, `cargo-analytics`, `cargo-billing`, `cargo-connection`, `cargo-context`, `cargo-orchestration`, `cargo-storage`, `cargo-workspace-management`) now:
- Link to `../cargo/references/prerequisites.md` instead of duplicating ~16 lines of boilerplate
- Have their Prerequisites sections trimmed to a single pointer
- Received version bumps (PATCH for most, MINOR for `cargo-connection`)

**`cargo/SKILL.md`** (1.0.0 → 1.1.0):
- Added reference to shared prerequisites
- Updated skill graph table to deep-link each row to target `SKILL.md`
- Clarified that full setup conventions are documented in `references/prerequisites.md`

## Implementation Details

- The linter is permissive about YAML parsing (line-based key:value extraction) since the frontmatter is flat and simple
- JSON validation handles common documentation patterns (ellipsis, templates, angle-bracket placeholders, inline comments) by skipping them
- Multi-line JSON objects in a single fenced block are supported, as are multiple sibling JSON objects (one per line)
- Bash validation uses regex to find `cargo-ai <token>` invocations and warns if the token is not in the known domains set
- All findings are grouped by file and printed with severity (ERROR/warn) and line numbers for easy navigation
- Exit code is 1 on any error, 0 otherwise (warnings do not fail the run)

https://claude.ai/code/session_011ZEDNX3x37Q1pFbbbef3xZ