### PR TITLE
Document structured output & heartbeat API fields in cargo-ai

### DIFF
--- a/cargo-ai/SKILL.md
+++ b/cargo-ai/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cargo-ai
 description: Create and configure AI agents, attach knowledge for RAG, manage MCP servers, and handle agent memories using the Cargo CLI. Use when the user wants to create or update agents, configure agent releases, connect MCP tool servers, or manage agent memories. To upload knowledge files or build knowledge libraries, use the cargo-content skill. For sending messages to agents, use the cargo-orchestration skill instead.
-version: "2.1.0"
+version: "2.2.0"
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 homepage: https://github.com/getcargohq/cargo-skills
 metadata:
@@ -144,6 +144,27 @@ cargo-ai ai release deploy-draft --agent-uuid <uuid> \
   --suggested-actions '[]' \
   --description "Added research actions"
 ```
+
+### Structured output & heartbeat — not yet exposed as CLI flags
+
+The release API payload (both `draft/update` and `draft/deploy`) accepts two fields that **`release update-draft` / `release deploy-draft` do not surface as flags** (verified against the CLI source — there is no `--output` / `--output-schema` or `--heartbeat`):
+
+| Field | Shape | Purpose |
+|---|---|---|
+| `output` | `{"type":"text"}` **or** `{"type":"jsonSchema","jsonSchema": <standard JSON Schema object>}` | Force the agent to return structured output matching a JSON Schema. |
+| `heartbeat` | `{"intervalMinutes": number, "maxMessages": number, "prompt": string \| null}` | Periodically re-wake the chat (`intervalMinutes`) until it reaches `maxMessages`; `prompt` is the wake message (null = generic "continue"). |
+
+The generic `--options` flag does **not** carry these — the API's `options` only holds `{connectorUuidsByIntegrationSlug, modelUuidsByIntegrationSlug}`. Until the flags ship, set these with a direct API call against the same endpoints the CLI uses:
+
+```bash
+# Structured (JSON Schema) output on the draft release
+curl -sS -X PUT "$CARGO_API_BASE/v1/ai/releases/draft/update" \
+  -H "Authorization: Bearer $CARGO_TOKEN" -H "Content-Type: application/json" \
+  -d '{"agentUuid":"<uuid>","output":{"type":"jsonSchema","jsonSchema":{"type":"object","properties":{"score":{"type":"number"}},"required":["score"]}}}'
+# Deploy carries the same fields — POST .../v1/ai/releases/draft/deploy
+```
+
+Send these payloads alongside the other fields you're updating (the endpoint replaces the draft config). **File a `workspaceManagement report`** (see [`../cargo-workspace-management/SKILL.md`](../cargo-workspace-management/SKILL.md)) to request first-class `--output` / `--heartbeat` flags — this is the documented feedback channel for CLI/UI parity gaps.
 
 **Agent configuration workflow:**
 

--- a/cargo-ai/references/troubleshooting.md
+++ b/cargo-ai/references/troubleshooting.md
@@ -41,6 +41,9 @@ A connector UUID referenced in the release actions or configuration does not exi
 **`failedToReconciliateAgentAiTools`**
 The actions configuration in the release is invalid — a referenced tool, agent, or connector UUID may not exist. Verify all UUIDs in the actions array.
 
+**Can't set structured (JSON Schema) output or a heartbeat from the CLI**
+`release update-draft` / `release deploy-draft` have no `--output` / `--output-schema` or `--heartbeat` flag, even though the release API payload accepts `output` and `heartbeat`. The generic `--options` flag won't carry them. See the "Structured output & heartbeat" section in [`../SKILL.md`](../SKILL.md) for the shapes and the direct-API workaround, and file a `workspaceManagement report` to request the flags.
+
 ## Templates
 
 **`templateNotFound`**


### PR DESCRIPTION
## Summary
Updated the cargo-ai skill documentation to clarify that the release API supports `output` (JSON Schema) and `heartbeat` fields that are not yet exposed as CLI flags, and provided workarounds and guidance for users who need these features.

## Changes
- **SKILL.md**: Added a new "Structured output & heartbeat" section documenting:
  - The two unsupported API fields (`output` for JSON Schema validation and `heartbeat` for periodic re-wake)
  - Their shapes and purposes in a reference table
  - A curl example showing how to set structured output via direct API call
  - Guidance to file a workspace management report to request first-class CLI flags

- **troubleshooting.md**: Added a new troubleshooting entry explaining:
  - Why `--output` / `--output-schema` and `--heartbeat` flags don't exist in the CLI
  - That the generic `--options` flag cannot carry these fields
  - Cross-reference to the workaround in SKILL.md

## Notable Details
- Version bumped from 2.1.0 to 2.2.0 to reflect documentation improvements
- Documented the API/CLI parity gap and provided a clear feedback channel (workspace management report) for users to request these features
- Included a practical curl example so users can work around the missing flags immediately

https://claude.ai/code/session_01SnAi6xefPd3TiZLuheGAJa