### PR TITLE
docs(orchestration): document action get-output-schema

### DIFF
--- a/cargo-connection/SKILL.md
+++ b/cargo-connection/SKILL.md
@@ -264,7 +264,9 @@ cargo-ai connection connector list
 
 # 2. Discover available actions for the integration
 cargo-ai connection integration get <integration-slug>
-# → actions are keyed by actionSlug, with config.jsonSchema for each
+# → actions are keyed by actionSlug, with config.jsonSchema (input) for each
+# → many actions also carry output.schema — the JSON Schema of what the action
+#   emits; use it to wire downstream nodes instead of guessing (absent on some actions)
 # → Or use get-documentation for a plain text overview
 # → Or use native-integration get for built-in Cargo actions (not third-party)
 
@@ -280,7 +282,7 @@ Example connector node (Clearbit company enrichment):
   "slug": "enrich",
   "kind": "connector",
   "integrationSlug": "clearbit",
-  "actionSlug": "company_enrich",
+  "actionSlug": "enrichCompany",
   "connectorUuid": "<clearbit-connector-uuid>",
   "config": {
     "domain": {

--- a/cargo-connection/references/response-shapes.md
+++ b/cargo-connection/references/response-shapes.md
@@ -123,6 +123,12 @@ Returns the full integration object, including all actions and extractors with t
         "config": {
           "jsonSchema": { "type": "object", "properties": { "domain": { "type": "string" } } }
         },
+        "output": {
+          "schema": {
+            "type": "object",
+            "properties": { "name": { "type": "string" }, "domain": { "type": "string" } }
+          }
+        },
         "credits": {
           "costs": [{ "type": "fixed", "cost": 1 }]
         },
@@ -174,7 +180,7 @@ Returns the full integration object, including all actions and extractors with t
 }
 ```
 
-**Key fields:** `actions` is keyed by `actionSlug` — use these in workflow connector nodes. `connector.config.jsonSchema` describes the credentials needed when creating a connector (for non-credit integrations). `extractors` is keyed by extractor slug — use these when creating models.
+**Key fields:** `actions` is keyed by `actionSlug` — use these in workflow connector nodes. Each action's `config.jsonSchema` is its **input**; `output.schema`, when present, is the JSON Schema of what the action **emits** — read it instead of guessing the output shape (not every action declares one; `integration list` includes it too). `connector.config.jsonSchema` describes the credentials needed when creating a connector (for non-credit integrations). `extractors` is keyed by extractor slug — use these when creating models.
 
 **`uiSchema` and autocomplete:** Each action's `config` may include a `uiSchema` alongside `jsonSchema`. When a field in `uiSchema` has `"ui:widget": "IntegrationAutocompleteWidget"`, its allowed values must be fetched via `connector autocomplete`. The `ui:options.slug` tells you which autocomplete slug to use, and `ui:options.params` (if present) specifies dependent parameters — replace `$this.$parent...` expressions with actual values. See the main SKILL.md for the full autocomplete workflow.
 

--- a/cargo-orchestration/SKILL.md
+++ b/cargo-orchestration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cargo-orchestration
-description: Interact with the Cargo platform via CLI. Use when the user wants to execute an action, run a workflow, trigger a batch, message an AI agent, query orchestration runtime tables (runs/batches/spans/records) with SQL, fetch segment records, or inspect a model schema.
+description: Interact with the Cargo platform via CLI. Use when the user wants to execute an action, run a workflow, trigger a batch, message an AI agent, query orchestration runtime tables (runs/batches/spans/records) with SQL, fetch segment records, resolve an action's output schema, or inspect a model schema.
 version: "1.5.0"
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 homepage: https://github.com/getcargohq/cargo-skills
@@ -101,6 +101,7 @@ cargo-ai connection connector list         # all connectors
 # Single actions
 cargo-ai orchestration action execute --action '{"kind":"tool","toolUuid":"<uuid>","config":{}}' --data '{"domain":"acme.com"}'
 cargo-ai orchestration action execute-batch --action '{"kind":"connector","integrationSlug":"clearbit","actionSlug":"company_enrich","config":{}}' --records '[{...},{...}]'
+cargo-ai orchestration action get-output-schema --action '{"kind":"connector","integrationSlug":"clearbit","actionSlug":"company_enrich","config":{}}' # resolve output JSON Schema without executing
 
 # Workflows (chain multiple actions)
 cargo-ai orchestration run create --workflow-uuid <uuid> --data '{"company":"Acme","domain":"acme.com"}'
@@ -149,6 +150,24 @@ cargo-ai orchestration action execute-batch \
 ```
 
 Action kinds: `tool`, `connector`, `agent`, `native`. See `references/examples/actions.md` for all action kinds, parameters, retry config, response shapes, and end-to-end examples.
+
+### Resolve an action's output schema (without executing)
+
+`integration get <slug>` tells you an action's **input** shape (`config.jsonSchema`). To learn what an action **produces** — the fields and types in its `data` output — resolve its output schema **without spending credits or running anything**:
+
+```bash
+cargo-ai orchestration action get-output-schema \
+  --action '{"kind":"connector","integrationSlug":"clearbit","actionSlug":"company_enrich","config":{}}'
+# → JSON Schema describing the action's data output
+```
+
+Takes the same `--action` shape as `action execute` (`tool` / `connector` / `agent` / `native`). Use it to:
+
+- Know which fields a downstream node can read (`{{nodes.<slug>.<field>}}`) **before** wiring the graph.
+- Build a structured `agent` node `output.jsonSchema` from an upstream action's real output shape.
+- Map an action's output onto storage columns without a throwaway run.
+
+See `references/examples/actions.md` ("Resolve an action's output schema") for response shape and end-to-end usage.
 
 ## Create a run
 

--- a/cargo-orchestration/SKILL.md
+++ b/cargo-orchestration/SKILL.md
@@ -153,7 +153,10 @@ Action kinds: `tool`, `connector`, `agent`, `native`. See `references/examples/a
 
 ### Resolve an action's output schema (without executing)
 
-**Never guess what an action outputs.** `integration get <slug>` tells you an action's **input** shape (`config.jsonSchema`); its output shape is resolvable too — **without spending credits or running anything**:
+**Never guess what an action outputs.** Two free sources — no run, no credits:
+
+1. **Connector actions:** the integration catalog carries the output schema inline — `integration get <slug>` (and `integration list`) return `actions.<actionSlug>.output.schema` next to the input `config.jsonSchema`. Not every action declares one.
+2. **Any action kind** (`tool` / `connector` / `agent` / `native`) — resolve it with the same `--action` object as `action execute`:
 
 ```bash
 cargo-ai orchestration action get-output-schema \
@@ -161,7 +164,7 @@ cargo-ai orchestration action get-output-schema \
 # → {"schema": {"type": "object", "properties": {...}}}  — the JSON Schema is under the top-level "schema" key
 ```
 
-Takes the same `--action` object as `action execute` (`tool` / `connector` / `agent` / `native`). Use it to:
+Actions that declare no output schema fail with `"Action has no output schema."` (non-zero exit, status 404) — that's the signal to fall back to inspecting `runContext` from a real run. Use these to:
 
 - Know which fields a downstream node can read (`{{nodes.<slug>.<field>}}`) **before** wiring the graph.
 - See an `agent` action's real output envelope — a default free-text agent resolves to `{"schema":{"type":"object","properties":{"answer":{"type":"string"}}}}`, which is why downstream references need `{{nodes.<slug>.answer...}}`.

--- a/cargo-orchestration/SKILL.md
+++ b/cargo-orchestration/SKILL.md
@@ -100,8 +100,8 @@ cargo-ai connection connector list         # all connectors
 ```bash
 # Single actions
 cargo-ai orchestration action execute --action '{"kind":"tool","toolUuid":"<uuid>","config":{}}' --data '{"domain":"acme.com"}'
-cargo-ai orchestration action execute-batch --action '{"kind":"connector","integrationSlug":"clearbit","actionSlug":"company_enrich","config":{}}' --records '[{...},{...}]'
-cargo-ai orchestration action get-output-schema --action '{"kind":"connector","integrationSlug":"clearbit","actionSlug":"company_enrich","config":{}}' # resolve output JSON Schema without executing
+cargo-ai orchestration action execute-batch --action '{"kind":"connector","integrationSlug":"clearbit","actionSlug":"enrichCompany","config":{}}' --records '[{...},{...}]'
+cargo-ai orchestration action get-output-schema --action '{"kind":"connector","integrationSlug":"clearbit","actionSlug":"enrichCompany","config":{}}' # → {"schema": <JSON Schema>} without executing
 
 # Workflows (chain multiple actions)
 cargo-ai orchestration run create --workflow-uuid <uuid> --data '{"company":"Acme","domain":"acme.com"}'
@@ -138,7 +138,7 @@ Run a single action — no workflow or node graph needed.
 ```bash
 # One action, one record → returns a run
 cargo-ai orchestration action execute \
-  --action '{"kind":"connector","integrationSlug":"clearbit","actionSlug":"company_enrich","config":{}}' \
+  --action '{"kind":"connector","integrationSlug":"clearbit","actionSlug":"enrichCompany","config":{}}' \
   --data '{"domain":"acme.com"}' \
   --wait-until-finished
 
@@ -153,21 +153,21 @@ Action kinds: `tool`, `connector`, `agent`, `native`. See `references/examples/a
 
 ### Resolve an action's output schema (without executing)
 
-`integration get <slug>` tells you an action's **input** shape (`config.jsonSchema`). To learn what an action **produces** — the fields and types in its `data` output — resolve its output schema **without spending credits or running anything**:
+**Never guess what an action outputs.** `integration get <slug>` tells you an action's **input** shape (`config.jsonSchema`); its output shape is resolvable too — **without spending credits or running anything**:
 
 ```bash
 cargo-ai orchestration action get-output-schema \
-  --action '{"kind":"connector","integrationSlug":"clearbit","actionSlug":"company_enrich","config":{}}'
-# → JSON Schema describing the action's data output
+  --action '{"kind":"connector","integrationSlug":"clearbit","actionSlug":"enrichCompany","config":{}}'
+# → {"schema": {"type": "object", "properties": {...}}}  — the JSON Schema is under the top-level "schema" key
 ```
 
-Takes the same `--action` shape as `action execute` (`tool` / `connector` / `agent` / `native`). Use it to:
+Takes the same `--action` object as `action execute` (`tool` / `connector` / `agent` / `native`). Use it to:
 
 - Know which fields a downstream node can read (`{{nodes.<slug>.<field>}}`) **before** wiring the graph.
-- Build a structured `agent` node `output.jsonSchema` from an upstream action's real output shape.
+- See an `agent` action's real output envelope — a default free-text agent resolves to `{"schema":{"type":"object","properties":{"answer":{"type":"string"}}}}`, which is why downstream references need `{{nodes.<slug>.answer...}}`.
 - Map an action's output onto storage columns without a throwaway run.
 
-See `references/examples/actions.md` ("Resolve an action's output schema") for response shape and end-to-end usage.
+See `references/examples/actions.md` ("Resolve an action's output schema") for verified per-kind examples and the response/error shapes.
 
 ## Create a run
 

--- a/cargo-orchestration/references/examples/actions.md
+++ b/cargo-orchestration/references/examples/actions.md
@@ -189,6 +189,50 @@ cargo-ai connection connector list
 
 ---
 
+## Resolve an action's output schema
+
+`integration get <slug>` describes an action's **input** (`config.jsonSchema`). To discover what an action **produces** — the shape of its `data` output — resolve its output schema **without executing it** (no run, no credits):
+
+```bash
+cargo-ai orchestration action get-output-schema \
+  --action '{"kind":"connector","integrationSlug":"clearbit","actionSlug":"company_enrich","config":{}}'
+```
+
+It accepts the same `--action` object as `action execute`, so it works for every kind:
+
+```bash
+# Tool action
+cargo-ai orchestration action get-output-schema \
+  --action '{"kind":"tool","toolUuid":"<tool-uuid>","config":{}}'
+
+# Native action
+cargo-ai orchestration action get-output-schema \
+  --action '{"kind":"native","actionSlug":"<slug>","config":{}}'
+```
+
+### Response
+
+A JSON Schema object describing the fields and types the action emits in its `data` output — e.g.:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "name": { "type": "string" },
+    "domain": { "type": "string" },
+    "employeesCount": { "type": "number" }
+  }
+}
+```
+
+### Why it's useful
+
+- **Wire a node graph correctly the first time.** Know which fields exist before referencing them downstream as `{{nodes.<slug>.<field>}}` — avoids the silent-`undefined` footgun (see `../node-selection.md`).
+- **Drive a structured `agent` node.** Shape the agent's `output.jsonSchema` from an upstream action's real output instead of guessing.
+- **Map onto storage columns** ahead of a batch, without a throwaway run to inspect the output.
+
+---
+
 ## End-to-end: enrich a company with a connector action
 
 ```bash

--- a/cargo-orchestration/references/examples/actions.md
+++ b/cargo-orchestration/references/examples/actions.md
@@ -29,7 +29,7 @@ cargo-ai orchestration action execute \
 
 # Connector action
 cargo-ai orchestration action execute \
-  --action '{"kind":"connector","integrationSlug":"clearbit","actionSlug":"company_enrich","config":{}}' \
+  --action '{"kind":"connector","integrationSlug":"clearbit","actionSlug":"enrichCompany","config":{}}' \
   --data '{"domain":"acme.com"}'
 
 # Agent action
@@ -42,7 +42,7 @@ Returns a `run` object. Poll with `run get <uuid>` until terminal, or pass `--wa
 
 ```bash
 cargo-ai orchestration action execute \
-  --action '{"kind":"connector","integrationSlug":"clearbit","actionSlug":"company_enrich","config":{}}' \
+  --action '{"kind":"connector","integrationSlug":"clearbit","actionSlug":"enrichCompany","config":{}}' \
   --data '{"domain":"acme.com"}' \
   --wait-until-finished
 ```
@@ -97,7 +97,7 @@ Returns a `batch` object. Poll with `batch get <uuid>` until terminal, or pass `
 
 ```bash
 cargo-ai orchestration action execute-batch \
-  --action '{"kind":"connector","integrationSlug":"clearbit","actionSlug":"company_enrich","config":{}}' \
+  --action '{"kind":"connector","integrationSlug":"clearbit","actionSlug":"enrichCompany","config":{}}' \
   --records '[{"domain":"acme.com"},{"domain":"globex.com"}]' \
   --wait-until-finished
 ```
@@ -154,7 +154,7 @@ cargo-ai orchestration action execute \
   --action '{
     "kind":"connector",
     "integrationSlug":"clearbit",
-    "actionSlug":"company_enrich",
+    "actionSlug":"enrichCompany",
     "config":{},
     "retry":{"maximumAttempts":3,"initialInterval":1000,"backoffCoefficient":2}
   }' \
@@ -191,19 +191,23 @@ cargo-ai connection connector list
 
 ## Resolve an action's output schema
 
-`integration get <slug>` describes an action's **input** (`config.jsonSchema`). To discover what an action **produces** — the shape of its `data` output — resolve its output schema **without executing it** (no run, no credits):
+**Never guess what an action outputs.** `integration get <slug>` only describes an action's **input** (`config.jsonSchema`) — the integration catalog carries no output information. To discover what an action **produces**, resolve its output schema **without executing it** (no run, no credits):
 
 ```bash
 cargo-ai orchestration action get-output-schema \
-  --action '{"kind":"connector","integrationSlug":"clearbit","actionSlug":"company_enrich","config":{}}'
+  --action '{"kind":"connector","integrationSlug":"clearbit","actionSlug":"enrichCompany","config":{}}'
 ```
 
 It accepts the same `--action` object as `action execute`, so it works for every kind:
 
 ```bash
-# Tool action
+# Tool action — resolves the tool workflow's output-node schema
 cargo-ai orchestration action get-output-schema \
   --action '{"kind":"tool","toolUuid":"<tool-uuid>","config":{}}'
+
+# Agent action — resolves the deployed release's output schema
+cargo-ai orchestration action get-output-schema \
+  --action '{"kind":"agent","agentUuid":"<agent-uuid>","config":{}}'
 
 # Native action
 cargo-ai orchestration action get-output-schema \
@@ -212,23 +216,32 @@ cargo-ai orchestration action get-output-schema \
 
 ### Response
 
-A JSON Schema object describing the fields and types the action emits in its `data` output — e.g.:
+The JSON Schema sits under a top-level **`schema`** key (not returned bare) — e.g. `waterfall` / `verifyEmail` resolves to:
 
 ```json
 {
-  "type": "object",
-  "properties": {
-    "name": { "type": "string" },
-    "domain": { "type": "string" },
-    "employeesCount": { "type": "number" }
+  "schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "email": { "type": "string" },
+      "domain": { "type": "string" },
+      "email_status": { "type": "string" },
+      "smtp_provider": { "type": "string" },
+      "mx_records": { "type": "array", "items": { "type": "string" } }
+    }
   }
 }
 ```
 
+An `agent` action without a structured `output.jsonSchema` resolves to `{"schema":{"type":"object","properties":{"answer":{"type":"string"}}}}` — the free-text answer envelope. This is the authoritative confirmation that downstream references must go through `.answer` (`{{nodes.<slug>.answer}}`, or `{{nodes.<slug>.answer.<field>}}` for structured agents).
+
+An unknown `actionSlug` / `toolUuid` / `agentUuid` exits non-zero with `{"error":"Not found: RequestError: Action not found.. Verify the UUID(s) you passed.","status":404,...}` — action slugs are exact and case-sensitive (`enrichCompany`, not `company_enrich`); list them via `integration get <slug>` → `.integration.actions` keys.
+
 ### Why it's useful
 
 - **Wire a node graph correctly the first time.** Know which fields exist before referencing them downstream as `{{nodes.<slug>.<field>}}` — avoids the silent-`undefined` footgun (see `../node-selection.md`).
-- **Drive a structured `agent` node.** Shape the agent's `output.jsonSchema` from an upstream action's real output instead of guessing.
+- **Know an agent's output envelope** (`.answer` vs structured fields) before writing branch/filter expressions against it.
 - **Map onto storage columns** ahead of a batch, without a throwaway run to inspect the output.
 
 ---
@@ -238,11 +251,11 @@ A JSON Schema object describing the fields and types the action emits in its `da
 ```bash
 # 1. Find the integration and action
 cargo-ai connection integration get clearbit
-# → Find actionSlug: "company_enrich"
+# → Find actionSlug: "enrichCompany" (slugs are exact — keys of .integration.actions)
 
 # 2. Execute
 cargo-ai orchestration action execute \
-  --action '{"kind":"connector","integrationSlug":"clearbit","actionSlug":"company_enrich","config":{}}' \
+  --action '{"kind":"connector","integrationSlug":"clearbit","actionSlug":"enrichCompany","config":{}}' \
   --data '{"domain":"acme.com"}' \
   --wait-until-finished
 # → Done. Check run.status for success/error.

--- a/cargo-orchestration/references/examples/actions.md
+++ b/cargo-orchestration/references/examples/actions.md
@@ -191,7 +191,23 @@ cargo-ai connection connector list
 
 ## Resolve an action's output schema
 
-**Never guess what an action outputs.** `integration get <slug>` only describes an action's **input** (`config.jsonSchema`) — the integration catalog carries no output information. To discover what an action **produces**, resolve its output schema **without executing it** (no run, no credits):
+**Never guess what an action outputs.** There are two free ways to discover what an action **produces** — no run, no credits.
+
+### 1. Connector actions: read `output.schema` from the integration catalog
+
+`integration get <slug>` (and `integration list`) return each action's output schema inline, next to its input schema:
+
+```bash
+cargo-ai connection integration get waterfall
+# → .integration.actions.verifyEmail.config.schema   — input (what you pass)
+# → .integration.actions.verifyEmail.output.schema   — output (what it emits)
+```
+
+**Not every action declares an output schema** — e.g. `waterfall.verifyEmail`, `clearbit.enrichCompany`, and most `hubspot` record actions do, while `waterfall.detectJobChange`, `waterfall.searchProspects`, and `salesNavigator.searchAccounts` don't (no `output` key). When it's absent, the only way to see the real shape is `runContext` from an actual run.
+
+### 2. Any action kind: `action get-output-schema`
+
+For non-connector kinds (`tool`, `agent`, `native`) — or when you already have the action object in hand — resolve the same schema without touching the catalog:
 
 ```bash
 cargo-ai orchestration action get-output-schema \
@@ -216,7 +232,7 @@ cargo-ai orchestration action get-output-schema \
 
 ### Response
 
-The JSON Schema sits under a top-level **`schema`** key (not returned bare) — e.g. `waterfall` / `verifyEmail` resolves to:
+The JSON Schema sits under a top-level **`schema`** key (not returned bare), and for connector actions it is exactly the catalog's `output.schema` — e.g. `waterfall` / `verifyEmail` resolves to:
 
 ```json
 {
@@ -236,7 +252,10 @@ The JSON Schema sits under a top-level **`schema`** key (not returned bare) — 
 
 An `agent` action without a structured `output.jsonSchema` resolves to `{"schema":{"type":"object","properties":{"answer":{"type":"string"}}}}` — the free-text answer envelope. This is the authoritative confirmation that downstream references must go through `.answer` (`{{nodes.<slug>.answer}}`, or `{{nodes.<slug>.answer.<field>}}` for structured agents).
 
-An unknown `actionSlug` / `toolUuid` / `agentUuid` exits non-zero with `{"error":"Not found: RequestError: Action not found.. Verify the UUID(s) you passed.","status":404,...}` — action slugs are exact and case-sensitive (`enrichCompany`, not `company_enrich`); list them via `integration get <slug>` → `.integration.actions` keys.
+Two distinct failure modes, both non-zero exit with `status: 404`:
+
+- `"Action not found."` — the `actionSlug` / `toolUuid` / `agentUuid` doesn't exist. Slugs are exact and case-sensitive (`enrichCompany`, not `company_enrich`); list them via `integration get <slug>` → `.integration.actions` keys.
+- `"Action has no output schema."` — the action exists but declares no output schema (its catalog entry has no `output` key). Fall back to running it once and reading `runContext.<nodeSlug>` from `run get`.
 
 ### Why it's useful
 

--- a/cargo-orchestration/references/troubleshooting.md
+++ b/cargo-orchestration/references/troubleshooting.md
@@ -84,7 +84,7 @@ If a `branch` node's `title` says "❌ Condition is not matched" but you expecte
 |---|---|
 | Path in the expression doesn't exist | Read `runContext.<upstreamSlug>` from `run get <run-uuid>` and check the actual shape — common case: an agent's output is nested under `.answer`, so `{{nodes.qualify.qualified}}` resolves to undefined while `{{nodes.qualify.answer.qualified}}` works |
 | Stringified boolean comparison | `{{nodes.qualify.answer.qualified === true}}` may evaluate the inner expression as a string template — prefer the truthy form `{{nodes.qualify.answer.qualified}}` |
-| Field actually missing from the output | The upstream node didn't produce it — `runContext.<upstreamSlug>` will confirm. To see what an action *should* emit without running it, resolve `orchestration action get-output-schema --action '<json>'`. For agents, this usually means revisiting the prompt + `jsonSchema` |
+| Field actually missing from the output | The upstream node didn't produce it — `runContext.<upstreamSlug>` will confirm. To see what an action *should* emit without running it, read `output.schema` from `integration get <slug>` (connector actions) or resolve `orchestration action get-output-schema --action '<json>'` (any kind). For agents, this usually means revisiting the prompt + `jsonSchema` |
 | Typo in slug or field | Slugs are case-sensitive; `nodes.Qualify.answer.qualified` won't resolve |
 
 ### 3. Re-run a single record after fixing

--- a/cargo-orchestration/references/troubleshooting.md
+++ b/cargo-orchestration/references/troubleshooting.md
@@ -84,7 +84,7 @@ If a `branch` node's `title` says "❌ Condition is not matched" but you expecte
 |---|---|
 | Path in the expression doesn't exist | Read `runContext.<upstreamSlug>` from `run get <run-uuid>` and check the actual shape — common case: an agent's output is nested under `.answer`, so `{{nodes.qualify.qualified}}` resolves to undefined while `{{nodes.qualify.answer.qualified}}` works |
 | Stringified boolean comparison | `{{nodes.qualify.answer.qualified === true}}` may evaluate the inner expression as a string template — prefer the truthy form `{{nodes.qualify.answer.qualified}}` |
-| Field actually missing from the output | The upstream node didn't produce it — `runContext.<upstreamSlug>` will confirm. For agents, this usually means revisiting the prompt + `jsonSchema` |
+| Field actually missing from the output | The upstream node didn't produce it — `runContext.<upstreamSlug>` will confirm. To see what an action *should* emit without running it, resolve `orchestration action get-output-schema --action '<json>'`. For agents, this usually means revisiting the prompt + `jsonSchema` |
 | Typo in slug or field | Slugs are case-sensitive; `nodes.Qualify.answer.qualified` won't resolve |
 
 ### 3. Re-run a single record after fixing


### PR DESCRIPTION
Document how to discover an action's **output** shape without executing it — previously the skills only covered inputs (`config.jsonSchema`), so agents guessed what actions emit. All behavior below is verified against the live API (CLI 1.0.28).

Two sources, both free (no run, no credits):

1. **Integration catalog** — `integration get`/`list` now return `actions.<slug>.output.schema` next to `config.jsonSchema`. Present on most but not all actions (e.g. `waterfall.verifyEmail`, `clearbit.enrichCompany`, most hubspot record actions have it; `waterfall.detectJobChange`, `salesNavigator.searchAccounts` don't).
2. **`orchestration action get-output-schema`** — resolves the same schema for **any** action kind (`tool`/`connector`/`agent`/`native`) from the same `--action` object as `action execute`. Response wraps the JSON Schema under a top-level `schema` key.

Also verified and documented:
- Agent kind: a default free-text agent resolves to `{answer: string}` — authoritative confirmation of the `.answer` output envelope.
- Two distinct 404s: `Action not found.` (bad slug/uuid) vs `Action has no output schema.` (action declares none → fall back to `runContext` from a real run).
- Fixed a pre-existing footgun in the touched files: clearbit's real slug is `enrichCompany`; the documented `company_enrich` 404s. (Other files still use the wrong slug — follow-up.)

Files:
- `cargo-orchestration/SKILL.md` + `references/examples/actions.md`: quick-reference line and a "never guess the output" section with verified per-kind examples and response/error shapes.
- `cargo-orchestration/references/troubleshooting.md`: missing-field diagnosis points at both sources.
- `cargo-connection/SKILL.md` + `references/response-shapes.md`: `output.schema` in the `integration get` response shape and the action-discovery flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to Cargo CLI skills; no runtime, auth, or application code changes.
> 
> **Overview**
> Documents how to discover an action’s **output** JSON Schema without executing it, closing a gap where skills only described **input** via `config.jsonSchema`.
> 
> **`cargo-orchestration`:** Adds `orchestration action get-output-schema` to the quick reference and a dedicated subsection (“never guess what an action outputs”), including the `{"schema": ...}` response shape, agent `.answer` envelope, and 404 cases (`Action not found` / `Action has no output schema`). **`references/examples/actions.md`** gets a full section with catalog vs CLI paths, per-kind examples, and wiring guidance for `{{nodes.<slug>...}}`. **`troubleshooting.md`** now points missing-field debugging at `integration get` `output.schema` and `get-output-schema`.
> 
> **`cargo-connection`:** Clarifies that `integration get` / `integration list` expose `actions.<actionSlug>.output.schema` alongside input; **`response-shapes.md`** sample action includes an `output.schema` block.
> 
> **Slug fix:** Examples in these files switch Clearbit from the invalid `company_enrich` to **`enrichCompany`** (other repo files may still use the old slug).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eadd0e979fa4f3271b03ab436ebacd62a5d49378. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->