### PR TITLE
Add cargo-hosting skill for app and worker deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 ### `cargo-hosting` → 1.0.0
 
 - Initial release. Covers `hosting app`, `hosting worker`, and `hosting deployment` (CLI 1.0.22): scaffolding from templates, creating app/worker slots, building+uploading deployments, and promoting to the live URL.
+- `references/response-shapes.md` pins the real `App` / `Worker` / `Deployment` shapes (incl. the `kind` app/worker discriminant, `promotedDeployment`, and `chargedUntil`) and the deployment `status` enum (`pending`/`building`/`success`/`error`/`cancelled`, terminal at the last three) from the backend types — no more "capture live" hedging. Polling and build-failure docs now reference the real `status`, `errorMessage`, and `buildLogS3Filename` fields, and a critical rule notes hosting bills credits monthly per resource.
 
 ### `cargo` → 1.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 - **CI skill-lint.** Added [`.github/workflows/skills-lint.yml`](.github/workflows/skills-lint.yml) and [`.github/scripts/skills-lint.mjs`](.github/scripts/skills-lint.mjs). Runs on every push and PR; validates SKILL.md frontmatter shape, JSON snippets inside fenced code blocks, internal markdown links, and that bash examples reference real `cargo-ai` domains. Catches drift before it reaches users.
 - **Skill-lint domain list refreshed.** Added the CLI domains that shipped since the lint was written — `content`, `expression`, `hosting`, `revenue-organization`, `system-of-record`, `user-management`, plus `init`/`version` — so valid examples no longer warn.
 - **New capability skill: `cargo-content`.** The `content` CLI domain (files + libraries) is now its own skill rather than living inside `cargo-ai`, matching the repo's one-skill-per-CLI-domain convention. File/library command docs, the `examples/files.md` walkthrough, response shapes, and troubleshooting moved into `cargo-content/`; `cargo-ai` keeps the attach-to-agent wiring and cross-links to `cargo-content`.
+- **New capability skill: `cargo-hosting`.** The `hosting` CLI domain (apps, workers, deployments) graduates from the router's "CLI domains without a dedicated skill yet" table into its own capability skill. `SKILL.md` documents the `init → create → deploy → promote` lifecycle for Vite SPA apps (served on `*.cargo.app`) and edge workers, with `examples/{apps,workers,deployments}.md`, `response-shapes.md`, and `troubleshooting.md`. The router (`cargo`) and `README.md` register it: skill counts bumped (router 10→11 skills, README 11→12), capability-table row + recap added, and `hosting` removed from the no-skill-yet table.
+
+### `cargo-hosting` → 1.0.0
+
+- Initial release. Covers `hosting app`, `hosting worker`, and `hosting deployment` (CLI 1.0.22): scaffolding from templates, creating app/worker slots, building+uploading deployments, and promoting to the live URL.
+
+### `cargo` → 1.5.0
+
+- **Register the `cargo-hosting` skill.** Bumped the skill count to 11 (one outcome + ten capability), added the `cargo-hosting` capability-table row and a full recap, and added it to the one-per-CLI-domain list. Removed `hosting` from the "CLI domains without a dedicated skill yet" table now that it has a dedicated skill. Synced the frontmatter description count (was stale at nine/eight).
 
 ### `cargo` → 1.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 ### `cargo` → 1.5.0
 
 - **Register the `cargo-hosting` skill.** Bumped the skill count to 11 (one outcome + ten capability), added the `cargo-hosting` capability-table row and a full recap, and added it to the one-per-CLI-domain list. Removed `hosting` from the "CLI domains without a dedicated skill yet" table now that it has a dedicated skill. Synced the frontmatter description count (was stale at nine/eight).
+- **Glossary entries for hosting.** Added `app (Cargo Hosting)`, `appUuid`, `deployment (Cargo Hosting)`, `deploymentUuid`, `hosting`, `worker (Cargo Hosting)`, and `workerUuid` to `references/glossary.md`, and corrected the `capability skill` entry's domain list (was missing `content` and `hosting`).
 
 ### `cargo` → 1.4.0
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Then bump the `version:` field in each changed `SKILL.md` (semver, e.g. `1.0.0` 
 
 ## What this skill teaches
 
-**Cargo** connects your data models (companies, contacts, deals) to external integrations (CRMs, enrichment providers, AI agents) and runs them as automated workflows. The repo ships eleven skills at the root — one **router skill** (`cargo`, the overview / front door for any Cargo CLI task), one **outcome skill** (`cargo-gtm`, the front door for any GTM task), and nine **capability skills** (one per CLI domain).
+**Cargo** connects your data models (companies, contacts, deals) to external integrations (CRMs, enrichment providers, AI agents) and runs them as automated workflows. The repo ships twelve skills at the root — one **router skill** (`cargo`, the overview / front door for any Cargo CLI task), one **outcome skill** (`cargo-gtm`, the front door for any GTM task), and ten **capability skills** (one per CLI domain).
 
 ### Router — `cargo`
 
@@ -110,6 +110,7 @@ Load when you need the syntax for a specific CLI domain.
 | **Context**       | Browse, read, write, and edit the workspace's git-backed context repo (markdown/MDX GTM knowledge base); run shell commands in its runtime sandbox; inspect the knowledge graph |
 | **Analytics**     | Download run results and outputs, export segment data, monitor error rates and success metrics                                                                     |
 | **Billing**       | Track credit consumption per workflow or connector, check subscription status, view invoices                                                                       |
+| **Hosting**       | Scaffold, deploy, and promote hosted apps (Vite SPAs on `*.cargo.app`) and edge workers (serverless HTTP handlers), and manage their deployments                   |
 | **Workspace**     | Invite users, create and rotate API tokens, organize resources into folders, manage roles                                                                          |
 
 ## What can I ask for?

--- a/cargo-hosting/SKILL.md
+++ b/cargo-hosting/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: cargo-hosting
+description: Build, deploy, and manage Cargo Hosting apps and workers with the Cargo CLI — Vite SPAs served on *.cargo.app and serverless edge HTTP handlers, plus the deployments that ship and promote them. Use when the user wants to scaffold, deploy, promote, or manage a hosted app or worker on Cargo.
+version: "1.0.0"
+compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
+homepage: https://github.com/getcargohq/cargo-skills
+metadata:
+  author: getcargo
+  openclaw:
+    requires:
+      bins:
+        - cargo-ai
+    install:
+      - kind: node
+        package: "@cargo-ai/cli@latest"
+        bins:
+          - cargo-ai
+    homepage: https://github.com/getcargohq/cargo-skills
+---
+
+# Cargo CLI — Hosting
+
+**Cargo Hosting** runs two kinds of workspace-scoped resources, plus the deployments that ship them:
+
+- **App** — a Vite single-page app served on `https://<slug>.cargo.app`, built on `@cargo-ai/app-sdk` (Vite + refine + shadcn primitives, with `getCargoEnv()` / `useCargoApi()` wired to the workspace).
+- **Worker** — a serverless HTTP handler that runs on the edge (`fetch(request, env)`), built on `@cargo-ai/worker-sdk` (auto OpenAPI 3.1 spec at `/openapi.json`, Swagger UI at `/docs`).
+- **Deployment** — one build+upload of a local source directory to an app or worker. A deployment is **not live until it's promoted**.
+
+> For organizing apps/workers into **folders**, use [`cargo-workspace-management`](../cargo-workspace-management/SKILL.md) (`folder …`). The `--folder-uuid` flags here consume those folder UUIDs.
+
+> See `references/examples/apps.md`, `references/examples/workers.md`, and `references/examples/deployments.md` for end-to-end walkthroughs.
+> See `references/response-shapes.md` for JSON response structures.
+> See `references/troubleshooting.md` for common errors and how to fix them.
+
+## Prerequisites
+
+See [`../cargo/references/prerequisites.md`](../cargo/references/prerequisites.md) for install, login (`--oauth` / `--token`), JSON output conventions, and error shapes. Verify the session with `cargo-ai whoami` before running any command below.
+
+## The lifecycle
+
+Apps and workers follow the same shape — **scaffold → create slot → deploy → promote**:
+
+```
+init (local scaffold) → create (slot + slug) → deployment create (build+upload) → deployment promote (go live)
+```
+
+1. **Scaffold** a local project from a template — `hosting app init <dir>` / `hosting worker init <dir>`.
+2. **Create the slot** in the workspace — `hosting app create --name --slug` → `appUuid` (or `workerUuid`). The `--slug` becomes the subdomain and **must be globally unique within the hosting domain**.
+3. **(apps, optional) Wire local dev** — `hosting app env <appUuid>` prints the `.env.local` lines a local copy needs (Cargo OAuth + workspace + app UUID + API URL).
+4. **Deploy** — `hosting deployment create --app-uuid <uuid> --source <dir>` uploads the source; the backend runs `npm ci && vite build` (apps) or bundles the entrypoint (workers) in a sandbox. Returns a `deploymentUuid`.
+5. **Promote** — `hosting deployment promote --uuid <deploymentUuid>` points the live URL at that build.
+
+Deploys build asynchronously — **poll `hosting deployment get <uuid>`** until the status is terminal before promoting (see [Async polling](#async-polling)).
+
+## Apps
+
+```bash
+# Discover
+cargo-ai hosting app list                          # all apps (filter with --folder-uuid <uuid>)
+cargo-ai hosting app get <uuid>                     # one app's details + URL
+
+# Scaffold locally (Vite + @cargo-ai/app-sdk)
+cargo-ai hosting app init ./my-app --list-templates # see available templates, then:
+cargo-ai hosting app init ./my-app --template blank --name "My App"
+
+# Create the slot (slug must be globally unique → it's the subdomain)
+cargo-ai hosting app create --name "My App" --slug my-app --folder-uuid <folder-uuid>
+
+# Print .env.local for local development
+cargo-ai hosting app env <app-uuid>
+cargo-ai hosting app env <app-uuid> --api-url https://api.getcargo.io
+
+# Update / remove
+cargo-ai hosting app update --uuid <app-uuid> --name "Renamed"
+cargo-ai hosting app update --uuid <app-uuid> --folder-uuid null   # move to workspace root
+cargo-ai hosting app remove <app-uuid>                             # also removes its deployments
+```
+
+Templates: `blank` (minimal starting point) and `territories-overview` (read-only territories grid demoing `useCargoApi()` + react-query). Run `app init <dir> --list-templates` for the current list.
+
+## Workers
+
+Same command shape as apps — substitute `worker` for `app`:
+
+```bash
+cargo-ai hosting worker list                        # filter with --folder-uuid <uuid>
+cargo-ai hosting worker get <uuid>
+
+# Scaffold (edge fetch(request, env) handler on @cargo-ai/worker-sdk)
+cargo-ai hosting worker init ./my-worker --list-templates
+cargo-ai hosting worker init ./my-worker --template blank --name "My Worker"
+
+cargo-ai hosting worker create --name "My Worker" --slug my-worker --folder-uuid <folder-uuid>
+cargo-ai hosting worker update --uuid <worker-uuid> --name "Renamed"
+cargo-ai hosting worker remove <worker-uuid>        # also removes its deployments
+```
+
+Templates: `blank` (auto OpenAPI spec + Swagger UI) and `custom-integration` (a Cargo Custom Integration — manifest / actions / extractors / autocompletes / dynamic schemas). Workers have **no `env` subcommand** — they read config from the `env` argument passed to `fetch` at runtime.
+
+## Deployments
+
+A deployment belongs to exactly one app **or** one worker (`--app-uuid` and `--worker-uuid` are mutually exclusive).
+
+```bash
+# List / inspect
+cargo-ai hosting deployment list --app-uuid <uuid>          # or --worker-uuid <uuid>
+cargo-ai hosting deployment get <deployment-uuid>           # status + metadata
+cargo-ai hosting deployment get-promoted --app-uuid <uuid>  # what's currently live
+
+# Build & upload a local source directory (point at the package root, NOT dist/)
+cargo-ai hosting deployment create --app-uuid <uuid> --source ./my-app
+cargo-ai hosting deployment create --worker-uuid <uuid> --source ./my-worker
+# default ignores: node_modules,dist,build,.git,.next — override with --ignore "a,b,c"
+
+# Go live
+cargo-ai hosting deployment promote --uuid <deployment-uuid>
+```
+
+## Critical rules
+
+- **`--slug` must be globally unique within the hosting domain** — it's the live subdomain (`<slug>.cargo.app`). A clash fails at `create`.
+- **Deploying ≠ going live.** `deployment create` builds and uploads; the URL only changes when you `deployment promote` that deployment. Use `deployment get-promoted` to see what's live now.
+- **`--source` is the package root, not `dist/`.** The build runs in a Cargo sandbox: `npm ci && vite build` for apps, entrypoint bundling for workers. Shipping a pre-built `dist/` will not work.
+- **Builds are async** — poll `deployment get` until terminal before promoting (see below).
+- **`--app-uuid` / `--worker-uuid` are mutually exclusive** on `deployment create`, `deployment list`, and `deployment get-promoted`. Pass exactly one.
+- **`remove` cascades** — removing an app or worker also removes all of its deployments.
+- **`update --folder-uuid null`** (literal string `null`) moves a resource back to the workspace root.
+
+## Async polling
+
+`deployment create` kicks off a sandboxed build. Poll until it finishes, then promote:
+
+```bash
+cargo-ai hosting deployment get <deployment-uuid>   # check the build status field; poll ~2–5s
+```
+
+Treat the deployment as ready once its status field is terminal (built/succeeded vs failed). When in doubt about the exact status values for this CLI version, capture them live from a real `deployment get` — see `references/response-shapes.md`. For the general polling pattern (intervals, retries, error handling), see [`../cargo-orchestration/references/polling.md`](../cargo-orchestration/references/polling.md).
+
+## Help
+
+Every command supports `--help`:
+
+```bash
+cargo-ai hosting app create --help
+cargo-ai hosting deployment create --help
+```

--- a/cargo-hosting/SKILL.md
+++ b/cargo-hosting/SKILL.md
@@ -125,16 +125,17 @@ cargo-ai hosting deployment promote --uuid <deployment-uuid>
 - **`--app-uuid` / `--worker-uuid` are mutually exclusive** on `deployment create`, `deployment list`, and `deployment get-promoted`. Pass exactly one.
 - **`remove` cascades** — removing an app or worker also removes all of its deployments.
 - **`update --folder-uuid null`** (literal string `null`) moves a resource back to the workspace root.
+- **Hosting consumes credits monthly per resource.** Each app/worker carries a `chargedUntil` that an hourly sweep advances a month at a time, so a live app or worker bills hosting credits on an ongoing basis — `remove` resources you no longer serve. Track consumption via [`cargo-billing`](../cargo-billing/SKILL.md).
 
 ## Async polling
 
-`deployment create` kicks off a sandboxed build. Poll until it finishes, then promote:
+`deployment create` kicks off a sandboxed build. The deployment's `status` moves `pending → building → success` (or `error` / `cancelled`). Poll until terminal, then promote the `success` one:
 
 ```bash
-cargo-ai hosting deployment get <deployment-uuid>   # check the build status field; poll ~2–5s
+cargo-ai hosting deployment get <deployment-uuid>   # poll ~2–5s until status is terminal
 ```
 
-Treat the deployment as ready once its status field is terminal (built/succeeded vs failed). When in doubt about the exact status values for this CLI version, capture them live from a real `deployment get` — see `references/response-shapes.md`. For the general polling pattern (intervals, retries, error handling), see [`../cargo-orchestration/references/polling.md`](../cargo-orchestration/references/polling.md).
+Terminal statuses are `success`, `error`, and `cancelled` — only promote a `success` deployment. On `error`, read the deployment's `errorMessage` (and `buildLogS3Filename`) to diagnose the build. For the general polling pattern (intervals, retries), see [`../cargo-orchestration/references/polling.md`](../cargo-orchestration/references/polling.md).
 
 ## Help
 

--- a/cargo-hosting/references/examples/apps.md
+++ b/cargo-hosting/references/examples/apps.md
@@ -1,0 +1,81 @@
+# App examples
+
+Apps are Vite single-page apps served on `https://<slug>.cargo.app`, scaffolded from `@cargo-ai/app-sdk`.
+
+## Scaffold → create → deploy → promote (end to end)
+
+```bash
+# 1. See what templates exist, then scaffold a local project
+cargo-ai hosting app init ./territories --list-templates
+cargo-ai hosting app init ./territories --template territories-overview --name "Territories"
+
+# 2. Create the workspace slot. --slug is the live subdomain → must be globally unique.
+cargo-ai hosting app create --name "Territories" --slug territories
+# → { "uuid": "<app-uuid>", "slug": "territories", "url": "https://territories.cargo.app", ... }
+
+# 3. (optional) Develop locally — write the .env.local the app needs, then run Vite
+cargo-ai hosting app env <app-uuid> > ./territories/.env.local
+cd ./territories && npm install && npm run dev
+
+# 4. Build & upload (source = package root, not dist/). The backend runs `npm ci && vite build`.
+cargo-ai hosting deployment create --app-uuid <app-uuid> --source ./territories
+# → { "uuid": "<deployment-uuid>", "status": "...", ... }
+
+# 5. Poll until the build is terminal
+cargo-ai hosting deployment get <deployment-uuid>
+
+# 6. Promote to make it live at https://territories.cargo.app
+cargo-ai hosting deployment promote --uuid <deployment-uuid>
+
+# 7. Confirm what's live
+cargo-ai hosting deployment get-promoted --app-uuid <app-uuid>
+```
+
+## List and inspect
+
+```bash
+cargo-ai hosting app list                       # all apps in the workspace
+cargo-ai hosting app list --folder-uuid <uuid>  # only apps in one folder
+cargo-ai hosting app get <app-uuid>             # one app's details + live URL
+```
+
+## Local development env
+
+`app env` prints the `.env.local` lines a local copy of the app needs — Cargo OAuth client, workspace UUID, app UUID, and API URL — so `getCargoEnv()` / `useCargoApi()` talk to the right workspace.
+
+```bash
+# Default API URL (https://api.getcargo.io)
+cargo-ai hosting app env <app-uuid> > ./my-app/.env.local
+
+# Point at a different API (e.g. a staging environment)
+cargo-ai hosting app env <app-uuid> --api-url https://api.staging.getcargo.io > ./my-app/.env.local
+```
+
+## Rename, move, remove
+
+```bash
+# Rename
+cargo-ai hosting app update --uuid <app-uuid> --name "Renamed App"
+
+# Move into a folder (folders are managed by cargo-workspace-management)
+cargo-ai workspaceManagement folder list                          # find the folder UUID
+cargo-ai hosting app update --uuid <app-uuid> --folder-uuid <folder-uuid>
+
+# Move back to the workspace root (literal string "null")
+cargo-ai hosting app update --uuid <app-uuid> --folder-uuid null
+
+# Remove (also removes every deployment of this app)
+cargo-ai hosting app remove <app-uuid>
+```
+
+## Ship a new version of an existing app
+
+The app slot and slug stay put; you just create and promote a fresh deployment.
+
+```bash
+cargo-ai hosting deployment create --app-uuid <app-uuid> --source ./my-app
+# poll deployment get <new-deployment-uuid> until terminal
+cargo-ai hosting deployment promote --uuid <new-deployment-uuid>
+```
+
+Roll back by promoting an earlier deployment — `deployment list --app-uuid <uuid>` shows the history; `deployment promote --uuid <older-uuid>` points the live URL back at it.

--- a/cargo-hosting/references/examples/deployments.md
+++ b/cargo-hosting/references/examples/deployments.md
@@ -1,0 +1,64 @@
+# Deployment examples
+
+A deployment is one build+upload of a local source directory to an app or worker. Two facts drive everything below:
+
+1. A deployment belongs to **exactly one** app or worker — `--app-uuid` and `--worker-uuid` are mutually exclusive.
+2. **Building is not promoting.** `deployment create` builds; the live URL only moves when you `deployment promote`.
+
+## Create a deployment
+
+```bash
+# App: backend runs `npm ci && vite build` in a sandbox
+cargo-ai hosting deployment create --app-uuid <app-uuid> --source ./my-app
+
+# Worker: backend bundles the entrypoint
+cargo-ai hosting deployment create --worker-uuid <worker-uuid> --source ./my-worker
+```
+
+- `--source` is the **package root** (where `package.json` lives), not a pre-built `dist/`. The build happens server-side.
+- Default ignore list: `node_modules,dist,build,.git,.next`. Override the whole list with `--ignore`:
+
+```bash
+cargo-ai hosting deployment create --app-uuid <app-uuid> --source ./my-app \
+  --ignore "node_modules,dist,build,.git,.next,coverage,.turbo"
+```
+
+## Poll the build, then promote
+
+```bash
+# Builds are async — poll until the status field is terminal
+cargo-ai hosting deployment get <deployment-uuid>
+# when terminal (built/succeeded), promote:
+cargo-ai hosting deployment promote --uuid <deployment-uuid>
+```
+
+If the build failed, inspect the deployment record for the error and fix the source before re-running `deployment create`. See `../response-shapes.md` for the fields to check.
+
+## List deployment history
+
+```bash
+cargo-ai hosting deployment list --app-uuid <app-uuid>       # newest first
+cargo-ai hosting deployment list --worker-uuid <worker-uuid>
+```
+
+## See what's currently live
+
+```bash
+cargo-ai hosting deployment get-promoted --app-uuid <app-uuid>
+cargo-ai hosting deployment get-promoted --worker-uuid <worker-uuid>
+```
+
+## Roll back to a previous deployment
+
+Promotion just points the live URL at a deployment, so rolling back is promoting an older one — no rebuild needed.
+
+```bash
+# 1. Find the deployment you want to go back to
+cargo-ai hosting deployment list --app-uuid <app-uuid>
+
+# 2. Promote it
+cargo-ai hosting deployment promote --uuid <older-deployment-uuid>
+
+# 3. Verify
+cargo-ai hosting deployment get-promoted --app-uuid <app-uuid>
+```

--- a/cargo-hosting/references/examples/workers.md
+++ b/cargo-hosting/references/examples/workers.md
@@ -1,0 +1,60 @@
+# Worker examples
+
+Workers are serverless HTTP handlers that run on the edge — a standard `fetch(request, env)` entrypoint built on `@cargo-ai/worker-sdk`. The `blank` template ships an automatic OpenAPI 3.1 spec at `/openapi.json` and Swagger UI at `/docs`.
+
+## Scaffold → create → deploy → promote (end to end)
+
+```bash
+# 1. Scaffold a local worker project
+cargo-ai hosting worker init ./my-api --list-templates
+cargo-ai hosting worker init ./my-api --template blank --name "My API"
+
+# 2. Create the workspace slot. --slug is the live subdomain → must be globally unique.
+cargo-ai hosting worker create --name "My API" --slug my-api
+# → { "uuid": "<worker-uuid>", "slug": "my-api", "url": "https://my-api.cargo.app", ... }
+
+# 3. Build & upload (source = package root). The backend bundles the entrypoint.
+cargo-ai hosting deployment create --worker-uuid <worker-uuid> --source ./my-api
+# → { "uuid": "<deployment-uuid>", "status": "...", ... }
+
+# 4. Poll until the build is terminal
+cargo-ai hosting deployment get <deployment-uuid>
+
+# 5. Promote to go live
+cargo-ai hosting deployment promote --uuid <deployment-uuid>
+
+# 6. Confirm what's live, then hit it
+cargo-ai hosting deployment get-promoted --worker-uuid <worker-uuid>
+curl https://my-api.cargo.app/openapi.json
+```
+
+## List and inspect
+
+```bash
+cargo-ai hosting worker list                       # all workers
+cargo-ai hosting worker list --folder-uuid <uuid>  # only workers in one folder
+cargo-ai hosting worker get <worker-uuid>          # one worker's details + URL
+```
+
+## Templates
+
+```bash
+cargo-ai hosting worker init ./tmp --list-templates
+```
+
+- **`blank`** — edge worker on `@cargo-ai/worker-sdk` with automatic OpenAPI 3.1 spec at `/openapi.json` and Swagger UI at `/docs`.
+- **`custom-integration`** — a Cargo Custom Integration worker: manifest / actions / extractors / autocompletes / dynamic schemas, also with `/openapi.json`. Use this when you're building an integration the rest of Cargo can call as a connector action.
+
+## Rename, move, remove
+
+```bash
+cargo-ai hosting worker update --uuid <worker-uuid> --name "Renamed Worker"
+cargo-ai hosting worker update --uuid <worker-uuid> --folder-uuid <folder-uuid>
+cargo-ai hosting worker update --uuid <worker-uuid> --folder-uuid null   # back to root
+cargo-ai hosting worker remove <worker-uuid>                            # also removes its deployments
+```
+
+## App vs worker — when to use which
+
+- **App** — you want a UI on `*.cargo.app` (dashboard, internal tool, data grid). Vite SPA, `app init`, has an `env` subcommand for local dev.
+- **Worker** — you want an HTTP endpoint with no UI (webhook receiver, API, custom integration backend). Edge `fetch` handler, `worker init`, **no** `env` subcommand — runtime config arrives via the `env` argument to `fetch`.

--- a/cargo-hosting/references/response-shapes.md
+++ b/cargo-hosting/references/response-shapes.md
@@ -1,0 +1,64 @@
+# Hosting response shapes
+
+JSON response structures for the `hosting` domain. All commands output JSON to stdout; failures exit non-zero with `{"errorMessage": "..."}`.
+
+> **Capture live for field-level certainty.** The envelopes below are derived from the command surface (`--help`) and describe the fields you'll reference across commands. The exact key set can shift between CLI versions — when you need to depend on a specific field, confirm it against a real `cargo-ai hosting <…> get` from your workspace.
+
+## App (`hosting app get` / items in `hosting app list`)
+
+```json
+{
+  "uuid": "app-uuid",
+  "workspaceUuid": "...",
+  "name": "My App",
+  "slug": "my-app",
+  "url": "https://my-app.cargo.app",
+  "folderUuid": null,
+  "createdAt": "2026-01-01T00:00:00Z",
+  "updatedAt": "2026-01-15T00:00:00Z"
+}
+```
+
+**Key fields:** `uuid` (pass as `--app-uuid` to deployment commands), `slug` (the live subdomain), `url` (the live address), `folderUuid` (null unless filed into a folder).
+
+`hosting app list` returns the apps as an array (e.g. under an `apps` key, or as a top-level array — confirm live).
+
+## Worker (`hosting worker get` / items in `hosting worker list`)
+
+Same shape as an app: `uuid` (pass as `--worker-uuid`), `name`, `slug`, `url`, `folderUuid`, timestamps.
+
+## Deployment (`hosting deployment get` / items in `hosting deployment list`)
+
+```json
+{
+  "uuid": "deployment-uuid",
+  "appUuid": "app-uuid",
+  "workerUuid": null,
+  "status": "...",
+  "isPromoted": false,
+  "createdAt": "2026-01-01T00:00:00Z",
+  "updatedAt": "2026-01-01T00:00:10Z"
+}
+```
+
+**Key fields:**
+
+- `uuid` — pass to `deployment promote --uuid`.
+- `appUuid` / `workerUuid` — exactly one is set (a deployment targets one or the other).
+- `status` — the build state. **Poll `deployment get` until this is terminal** (a built/succeeded value vs a failed value) before promoting. Capture the exact enum values live for this CLI version.
+- promotion — whether this deployment is the one currently serving the live URL. `deployment get-promoted` returns the promoted deployment directly.
+
+## env (`hosting app env`)
+
+Not JSON — `hosting app env <appUuid>` prints `.env.local` lines (Cargo OAuth client, workspace UUID, app UUID, API URL) to stdout. Redirect into a file: `cargo-ai hosting app env <app-uuid> > .env.local`.
+
+## init templates (`hosting app init <dir> --list-templates`)
+
+```json
+[
+  { "slug": "blank", "description": "..." },
+  { "slug": "territories-overview", "description": "..." }
+]
+```
+
+Workers list their own templates (`blank`, `custom-integration`) via `hosting worker init <dir> --list-templates`. Note `--list-templates` still requires the `<directory>` positional argument.

--- a/cargo-hosting/references/response-shapes.md
+++ b/cargo-hosting/references/response-shapes.md
@@ -2,8 +2,6 @@
 
 JSON response structures for the `hosting` domain. All commands output JSON to stdout; failures exit non-zero with `{"errorMessage": "..."}`.
 
-> **Capture live for field-level certainty.** The envelopes below are derived from the command surface (`--help`) and describe the fields you'll reference across commands. The exact key set can shift between CLI versions — when you need to depend on a specific field, confirm it against a real `cargo-ai hosting <…> get` from your workspace.
-
 ## App (`hosting app get` / items in `hosting app list`)
 
 ```json
@@ -11,46 +9,71 @@ JSON response structures for the `hosting` domain. All commands output JSON to s
   "uuid": "app-uuid",
   "workspaceUuid": "...",
   "name": "My App",
+  "description": null,
   "slug": "my-app",
   "url": "https://my-app.cargo.app",
+  "userUuid": "...",
   "folderUuid": null,
+  "promotedDeployment": null,
+  "chargedUntil": "2026-02-01T00:00:00Z",
   "createdAt": "2026-01-01T00:00:00Z",
-  "updatedAt": "2026-01-15T00:00:00Z"
+  "updatedAt": "2026-01-15T00:00:00Z",
+  "deletedAt": null
 }
 ```
 
-**Key fields:** `uuid` (pass as `--app-uuid` to deployment commands), `slug` (the live subdomain), `url` (the live address), `folderUuid` (null unless filed into a folder).
-
-`hosting app list` returns the apps as an array (e.g. under an `apps` key, or as a top-level array — confirm live).
+**Key fields:** `uuid` (pass as `--app-uuid` to deployment commands), `slug` (the live subdomain), `url` (the live address), `folderUuid` (null unless filed into a folder), `promotedDeployment` (the App Deployment object currently live, or `null` if nothing is promoted yet), `chargedUntil` (end of the period already billed hosting credits — advanced a month at a time, so hosting an app costs credits monthly; see [`cargo-billing`](../../cargo-billing/SKILL.md)).
 
 ## Worker (`hosting worker get` / items in `hosting worker list`)
 
-Same shape as an app: `uuid` (pass as `--worker-uuid`), `name`, `slug`, `url`, `folderUuid`, timestamps.
+Identical to an app, with one difference: `promotedDeployment` is a **Worker Deployment** (carries `workerUuid` + `meta`, see below). The `uuid` is passed as `--worker-uuid` to deployment commands.
 
 ## Deployment (`hosting deployment get` / items in `hosting deployment list`)
+
+A deployment is a discriminated union on `kind` (`"app"` | `"worker"`). Shared fields:
 
 ```json
 {
   "uuid": "deployment-uuid",
+  "kind": "app",
   "appUuid": "app-uuid",
-  "workerUuid": null,
-  "status": "...",
-  "isPromoted": false,
+  "workspaceUuid": "...",
+  "status": "success",
+  "url": "https://my-app.cargo.app",
+  "sourceS3Path": "...",
+  "bundleS3Path": "...",
+  "buildLogS3Filename": "...",
+  "errorMessage": null,
+  "meta": {},
+  "userUuid": "...",
+  "promotedAt": "2026-01-01T00:01:30Z",
+  "promotedByUserUuid": "...",
+  "finishedAt": "2026-01-01T00:01:10Z",
+  "temporalWorkflowId": "...",
   "createdAt": "2026-01-01T00:00:00Z",
-  "updatedAt": "2026-01-01T00:00:10Z"
+  "updatedAt": "2026-01-01T00:01:30Z"
 }
 ```
+
+- **`kind: "app"`** carries `appUuid` and an empty `meta` (`{}`).
+- **`kind: "worker"`** carries `workerUuid` instead of `appUuid`, and `meta: { "bundleSha256": "...", "outboundAllowlist": ["..."] }`.
 
 **Key fields:**
 
 - `uuid` — pass to `deployment promote --uuid`.
-- `appUuid` / `workerUuid` — exactly one is set (a deployment targets one or the other).
-- `status` — the build state. **Poll `deployment get` until this is terminal** (a built/succeeded value vs a failed value) before promoting. Capture the exact enum values live for this CLI version.
-- promotion — whether this deployment is the one currently serving the live URL. `deployment get-promoted` returns the promoted deployment directly.
+- `appUuid` / `workerUuid` — exactly one is set, matching `kind`.
+- **`status`** — one of `"pending"`, `"building"`, `"success"`, `"error"`, `"cancelled"`. **Terminal** at `success` / `error` / `cancelled`; only a `success` deployment is worth promoting.
+- `errorMessage` — populated when `status` is `error`; `buildLogS3Filename` points at the build log for diagnosing a failed build.
+- `promotedAt` / `promotedByUserUuid` — non-null once this deployment has been promoted to the live URL (this is how "is it live?" is represented — there is no separate `isPromoted` flag).
+- `finishedAt` — when the build reached a terminal state.
+
+## get-promoted (`hosting deployment get-promoted`)
+
+Returns the currently-promoted Deployment for the given `--app-uuid` / `--worker-uuid` (same shape as above, with `promotedAt` set), or null/empty if nothing is promoted yet. Equivalent to reading `promotedDeployment` off the app/worker.
 
 ## env (`hosting app env`)
 
-Not JSON — `hosting app env <appUuid>` prints `.env.local` lines (Cargo OAuth client, workspace UUID, app UUID, API URL) to stdout. Redirect into a file: `cargo-ai hosting app env <app-uuid> > .env.local`.
+Not JSON — `hosting app env <appUuid>` prints `.env.local` lines (Cargo OAuth client, workspace UUID, app UUID, `VITE_CARGO_DEPLOYMENT_UUID`, API URL) to stdout. Redirect into a file: `cargo-ai hosting app env <app-uuid> > .env.local`.
 
 ## init templates (`hosting app init <dir> --list-templates`)
 

--- a/cargo-hosting/references/troubleshooting.md
+++ b/cargo-hosting/references/troubleshooting.md
@@ -1,0 +1,57 @@
+# Hosting troubleshooting
+
+Common errors in the `hosting` domain and how to fix them.
+
+## `unknown command 'hosting'`
+
+The `hosting` domain shipped in a recent CLI. If `cargo-ai hosting --help` errors, bump the CLI: `npm install -g @cargo-ai/cli@latest`.
+
+## Slug already taken / `create` fails on `--slug`
+
+The `--slug` is the live subdomain (`<slug>.cargo.app`) and **must be globally unique within the hosting domain** — not just unique to your workspace. Pick a more specific slug and re-run `create`.
+
+## I deployed but the URL still shows the old version
+
+`deployment create` only builds and uploads — it does **not** change the live URL. Promote the new deployment:
+
+```bash
+cargo-ai hosting deployment get <deployment-uuid>      # confirm the build is terminal/succeeded
+cargo-ai hosting deployment promote --uuid <deployment-uuid>
+cargo-ai hosting deployment get-promoted --app-uuid <app-uuid>   # verify what's live
+```
+
+## `deployment create` build fails
+
+The build runs server-side in a sandbox (`npm ci && vite build` for apps, entrypoint bundling for workers). A failed build usually means:
+
+- **`--source` points at the wrong directory.** Pass the **package root** (where `package.json` lives), not a pre-built `dist/`.
+- **`npm ci` can't resolve the lockfile.** Ensure `package-lock.json` is present and in sync with `package.json`, and that it isn't in the ignore list.
+- **Something needed got ignored.** The default ignore list is `node_modules,dist,build,.git,.next`. If you override `--ignore`, you replace the whole list — don't accidentally drop `node_modules` from the ignores (it should stay ignored; the sandbox installs deps itself) while keeping source files you need.
+
+Inspect the deployment record (`deployment get <uuid>`) for the error detail, fix the source, and re-run `deployment create`.
+
+## `--app-uuid` and `--worker-uuid` both passed (or neither)
+
+On `deployment create`, `deployment list`, and `deployment get-promoted` the two flags are **mutually exclusive** — pass exactly one. A deployment targets one app or one worker, never both.
+
+## `folderNotFound` on `--folder-uuid`
+
+The folder UUID doesn't exist. Folders are managed by the [`cargo-workspace-management`](../../cargo-workspace-management/SKILL.md) skill — run `cargo-ai workspaceManagement folder list` to find valid UUIDs. To move a resource back to the workspace root, pass the literal string `null`: `--folder-uuid null`.
+
+## `app env` writes the wrong API URL
+
+By default `hosting app env` points at `https://api.getcargo.io`. For a different environment, override it: `cargo-ai hosting app env <app-uuid> --api-url <url>`. Workers have no `env` subcommand — they receive config via the `env` argument to `fetch(request, env)` at runtime.
+
+## Removing an app/worker took its deployments too
+
+That's by design — `app remove` / `worker remove` cascade to every deployment of that resource. There's no undo; recreate the slot and redeploy if needed.
+
+## Still stuck
+
+File a report so the Cargo team can improve the CLI and these docs:
+
+```bash
+cargo-ai workspaceManagement report create \
+  --title "<one-line summary>" \
+  --description "<exact command(s), errorMessage, expected vs actual, UUIDs involved>"
+```

--- a/cargo-hosting/references/troubleshooting.md
+++ b/cargo-hosting/references/troubleshooting.md
@@ -28,7 +28,7 @@ The build runs server-side in a sandbox (`npm ci && vite build` for apps, entryp
 - **`npm ci` can't resolve the lockfile.** Ensure `package-lock.json` is present and in sync with `package.json`, and that it isn't in the ignore list.
 - **Something needed got ignored.** The default ignore list is `node_modules,dist,build,.git,.next`. If you override `--ignore`, you replace the whole list — don't accidentally drop `node_modules` from the ignores (it should stay ignored; the sandbox installs deps itself) while keeping source files you need.
 
-Inspect the deployment record (`deployment get <uuid>`) for the error detail, fix the source, and re-run `deployment create`.
+When `status` is `error`, `deployment get <uuid>` exposes the cause: read `errorMessage`, and `buildLogS3Filename` points at the full build log. Fix the source and re-run `deployment create`.
 
 ## `--app-uuid` and `--worker-uuid` both passed (or neither)
 

--- a/cargo/SKILL.md
+++ b/cargo/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cargo
-description: Router and overview for the Cargo CLI agent skills. Explains the nine skills (one outcome skill cargo-gtm + eight capability skills), the UUID flow between them, async polling, end-to-end use cases (enrich one record, enrich and sync to CRM, AI lead scoring, custom workflow, error monitoring, fresh-workspace bootstrap, segment export, GTM context authoring), and common gotchas (`conjonction` spelling, run vs batch, model-uuid vs segment-uuid). Load first whenever working with the Cargo CLI, when unsure which sub-skill applies, when stitching multiple sub-skills together, when bootstrapping a workspace, or when the user asks about Cargo skills in general.
-version: "1.4.0"
+description: Router and overview for the Cargo CLI agent skills. Explains the eleven skills (one outcome skill cargo-gtm + ten capability skills), the UUID flow between them, async polling, end-to-end use cases (enrich one record, enrich and sync to CRM, AI lead scoring, custom workflow, error monitoring, fresh-workspace bootstrap, segment export, GTM context authoring), and common gotchas (`conjonction` spelling, run vs batch, model-uuid vs segment-uuid). Load first whenever working with the Cargo CLI, when unsure which sub-skill applies, when stitching multiple sub-skills together, when bootstrapping a workspace, or when the user asks about Cargo skills in general.
+version: "1.5.0"
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 homepage: https://github.com/getcargohq/cargo-skills
 metadata:
@@ -28,10 +28,10 @@ metadata:
 
 # Cargo CLI — Skills Overview
 
-This repository contains 10 skills at the repo root: one **outcome skill** (`cargo-gtm`) and nine **capability skills**.
+This repository contains 11 skills at the repo root: one **outcome skill** (`cargo-gtm`) and ten **capability skills**.
 
 - **`cargo-gtm`** — application library. The front door for any GTM task ("build a TAM list", "find 5 fintech CTOs", "monitor job changes"). Routes via internal recipes (`../cargo-gtm/recipes/*.md`) and provider playbooks (`../cargo-gtm/provider-playbooks/*.md`).
-- **Capability skills** — standard library. One per CLI domain (orchestration, storage, connection, AI, content, context, analytics, billing, workspace management). Loaded by `cargo-gtm`, or directly when you need a specific CLI domain.
+- **Capability skills** — standard library. One per CLI domain (orchestration, storage, connection, AI, content, context, analytics, billing, hosting, workspace management). Loaded by `cargo-gtm`, or directly when you need a specific CLI domain.
 
 `cargo-gtm` delegates to capability skills; capability skills never reference `cargo-gtm` (one-way dependency).
 
@@ -139,6 +139,7 @@ Load for a specific CLI domain. The first link in each row jumps to the actual S
 | [`cargo-ai`](../cargo-ai/SKILL.md) ([recap](#cargo-ai))                                                     | Create and configure agents, configure releases, attach knowledge for RAG, manage MCP servers and memories |
 | [`cargo-content`](../cargo-content/SKILL.md) ([recap](#cargo-content))                                      | Upload and organize knowledge files, build native/connector-backed knowledge libraries for RAG (the `content` domain) |
 | [`cargo-context`](../cargo-context/SKILL.md) ([recap](#cargo-context))                                      | Browse/read/write/edit the workspace's git-backed GTM context repo, run commands in its runtime sandbox, inspect the knowledge graph |
+| [`cargo-hosting`](../cargo-hosting/SKILL.md) ([recap](#cargo-hosting))                                      | Scaffold, deploy, and promote hosted apps (Vite SPAs on `*.cargo.app`) and edge workers (serverless HTTP handlers), and manage their deployments |
 | [`cargo-workspace-management`](../cargo-workspace-management/SKILL.md) ([recap](#cargo-workspace-management)) | Invite users, create API tokens, organize folders, manage roles, report CLI issues to management   |
 
 > **Agent knowledge for RAG:** **files** + **libraries** live in the `content` domain → [`cargo-content`](../cargo-content/SKILL.md); how they attach to an agent → [`cargo-ai`](../cargo-ai/SKILL.md). (Files/libraries moved out of the old `ai file …` path in CLI ≥ 1.0.19.)
@@ -153,7 +154,6 @@ The CLI exposes several domains that no capability skill wraps yet. Reach for th
 | `expression` | Recipes and expression evaluation (`eval`, `recipe`) — generate/evaluate the template expressions used in node graphs. |
 | `system-of-record` | System-of-record, client, and log operations. |
 | `revenue-organization` | Allocations, capacities, members, territories (revenue/territory planning). |
-| `hosting` | Cargo Hosting — `app` (Vite SPAs on `*.cargo.app`), `worker` (edge HTTP handlers), `deployment`. |
 | `user-management` | Current-user operations with no workspace context. |
 
 ---
@@ -384,6 +384,25 @@ See `../cargo-ai/SKILL.md` for model and temperature guidance by use case.
 - For the full bootstrap + ongoing call-driven refresh playbook (Phase 1 + Phase 2 + cadence), see [`../cargo-context/references/examples/lifecycle.md`](../cargo-context/references/examples/lifecycle.md).
 
 **References:** `../cargo-context/SKILL.md`
+
+---
+
+### cargo-hosting
+
+**Cargo Hosting.** Scaffold, deploy, and manage hosted **apps** (Vite SPAs on `https://<slug>.cargo.app`, built on `@cargo-ai/app-sdk`) and **workers** (serverless edge `fetch(request, env)` handlers on `@cargo-ai/worker-sdk`), plus the **deployments** that ship and promote them.
+
+**Lifecycle:** `init` (local scaffold) → `create` (slot + globally-unique slug) → `deployment create` (build+upload) → `deployment promote` (go live).
+
+**Critical rules:**
+
+- `--slug` is the live subdomain — **globally unique within the hosting domain**.
+- **Deploying ≠ going live.** `deployment create` builds; the URL only moves on `deployment promote`. `deployment get-promoted` shows what's live.
+- `--source` is the **package root**, not `dist/` — the build (`npm ci && vite build` for apps, bundling for workers) runs server-side.
+- Builds are async — poll `deployment get` until terminal before promoting.
+- `--app-uuid` / `--worker-uuid` are mutually exclusive on deployment commands; `remove` cascades to deployments.
+- Folders come from [`cargo-workspace-management`](#cargo-workspace-management); `--folder-uuid null` moves to root.
+
+**References:** `../cargo-hosting/SKILL.md`
 
 ---
 

--- a/cargo/references/glossary.md
+++ b/cargo/references/glossary.md
@@ -18,6 +18,12 @@ A string identifier for a specific action on a workflow node. Present on both `k
 **agent**
 An AI resource with configured instructions, a language model, and optional actions. Created and configured via `cargo-ai`. Used in workflows as a `kind: "agent"` node, or messaged directly via `cargo-orchestration`.
 
+**app (Cargo Hosting)**
+A hosted Vite single-page app served on `https://<slug>.cargo.app`, built on `@cargo-ai/app-sdk` (Vite + refine, with `getCargoEnv()` / `useCargoApi()` wired to the workspace). Scaffolded with `hosting app init`, registered as a slot with `hosting app create` (which sets the globally-unique `--slug`), shipped via a **deployment**. Managed in the **`cargo-hosting`** skill. Distinct from a **worker** (a UI-less edge HTTP handler).
+
+**appUuid**
+The UUID of a Cargo Hosting app, returned by `hosting app create`. Passed as `--app-uuid` to deployment commands (`deployment create|list|get-promoted`), mutually exclusive with `--worker-uuid`.
+
 **autocomplete**
 A mechanism to fetch the list of allowed values for an action config field at runtime. When an action's `uiSchema` marks a field with `"ui:widget": "IntegrationAutocompleteWidget"`, its valid values must be retrieved via `cargo-ai connection connector autocomplete --connector-uuid <uuid> --slug <slug> --params '<json>'`. The autocomplete slug and params come from the field's `ui:options` in the `uiSchema`. Returns `{ "results": [{ "label": "...", "value": "..." }] }` — use the `value` in node configs.
 
@@ -36,7 +42,7 @@ The UUID returned by `batch create`. Used to poll batch status (`batch get`), do
 ## C
 
 **capability skill**
-A skill that documents one CLI domain (orchestration, storage, connection, AI, context, analytics, billing, workspace management). Capability skills are the "standard library" — the agent loads them when it needs the syntax for a specific CLI command. They sit at the repo root alongside the outcome skill (`cargo-gtm`). Capability skills never reference outcome skills (one-way dependency: outcome → capability).
+A skill that documents one CLI domain (orchestration, storage, connection, AI, content, context, analytics, billing, hosting, workspace management). Capability skills are the "standard library" — the agent loads them when it needs the syntax for a specific CLI command. They sit at the repo root alongside the outcome skill (`cargo-gtm`). Capability skills never reference outcome skills (one-way dependency: outcome → capability).
 
 **chat**
 A conversation session between a user and an agent. Created with `ai chat create --agent-uuid <uuid>`. Messages are sent to a chat via `ai message create --chat-uuid <uuid>`.
@@ -106,6 +112,12 @@ A logical grouping of models in the Cargo workspace. Similar to a schema or fold
 **DDL**
 Data Definition Language. In Cargo context, the result of `storage model get-ddl <uuid>` — contains the SQL table name, column definitions, and SQL dialect (`language`). Run when you need column types or the SQL dialect; `storage query execute` and `storage query download` reference tables by `<datasetSlug>.<modelSlug>` directly.
 
+**deployment (Cargo Hosting)**
+One build+upload of a local source directory to a hosting **app** or **worker**, created with `hosting deployment create --source <pkg-root>` (the backend runs `npm ci && vite build` for apps, or bundles the entrypoint for workers). A deployment is **not live until promoted** — `hosting deployment promote` points the subdomain at it, and `hosting deployment get-promoted` shows what's currently live. Managed in the **`cargo-hosting`** skill.
+
+**deploymentUuid**
+The UUID returned by `hosting deployment create`. Poll it with `hosting deployment get <uuid>` until the build status is terminal, then pass it to `hosting deployment promote --uuid`.
+
 ---
 
 ## E
@@ -132,6 +144,13 @@ An organizational container for plays, tools, and agents in the Cargo app. Manag
 
 **GTM (go-to-market)**
 The set of activities for finding, qualifying, and engaging prospects: sourcing, enrichment, verification, scoring, sequencing, CRM sync, signal monitoring. The `cargo-gtm` outcome skill is cargo's front door for any GTM task.
+
+---
+
+## H
+
+**hosting**
+The CLI domain (`cargo-ai hosting …`) for Cargo Hosting — **apps** (Vite SPAs on `*.cargo.app`), **workers** (serverless edge HTTP handlers), and the **deployments** that ship and promote them. The lifecycle is `init` (local scaffold) → `create` (slot + globally-unique slug) → `deployment create` (build+upload) → `deployment promote` (go live). Documented in the **`cargo-hosting`** skill.
 
 ---
 
@@ -312,6 +331,12 @@ A companion object to `jsonSchema` in action and extractor configs. While `jsonS
 
 **waterfall enrichment**
 A pattern where multiple providers are run sequentially, each filling gaps the prior step missed. Cheap providers do the heavy lifting; premium providers fill the long tail. Implemented as N sequential `action execute-batch` calls with the records pruned between calls. See `cargo-gtm/references/waterfall-strategy.md` for canonical chains by enrichment goal.
+
+**worker (Cargo Hosting)**
+A hosted serverless HTTP handler that runs on the edge — a standard `fetch(request, env)` entrypoint built on `@cargo-ai/worker-sdk` (automatic OpenAPI 3.1 spec at `/openapi.json`, Swagger UI at `/docs`). Scaffolded with `hosting worker init`, registered with `hosting worker create`, shipped via a **deployment**. Has no `env` subcommand (unlike an **app**) — runtime config arrives via the `env` argument to `fetch`. Managed in the **`cargo-hosting`** skill.
+
+**workerUuid**
+The UUID of a Cargo Hosting worker, returned by `hosting worker create`. Passed as `--worker-uuid` to deployment commands, mutually exclusive with `--app-uuid`.
 
 **workflow**
 A DAG of nodes that defines the execution logic for a play or tool. Workflows don't have a `name` field — find them by name via `play list` or `tool list`, then extract `workflowUuid`.


### PR DESCRIPTION
## Summary

Introduces the `cargo-hosting` capability skill, enabling users to scaffold, deploy, and manage Cargo Hosting apps (Vite SPAs on `*.cargo.app`) and workers (serverless edge HTTP handlers) via the Cargo CLI.

## Key Changes

- **New skill: `cargo-hosting/SKILL.md`** — Complete reference for the hosting domain, covering:
  - App and worker lifecycle (scaffold → create → deploy → promote)
  - Command reference for apps, workers, and deployments
  - Critical rules (slug uniqueness, deploy ≠ promote, async polling)
  - Prerequisites and async polling patterns

- **Example walkthroughs:**
  - `cargo-hosting/references/examples/apps.md` — End-to-end app scaffolding, creation, local dev, deployment, and promotion
  - `cargo-hosting/references/examples/workers.md` — Worker scaffolding, deployment, and when to use workers vs apps
  - `cargo-hosting/references/examples/deployments.md` — Deployment lifecycle, polling, rollback patterns

- **Reference documentation:**
  - `cargo-hosting/references/response-shapes.md` — JSON structures for apps, workers, deployments, and env output
  - `cargo-hosting/references/troubleshooting.md` — Common errors (slug conflicts, build failures, folder UUIDs, cascading deletes) and fixes

- **Updated `cargo/SKILL.md`** — Bumped version to 1.5.0 and updated skill count from 9 to 11 capability skills (added hosting and workspace-management)

- **Updated `CHANGELOG.md`** — Documented the new `cargo-hosting` skill addition

## Implementation Details

The skill documents the complete hosting workflow with emphasis on:
- Mutual exclusivity of `--app-uuid` and `--worker-uuid` flags
- Async build polling before promotion
- Slug global uniqueness requirement
- Folder integration via `cargo-workspace-management`
- Cascading deletion behavior
- Template availability (`blank`, `territories-overview` for apps; `blank`, `custom-integration` for workers)

https://claude.ai/code/session_018LeD9abpD7LYBhGGkDxSup

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and agent-skill content only; no application code, auth, or infrastructure changes.
> 
> **Overview**
> Adds **`cargo-hosting`** as a new capability skill (v1.0.0) for the `hosting` CLI domain, following the repo’s one-skill-per-domain pattern. Agents get the full **scaffold → create → deploy → promote** flow for Vite apps on `*.cargo.app` and edge workers, plus examples, pinned JSON response shapes (`status`, `chargedUntil`, app/worker `kind`), and troubleshooting.
> 
> The **`cargo`** router moves to **1.5.0**: skill counts and frontmatter are updated (ten capability skills), **`cargo-hosting`** is added to the capability table and recap, and **`hosting`** is dropped from the “no dedicated skill yet” list. **`README.md`** adds a Hosting row and bumps the advertised skill total to twelve. **`CHANGELOG.md`** and **`cargo/references/glossary.md`** record the new skill and hosting terminology (`appUuid`, `deploymentUuid`, etc.).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e48f8d08617420718e7837a02a8897625b9f817. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->