### PR TITLE
Move session lifecycle hooks to installer, simplify docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,17 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Repository-wide
 
+- **Session lifecycle moved to the installer.** The Claude Code `SessionStart`/`SessionEnd` hooks that keep `@cargo-ai/cli` + the skills bundle current and log each session to `workspace_management.sessions` are now scaffolded by the Cargo bootstrap installer (`curl -fsSL https://api.getcargo.io/install.sh | sh`, interactive prompt, opt out with `CARGO_INSTALL_NO_HOOKS=1`). Removed the hand-rolled hook-scaffolding recipes from `cargo/SKILL.md`, `README.md`, and `cargo-workspace-management/references/examples/sessions.md`; those docs now point at the installer. The agent's three-session-jobs guidance stays as the manual fallback, and reporting (job 2) is unchanged — it can't be automated.
 - **Shared prerequisites reference.** Extracted the duplicated install / login / output-conventions block from every capability skill into [`cargo/references/prerequisites.md`](cargo/references/prerequisites.md). Each capability skill now links to it instead of redefining ~16 lines of boilerplate. No behavior change for agents — the canonical setup is the same — but a single place to keep it correct.
 - **CHANGELOG.** This file. Per-skill version bumps are now recorded here so consumers can see what changed between two pinned versions.
 - **CI skill-lint.** Added [`.github/workflows/skills-lint.yml`](.github/workflows/skills-lint.yml) and [`.github/scripts/skills-lint.mjs`](.github/scripts/skills-lint.mjs). Runs on every push and PR; validates SKILL.md frontmatter shape, JSON snippets inside fenced code blocks, internal markdown links, and that bash examples reference real `cargo-ai` domains. Catches drift before it reaches users.
 - **Skill-lint domain list refreshed.** Added the CLI domains that shipped since the lint was written — `content`, `expression`, `hosting`, `revenue-organization`, `system-of-record`, `user-management`, plus `init`/`version` — so valid examples no longer warn.
 - **New capability skill: `cargo-content`.** The `content` CLI domain (files + libraries) is now its own skill rather than living inside `cargo-ai`, matching the repo's one-skill-per-CLI-domain convention. File/library command docs, the `examples/files.md` walkthrough, response shapes, and troubleshooting moved into `cargo-content/`; `cargo-ai` keeps the attach-to-agent wiring and cross-links to `cargo-content`.
+
+### `cargo` → 1.4.0
+
+- Removed the "Claude Code: scaffold a hook pair to automate the lifecycle" section. The installer now owns hook scaffolding, so the router no longer instructs the agent to offer it.
+- The "Every Cargo session has three jobs" section gains a callout: jobs 1 (refresh + register) and 3 (finalize) run automatically when the installer's `SessionStart`/`SessionEnd` hooks are present; do them by hand only when the hooks aren't installed. Job 2 (reporting) is unchanged and stays the agent's responsibility.
 
 ### `cargo` → 1.3.0
 
@@ -74,6 +80,11 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 ### `cargo-storage` → 1.1.1
 
 - Prerequisites section trimmed to a one-line pointer at `cargo/references/prerequisites.md`. No command surface change.
+
+### `cargo-workspace-management` → 1.0.2
+
+- `references/examples/sessions.md` no longer hand-rolls the SessionStart/SessionEnd hook scripts — it points at the Cargo installer, which scaffolds them. The `session upsert` command docs (CLI surface, schema, manual upsert) are unchanged.
+- Both in-SKILL pointers to `sessions.md` reworded to say the installer wires the hooks automatically.
 
 ### `cargo-workspace-management` → 1.0.1
 

--- a/README.md
+++ b/README.md
@@ -34,124 +34,15 @@ The Cargo CLI and these skills ship updates regularly. To always run the latest:
 
 ### Claude Code
 
-The `cargo` router skill instructs the agent to refresh CLI + skills at the start of every session ([see `cargo/SKILL.md`](cargo/SKILL.md)) — works out of the box. If you want guaranteed enforcement instead of prompt-level guidance, drop a `SessionStart` hook into your project's `.claude/` folder:
-
-`.claude/hooks/session-start.sh`:
+The Cargo installer wires this up for you. Run it once and answer **y** at the session-hooks prompt:
 
 ```bash
-#!/bin/bash
-set -euo pipefail
-
-# Only run in Claude Code on the web; local sessions manage CLI versions themselves.
-if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
-  exit 0
-fi
-
-npm install -g @cargo-ai/cli@latest
-npx -y skills add getcargohq/cargo-skills --all
+curl -fsSL https://api.getcargo.io/install.sh | sh
 ```
 
-`.claude/settings.json`:
+It scaffolds a `SessionStart` + `SessionEnd` hook pair under `~/.claude/` so that every new Claude Code session automatically (1) refreshes `@cargo-ai/cli` and the skills bundle and (2) logs the session to `workspace_management.sessions` with an AI-generated title and summary. The hooks swallow errors, so a missing `cargo-ai`/`claude`/`jq` binary never blocks a session. Set `CARGO_INSTALL_NO_HOOKS=1` to skip the prompt.
 
-```json
-{
-  "hooks": {
-    "SessionStart": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
-          }
-        ]
-      }
-    ]
-  }
-}
-```
-
-Make the script executable (`chmod +x .claude/hooks/session-start.sh`) and you're done — every Claude Code on the web session against that project will refresh both before the agent loop starts.
-
-## Tracking Claude Code sessions
-
-To get a workspace-wide record of every Claude Code session (one row per session, with an AI-generated title and summary), wire two hooks that call `cargo-ai workspaceManagement session upsert`. SessionStart creates the row; SessionEnd reads the transcript, asks `claude -p` to summarize, and stamps `finished_at`.
-
-`.claude/hooks/session-start.sh`:
-
-```bash
-#!/bin/bash
-set -u
-
-INPUT="$(cat)"
-SESSION_ID="$(printf '%s' "$INPUT" | jq -r '.session_id // "unknown"' 2>/dev/null || echo "unknown")"
-
-cargo-ai workspaceManagement session upsert \
-  --session-id "$SESSION_ID" \
-  --title "Claude Code session ${SESSION_ID}" \
-  --summary "Session in progress." >/dev/null 2>&1 || true
-
-exit 0
-```
-
-`.claude/hooks/session-end.sh`:
-
-```bash
-#!/bin/bash
-set -u
-
-INPUT="$(cat)"
-SESSION_ID="$(printf '%s' "$INPUT" | jq -r '.session_id // "unknown"' 2>/dev/null || echo "unknown")"
-TRANSCRIPT_PATH="$(printf '%s' "$INPUT" | jq -r '.transcript_path // ""' 2>/dev/null || echo "")"
-
-TITLE="Claude Code session ${SESSION_ID}"
-SUMMARY="Session ended."
-
-if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ] && command -v claude >/dev/null 2>&1; then
-  TAIL="$(tail -c 60000 "$TRANSCRIPT_PATH" 2>/dev/null || true)"
-  if [ -n "$TAIL" ]; then
-    PROMPT='Read the Claude Code transcript on stdin and reply with a single JSON object: {"title":"<5-8 word title>","summary":"<1-2 sentence summary>"}. JSON only.'
-    RESPONSE="$(printf '%s' "$TAIL" | claude -p "$PROMPT" 2>/dev/null || true)"
-    CLEAN="$(printf '%s' "$RESPONSE" | sed -n '/{/,/}/p')"
-    PARSED_TITLE="$(printf '%s' "$CLEAN" | jq -r '.title // empty' 2>/dev/null || true)"
-    PARSED_SUMMARY="$(printf '%s' "$CLEAN" | jq -r '.summary // empty' 2>/dev/null || true)"
-    [ -n "$PARSED_TITLE" ] && TITLE="$PARSED_TITLE"
-    [ -n "$PARSED_SUMMARY" ] && SUMMARY="$PARSED_SUMMARY"
-  fi
-fi
-
-cargo-ai workspaceManagement session upsert \
-  --session-id "$SESSION_ID" \
-  --title "$TITLE" \
-  --summary "$SUMMARY" \
-  --finished >/dev/null 2>&1 || true
-
-exit 0
-```
-
-Merge into `.claude/settings.json` (alongside any other hooks already there):
-
-```json
-{
-  "hooks": {
-    "SessionStart": [
-      {
-        "hooks": [
-          { "type": "command", "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh" }
-        ]
-      }
-    ],
-    "SessionEnd": [
-      {
-        "hooks": [
-          { "type": "command", "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-end.sh" }
-        ]
-      }
-    ]
-  }
-}
-```
-
-`chmod +x .claude/hooks/session-{start,end}.sh` and every session against that project will land in `workspace_management.sessions` with a real title and summary. Hooks fail silently if `cargo-ai` or `claude` isn't on `$PATH`, so missing tooling never blocks a session.
+Without the installer, the `cargo` router skill still instructs the agent to refresh CLI + skills at the start of every session ([see `cargo/SKILL.md`](cargo/SKILL.md)) — that works out of the box, just without the hard enforcement and session logging the hooks provide.
 
 ### OpenClaw
 

--- a/cargo-workspace-management/SKILL.md
+++ b/cargo-workspace-management/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cargo-workspace-management
 description: Manage workspace users, API tokens, folders, roles, and submit reports to workspace management using the Cargo CLI. Use when the user wants to invite or manage workspace members, create or rotate API tokens, organize resources into folders, inspect workspace roles and permissions, or submit a report to workspace management when the CLI fails or is misused.
-version: "1.0.1"
+version: "1.0.2"
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 homepage: https://github.com/getcargohq/cargo-skills
 metadata:
@@ -28,7 +28,7 @@ Workspace administration: managing users, API tokens, folders, roles, workspace-
 > See `references/examples/tokens.md` for API token creation and rotation examples.
 > See `references/examples/folders.md` for organizing resources into folders.
 > See `references/examples/reports.md` for examples of submitting workspace management reports.
-> See `references/examples/sessions.md` for the Claude Code SessionStart + SessionEnd hook recipe.
+> See `references/examples/sessions.md` for session tracking — the Cargo installer scaffolds the Claude Code SessionStart + SessionEnd hooks automatically.
 
 ## Prerequisites
 
@@ -196,7 +196,7 @@ cargo-ai workspaceManagement session upsert \
 - `--finished` stamps `finished_at = now`. Use `--finished-at <iso>` for an explicit timestamp instead.
 - Calling `upsert` twice with the same `--session-id` updates the same row — `title`, `summary`, and `finished_at` are overwritten.
 
-Returns the upserted session as JSON. See [`references/examples/sessions.md`](references/examples/sessions.md) for the full hook recipe with transcript-driven AI summarization.
+Returns the upserted session as JSON. The Cargo installer (`curl -fsSL https://api.getcargo.io/install.sh | sh`) wires SessionStart + SessionEnd hooks that call this command with transcript-driven AI summarization automatically — see [`references/examples/sessions.md`](references/examples/sessions.md).
 
 ## Workspace files
 

--- a/cargo-workspace-management/references/examples/sessions.md
+++ b/cargo-workspace-management/references/examples/sessions.md
@@ -51,81 +51,12 @@ cargo-ai workspaceManagement session upsert \
 
 ## Automate with Claude Code hooks (recommended)
 
-Two hooks let Claude Code track every session automatically: SessionStart creates the row with placeholders, SessionEnd reads the transcript, asks `claude -p` to summarize, and writes the real title + summary along with `--finished`.
-
-`.claude/hooks/session-start.sh`:
+Don't hand-roll the hooks — the Cargo installer scaffolds them for you. Run it once and answer **y** at the session-hooks prompt:
 
 ```bash
-#!/bin/bash
-set -u
-
-INPUT="$(cat)"
-SESSION_ID="$(printf '%s' "$INPUT" | jq -r '.session_id // "unknown"' 2>/dev/null || echo "unknown")"
-
-cargo-ai workspaceManagement session upsert \
-  --session-id "$SESSION_ID" \
-  --title "Claude Code session ${SESSION_ID}" \
-  --summary "Session in progress." >/dev/null 2>&1 || true
-
-exit 0
+curl -fsSL https://api.getcargo.io/install.sh | sh
 ```
 
-`.claude/hooks/session-end.sh`:
+It writes a `SessionStart` + `SessionEnd` hook pair under `~/.claude/` and merges the matching entries into `~/.claude/settings.json`. SessionStart refreshes `@cargo-ai/cli` + the skills bundle and creates the session row with placeholders; SessionEnd reads the transcript, asks `claude -p` to summarize, and writes the real title + summary with `--finished`. Both hooks swallow errors (`|| true`), so a missing `cargo-ai`/`claude`/`jq` binary never blocks a session — at worst, the row just doesn't get written. Set `CARGO_INSTALL_NO_HOOKS=1` to skip the prompt.
 
-```bash
-#!/bin/bash
-set -u
-
-INPUT="$(cat)"
-SESSION_ID="$(printf '%s' "$INPUT" | jq -r '.session_id // "unknown"' 2>/dev/null || echo "unknown")"
-TRANSCRIPT_PATH="$(printf '%s' "$INPUT" | jq -r '.transcript_path // ""' 2>/dev/null || echo "")"
-
-TITLE="Claude Code session ${SESSION_ID}"
-SUMMARY="Session ended."
-
-if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ] && command -v claude >/dev/null 2>&1; then
-  TAIL="$(tail -c 60000 "$TRANSCRIPT_PATH" 2>/dev/null || true)"
-  if [ -n "$TAIL" ]; then
-    PROMPT='Read the Claude Code transcript on stdin and reply with a single JSON object: {"title":"<5-8 word title>","summary":"<1-2 sentence summary>"}. JSON only.'
-    RESPONSE="$(printf '%s' "$TAIL" | claude -p "$PROMPT" 2>/dev/null || true)"
-    CLEAN="$(printf '%s' "$RESPONSE" | sed -n '/{/,/}/p')"
-    PARSED_TITLE="$(printf '%s' "$CLEAN" | jq -r '.title // empty' 2>/dev/null || true)"
-    PARSED_SUMMARY="$(printf '%s' "$CLEAN" | jq -r '.summary // empty' 2>/dev/null || true)"
-    [ -n "$PARSED_TITLE" ] && TITLE="$PARSED_TITLE"
-    [ -n "$PARSED_SUMMARY" ] && SUMMARY="$PARSED_SUMMARY"
-  fi
-fi
-
-cargo-ai workspaceManagement session upsert \
-  --session-id "$SESSION_ID" \
-  --title "$TITLE" \
-  --summary "$SUMMARY" \
-  --finished >/dev/null 2>&1 || true
-
-exit 0
-```
-
-Merge into `.claude/settings.json`:
-
-```json
-{
-  "hooks": {
-    "SessionStart": [
-      {
-        "hooks": [
-          { "type": "command", "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh" }
-        ]
-      }
-    ],
-    "SessionEnd": [
-      {
-        "hooks": [
-          { "type": "command", "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-end.sh" }
-        ]
-      }
-    ]
-  }
-}
-```
-
-`chmod +x .claude/hooks/session-{start,end}.sh` to finish. Both hooks swallow errors (`|| true`) so a missing `cargo-ai` or `claude` binary never blocks a session — at worst, the row just doesn't get written.
+The hooks are thin wrappers around the `session upsert` command documented above — read the installer (`apps/backend/src/http/routes/install.sh` in `getcargohq/cargo`) if you want to see or customize the exact scripts.

--- a/cargo/SKILL.md
+++ b/cargo/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cargo
 description: Router and overview for the Cargo CLI agent skills. Explains the nine skills (one outcome skill cargo-gtm + eight capability skills), the UUID flow between them, async polling, end-to-end use cases (enrich one record, enrich and sync to CRM, AI lead scoring, custom workflow, error monitoring, fresh-workspace bootstrap, segment export, GTM context authoring), and common gotchas (`conjonction` spelling, run vs batch, model-uuid vs segment-uuid). Load first whenever working with the Cargo CLI, when unsure which sub-skill applies, when stitching multiple sub-skills together, when bootstrapping a workspace, or when the user asks about Cargo skills in general.
-version: "1.3.0"
+version: "1.4.0"
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 homepage: https://github.com/getcargohq/cargo-skills
 metadata:
@@ -54,6 +54,8 @@ Without a global install, prefix every command with `npx @cargo-ai/cli` instead 
 All commands output JSON to stdout. Failed commands exit non-zero and return `{"errorMessage": "..."}`. For the full setup conventions that every capability skill links to (token scopes, async polling, admin-only commands), see [`references/prerequisites.md`](references/prerequisites.md).
 
 ## Every Cargo session has three jobs
+
+> **Automated by the Cargo installer.** Jobs 1 and 3 (refresh + session register/finalize) run on their own when the `SessionStart`/`SessionEnd` hooks scaffolded by `curl -fsSL https://api.getcargo.io/install.sh | sh` are present. Do them by hand only when those hooks aren't installed. Job 2 (reporting) is always your responsibility — it can't be automated.
 
 ### 1. At session start — refresh and register
 
@@ -110,15 +112,6 @@ cargo-ai workspaceManagement session upsert \
 ```
 
 `--title` and `--summary` are required (NOT NULL). `--finished` stamps `finished_at = now`; pass `--finished-at <iso>` for an explicit timestamp.
-
-## Claude Code: scaffold a hook pair to automate the lifecycle
-
-If you are running in Claude Code and the user's project does not already have `SessionStart` + `SessionEnd` hooks for the lifecycle above (check `.claude/settings.json` and `.claude/hooks/`), offer **once per session** to scaffold them — phrase it as a single yes/no question ("Want me to wire up SessionStart + SessionEnd hooks so the CLI/skills auto-refresh and every session is tracked in workspace management?"). On yes, write `.claude/hooks/session-start.sh` + `.claude/hooks/session-end.sh`, merge the `SessionStart` + `SessionEnd` entries into `.claude/settings.json`, and `chmod +x` both scripts. Recipes:
-
-- [`../README.md#claude-code`](../README.md#claude-code) — auto-refresh CLI + skills at session start
-- [`../cargo-workspace-management/references/examples/sessions.md`](../cargo-workspace-management/references/examples/sessions.md) — session tracking with AI-generated title/summary at session end
-
-Both flows can share a single `session-start.sh` (refresh + register) and a single `session-end.sh` (summarize + finalize). Do not offer if the hooks are already present, if the user declined earlier in the session, or if the project clearly isn't using Claude Code.
 
 ---
 


### PR DESCRIPTION
## Summary
Moved the Claude Code `SessionStart`/`SessionEnd` hook scaffolding from manual documentation recipes into the Cargo bootstrap installer. Users now run a single command (`curl -fsSL https://api.getcargo.io/install.sh | sh`) to automatically set up session tracking and CLI/skills auto-refresh, rather than hand-rolling hooks and `.claude/settings.json` entries.

## Key Changes

- **Removed hand-rolled hook recipes** from `README.md`, `cargo/SKILL.md`, and `cargo-workspace-management/references/examples/sessions.md`. These files previously contained ~80 lines of bash scripts and JSON configuration that users had to manually copy and integrate.

- **Updated documentation to point at the installer** instead. All three files now direct users to run the installer command and note that it scaffolds the hooks automatically, with an option to skip via `CARGO_INSTALL_NO_HOOKS=1`.

- **Clarified the three-session-jobs pattern** in `cargo/SKILL.md` with a note that jobs 1 and 3 (refresh + session register/finalize) are now automated by the installer hooks, while job 2 (reporting) remains manual and cannot be automated.

- **Updated skill versions and CHANGELOG**:
  - `cargo/SKILL.md`: bumped to 1.4.0
  - `cargo-workspace-management/SKILL.md`: bumped to 1.0.2
  - Added entry to `CHANGELOG.md` documenting the session lifecycle migration to the installer

- **Updated cross-references** in `cargo-workspace-management/SKILL.md` to reflect that session tracking is now installer-driven rather than a manual recipe.

## Implementation Details

The hooks themselves (SessionStart + SessionEnd) are not removed — they're now generated and installed by the Cargo bootstrap installer (`apps/backend/src/http/routes/install.sh` in the main Cargo repo). This change reduces friction for new users and ensures hooks stay in sync with the CLI as it evolves. The manual fallback guidance remains in `cargo/SKILL.md` for users without the installer hooks.

https://claude.ai/code/session_017VAhep38mC31RPRE7xJwV4