### PR TITLE
Add cargo-diagnostics skill, interaction conventions, and catalog fixes

### DIFF
--- a/.github/scripts/skills-lint.mjs
+++ b/.github/scripts/skills-lint.mjs
@@ -32,6 +32,7 @@ const SKILL_DIRS = [
   "cargo-context",
   "cargo-analytics",
   "cargo-billing",
+  "cargo-diagnostics",
   "cargo-hosting",
   "cargo-workspace-management",
 ];

--- a/.github/workflows/clawhub-publish.yml
+++ b/.github/workflows/clawhub-publish.yml
@@ -50,8 +50,9 @@ jobs:
           skipped=0
           failed=0
 
-          for dir in cargo cargo-gtm cargo-cdk cargo-orchestration cargo-storage cargo-connection \
-                     cargo-ai cargo-context cargo-analytics cargo-billing cargo-workspace-management; do
+          for dir in cargo cargo-quickstart cargo-gtm cargo-cdk cargo-orchestration cargo-storage \
+                     cargo-connection cargo-ai cargo-content cargo-context cargo-analytics \
+                     cargo-billing cargo-diagnostics cargo-hosting cargo-workspace-management; do
             version=$(awk -F'"' '/^version:/ {print $2; exit}' "$dir/SKILL.md")
             if [ -z "$version" ]; then
               echo "::error::No version: in $dir/SKILL.md"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Cargo skills — agent guide
 
-The router skill at [`cargo/SKILL.md`](cargo/SKILL.md) is the canonical entry point for working with this skillpack. It explains the ten skills (one outcome skill `cargo-gtm` + nine capability skills), the UUID flow between them, async polling, end-to-end use cases, and common gotchas.
+The router skill at [`cargo/SKILL.md`](cargo/SKILL.md) is the canonical entry point for working with this skillpack. It explains the fifteen skills (the `cargo` router + one onboarding skill `cargo-quickstart` + one outcome skill `cargo-gtm` + twelve capability skills), the UUID flow between them, async polling, end-to-end use cases, and common gotchas.
 
 The term reference lives in [`cargo/references/glossary.md`](cargo/references/glossary.md).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,37 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ### Repository-wide
 
+- **ClawHub publish loop caught up.** `clawhub-publish.yml` was missing three shipped skills — `cargo-quickstart`, `cargo-content`, and `cargo-hosting` were lint-covered but never published. All fifteen skills (including the new `cargo-diagnostics`) are now in the publish loop.
+- **Stale counts fixed.** `AGENTS.md` still described "ten skills (one outcome + nine capability)"; the router frontmatter said thirteen and its body said 13 while `README.md` said fourteen. All three now use the same framing: fifteen skills = router + onboarding + outcome + twelve capability. `README.md`'s ClawHub prose also said `--owner getcargohq`; the workflow publishes under `cargo-ai`.
+- **Interaction conventions.** New shared reference [`cargo/references/interaction.md`](cargo/references/interaction.md): the plan gate (design approval before building a node graph or deploying, complementing the cost gate's spend approval), real choices presented with a recommended default (never pick silently between providers/actions), and presenting defaults (narrate, summarize instead of dumping raw JSON, conclusion first, always surface the `app.getcargo.io` URL). Linked from the router, `cargo-gtm`, `cargo-orchestration`, and the new diagnostics runbooks.
+- Note: `cargo` 1.7.0 shipped without a changelog entry (terminal-experience quick wins — quickstart routing, cost discipline, save-as-play, anti-drift); recorded here for the version trail.
+
+### `cargo` → 1.8.0
+
+- **Register the `cargo-diagnostics` skill.** Counts bumped to 15 skills / twelve capability, capability-table row, full recap, and a dependency-rule bullet (when a run fails or "succeeds but looks wrong", load diagnostics). Frontmatter description updated to the fifteen-skill framing, now counting the router itself.
+- **Interaction conventions registered.** New `references/interaction.md` + a pointer next to the glossary line.
+
+### `cargo-diagnostics` → 1.0.0 (new)
+
+- **New capability skill: after-the-fact forensics** over runs, batches, and credit spend — the interpretation layer on top of `run get`, `orchestration query execute`, and `billing usage get-metrics`. `SKILL.md` routes by symptom (one run vs many runs vs cost) across three runbooks:
+  - `references/run-trace.md` — explain one run end-to-end: `executions[]` path, `runContext` as source of truth, branch routing via `nodeChildIndex`, per-node credits/timing, symptom table, and a conclusion-first presentation format.
+  - `references/batch-error-sweep.md` — size the problem, find where failures concentrate (per-node spans SQL), distinguish concentrated defects from rate-limit spread and provider coverage, pick exemplar runs for the trace, and decide fix vs re-run vs report.
+  - `references/play-optimize-credits.md` — attribute spend workflow → node → provider (SQL + billing metrics, billing wins on disagreement), quantify credits wasted on errored runs, then apply levers cheapest-first (filter earlier, provider swap, model/`maxSteps`, stop-early, waterfall reshape, phone off by default), proving savings through the pilot gate.
+- Runbooks link the existing surfaces (`cargo-orchestration` queries/troubleshooting, `cargo-billing` cost levers, `cargo-gtm` cost discipline/credits table/alternatives/waterfall strategy) instead of duplicating them.
+- CI wired: added to `skills-lint.mjs` `SKILL_DIRS` and the `clawhub-publish.yml` publish loop; routed from the `cargo` router (linter-enforced).
+
+### `cargo-gtm` → 1.1.1
+
+- Hand-off pointer to `cargo-diagnostics` when a run/batch misbehaves (sweep before re-running anything paid), and a pointer to the new shared interaction conventions.
+
+### `cargo-orchestration` → 1.5.1
+
+- References callout pointing at `cargo-diagnostics` for the ordered forensic runbooks built on `run get` / orchestration SQL.
+
+### `cargo-billing` → 1.0.2
+
+- Cost-levers table now points at the diagnostics attribution runbook (`play-optimize-credits.md`) for finding which node/provider dominates spend before picking a lever.
+
 - **Session lifecycle moved to the installer.** The Claude Code `SessionStart`/`SessionEnd` hooks that keep `@cargo-ai/cli` + the skills bundle current and log each session to `workspace_management.sessions` are now scaffolded by the Cargo bootstrap installer (`curl -fsSL https://api.getcargo.io/install.sh | sh`, interactive prompt, opt out with `CARGO_INSTALL_HOOKS=0`). Removed the hand-rolled hook-scaffolding recipes from `cargo/SKILL.md`, `README.md`, and `cargo-workspace-management/references/examples/sessions.md`; those docs now point at the installer. The agent's three-session-jobs guidance stays as the manual fallback, and reporting (job 2) is unchanged — it can't be automated.
 - **Per-turn session checkpoint hook.** Documented the new `Stop` hook the installer scaffolds alongside `SessionStart`/`SessionEnd`: it checkpoints the session row at the end of each assistant turn (latest user request + timestamp, derived with `jq`, **no** LLM call, no `--finished`, throttled via `CARGO_CHECKPOINT_INTERVAL`, default 45s), so a session that never reaches `SessionEnd` no longer stays stuck on `"Session in progress."`. The `SessionEnd` hook now also resolves the `claude` binary from Node/version-manager bin dirs and logs to `$CARGO_SESSION_LOG` (default `~/.claude/cargo-session.log`) so a placeholder summary is diagnosable. Updated `cargo/SKILL.md`, `README.md`, `cargo-workspace-management/SKILL.md`, and `sessions.md`; also corrected the opt-out env var to `CARGO_INSTALL_HOOKS=0` (was mis-documented as `CARGO_INSTALL_NO_HOOKS=1`).
 - **Shared prerequisites reference.** Extracted the duplicated install / login / output-conventions block from every capability skill into [`cargo/references/prerequisites.md`](cargo/references/prerequisites.md). Each capability skill now links to it instead of redefining ~16 lines of boilerplate. No behavior change for agents — the canonical setup is the same — but a single place to keep it correct.

--- a/README.md
+++ b/README.md
@@ -66,14 +66,14 @@ npm install -g @cargo-ai/cli@latest               # bumps the CLI
 
 `.github/workflows/clawhub-publish.yml` publishes every skill whose `version:` was bumped, on each GitHub release. One-time setup:
 
-1. Sign in at [clawhub.ai](https://clawhub.ai) with the GitHub account that owns the `getcargohq` org publisher (run `clawhub publisher create getcargohq` first if it doesn't exist), then generate an API token from the web UI.
+1. Sign in at [clawhub.ai](https://clawhub.ai) with the GitHub account that owns the `cargo-ai` org publisher (run `clawhub publisher create cargo-ai` first if it doesn't exist), then generate an API token from the web UI.
 2. Add it as a repo secret named `CLAWHUB_TOKEN`.
 
-Then bump the `version:` field in each changed `SKILL.md` (semver, e.g. `1.0.0` → `1.1.0`) and cut a release. The workflow authenticates with `clawhub login --token`, calls `clawhub skill publish ./<dir> --version <semver> --owner getcargohq` for each skill, skips ones whose published version is unchanged, and fails on any other error. Trigger a manual run with `workflow_dispatch` (optional `dry_run: true`) to preview.
+Then bump the `version:` field in each changed `SKILL.md` (semver, e.g. `1.0.0` → `1.1.0`) and cut a release. The workflow authenticates with `clawhub login --token`, calls `clawhub skill publish ./<dir> --version <semver> --owner cargo-ai` for each skill, skips ones whose published version is unchanged, and fails on any other error. Trigger a manual run with `workflow_dispatch` (optional `dry_run: true`) to preview.
 
 ## What this skill teaches
 
-**Cargo** connects your data models (companies, contacts, deals) to external integrations (CRMs, enrichment providers, AI agents) and runs them as automated workflows. The repo ships fourteen skills at the root — one **router skill** (`cargo`, the overview / front door for any Cargo CLI task), one **onboarding skill** (`cargo-quickstart`, the guided first-run demo), one **outcome skill** (`cargo-gtm`, the front door for any GTM task), and eleven **capability skills** (one per CLI domain). Ten of the capability skills wrap the **imperative** CLI (one-off `cargo-ai <domain>` operations); `cargo-cdk` is the **declarative** one — define a whole workspace in code and deploy it.
+**Cargo** connects your data models (companies, contacts, deals) to external integrations (CRMs, enrichment providers, AI agents) and runs them as automated workflows. The repo ships fifteen skills at the root — one **router skill** (`cargo`, the overview / front door for any Cargo CLI task), one **onboarding skill** (`cargo-quickstart`, the guided first-run demo), one **outcome skill** (`cargo-gtm`, the front door for any GTM task), and twelve **capability skills** (one per CLI domain, plus the cross-domain `cargo-diagnostics`). Most capability skills wrap the **imperative** CLI (one-off `cargo-ai <domain>` operations); `cargo-cdk` is the **declarative** one — define a whole workspace in code and deploy it — and `cargo-diagnostics` sequences the run/SQL/billing surfaces into forensic runbooks (trace a run, sweep a batch for errors, profile credit spend).
 
 ### Router — `cargo`
 

--- a/cargo-billing/SKILL.md
+++ b/cargo-billing/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cargo-billing
 description: Pull usage metrics, check subscription status, view invoices, and manage credits using the Cargo CLI. Use when the user wants billing analytics, usage reports, credit usage, cost analysis, subscription details, or invoice history for their Cargo workspace.
-version: "1.0.1"
+version: "1.0.2"
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 homepage: https://github.com/getcargohq/cargo-skills
 metadata:
@@ -106,6 +106,8 @@ cargo-ai billing usage get-metrics \
 | Add `filter` nodes early in the graph | Skip ineligible records before expensive connector calls |
 | Set `fallbackOnFailure: false` | Stop the run early on failures instead of continuing to downstream nodes |
 | Reduce `maxSteps` on agent nodes | Limit how many tool calls an agent can make per record |
+
+> To find out **which** node or provider dominates a play's spend before picking a lever, follow the attribution runbook in [`../cargo-diagnostics/references/play-optimize-credits.md`](../cargo-diagnostics/references/play-optimize-credits.md).
 
 ## Usage metrics
 

--- a/cargo-diagnostics/SKILL.md
+++ b/cargo-diagnostics/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: cargo-diagnostics
+description: Diagnose and explain Cargo workflow behavior after the fact — trace why a single run produced the wrong output, sweep a batch or play for errors and group them by root cause, and profile where a play's credits go and how to cut the cost. Use when a run failed or "succeeded but looks wrong", a batch has errors, records are missing downstream values, or a play costs more than expected.
+version: "1.0.0"
+compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
+homepage: https://github.com/getcargohq/cargo-skills
+metadata:
+  author: getcargo
+  openclaw:
+    requires:
+      bins:
+        - cargo-ai
+    install:
+      - kind: node
+        package: "@cargo-ai/cli@latest"
+        bins:
+          - cargo-ai
+    homepage: https://github.com/getcargohq/cargo-skills
+---
+
+# Cargo CLI — Diagnostics
+
+Forensic runbooks for workflow behavior: trace one run, sweep a batch for errors, profile a play's credit spend. This skill is the **interpretation layer** — the raw surfaces (`run get`, orchestration SQL, billing metrics) are documented in `cargo-orchestration` and `cargo-billing`; each runbook here tells you which of them to pull, in what order, and what each output shape means.
+
+## Which runbook?
+
+```
+What are you diagnosing?
+│
+├── One run / one record ("why did this record fail?",
+│   "run succeeded but the output is wrong/empty")
+│   └── references/run-trace.md
+│
+├── Many runs ("the batch has errors", "error rate spiked",
+│   "which node keeps failing?")
+│   └── references/batch-error-sweep.md
+│
+└── Cost ("this play is expensive", "where do the credits go?",
+    "make this cheaper")
+    └── references/play-optimize-credits.md
+```
+
+Rule of thumb: start with the **sweep** when you don't yet know which run to look at — it ends by handing you exemplar run UUIDs to feed into the **trace**.
+
+## References
+
+| Doc | What it covers |
+| --- | --- |
+| [`references/run-trace.md`](references/run-trace.md) | Walk one run end-to-end: per-node executions, `runContext` outputs, branch routing, per-node credits and timing. |
+| [`references/batch-error-sweep.md`](references/batch-error-sweep.md) | Find errored runs across a batch/play/workspace, group failures by root cause, pick exemplars, decide fix vs report. |
+| [`references/play-optimize-credits.md`](references/play-optimize-credits.md) | Attribute credit spend to workflows and nodes, then apply the cost levers in priority order. |
+
+## Prerequisites
+
+See [`../cargo/references/prerequisites.md`](../cargo/references/prerequisites.md) for install, login (`--oauth` / `--token`), JSON output conventions, and error shapes. Verify the session with `cargo-ai whoami` before running any of the commands below.
+
+Credit attribution steps (`billing usage get-metrics`, `billing subscription get`) need a token with **admin access**; everything else works with a standard token.
+
+## The three surfaces every runbook draws on
+
+| Surface | Command | Gives you |
+| --- | --- | --- |
+| Run detail | `cargo-ai orchestration run get <run-uuid>` | `run.executions[]` (node-by-node trace), `runContext` (per-node output keyed by `nodeSlug`), `runComputedConfigs` (what each node was actually called with) |
+| Orchestration SQL | `cargo-ai orchestration query execute "<sql>"` | Aggregates over `runs`, `batches`, `spans`, `records` (ClickHouse; no schema prefix; workspace-scoped) |
+| Billing metrics | `cargo-ai billing usage get-metrics --from <date> --to <date>` | Credit totals, filterable and groupable by `workflow_uuid`, `connector_uuid`, `agent_uuid`, `integration_slug`, `model_uuid` |
+
+Full query syntax, table columns, and caps: [`../cargo-orchestration/references/examples/queries.md`](../cargo-orchestration/references/examples/queries.md). Debugging field semantics: [`../cargo-orchestration/references/troubleshooting.md`](../cargo-orchestration/references/troubleshooting.md).
+
+## Presenting findings
+
+Follow [`../cargo/references/interaction.md`](../cargo/references/interaction.md): lead with the conclusion ("18 of 20 failures are one cause: the connector's token expired"), summarize evidence in a short table, never dump raw `run get` JSON or full query results into the conversation. Any fix that re-runs paid nodes goes through the pilot gate in [`../cargo-gtm/references/cost-discipline.md`](../cargo-gtm/references/cost-discipline.md).
+
+## When diagnosis dead-ends
+
+If the evidence contradicts documented behavior (a field missing from `run get`, a query cap that doesn't match the docs, an error that makes no sense), file a report — that's the official channel and the team reads every one:
+
+```bash
+cargo-ai workspaceManagement report create \
+  --title "<one-line summary>" \
+  --description "<commands run, errorMessage verbatim, expected vs actual, UUIDs>"
+```

--- a/cargo-diagnostics/references/batch-error-sweep.md
+++ b/cargo-diagnostics/references/batch-error-sweep.md
@@ -1,0 +1,78 @@
+# Batch error sweep — group failures by root cause
+
+Use this when many runs are involved and you don't yet know where to look: a batch reports errors, a play's error rate spiked, or "some records didn't come through". The output of a sweep is a **small table of failure groups with an exemplar run UUID each** — not a list of every failed run.
+
+> SQL syntax, table columns, and query caps: [`../../cargo-orchestration/references/examples/queries.md`](../../cargo-orchestration/references/examples/queries.md). All queries below are read-only and workspace-scoped automatically.
+
+## 1. Size the problem
+
+```bash
+# For one batch
+cargo-ai orchestration query execute \
+  "SELECT status, count() FROM runs WHERE batch_uuid = '<batch-uuid>' GROUP BY status"
+
+# For a play/workflow over time
+cargo-ai orchestration query execute \
+  "SELECT countIf(status='error') / count() AS error_rate, count() AS total
+   FROM runs
+   WHERE workflow_uuid = '<workflow-uuid>' AND created_at > now() - INTERVAL 7 DAY"
+```
+
+Calibration: error rates under ~5% on connector-heavy workflows are often provider coverage, not defects (see the over-provision rule in [`cost-discipline.md`](../../cargo-gtm/references/cost-discipline.md)). A spike above that, or errors on native nodes, is worth the sweep.
+
+## 2. Find where failures concentrate
+
+```bash
+# Which node fails most
+cargo-ai orchestration query execute \
+  "SELECT node_slug, count() AS failures
+   FROM spans
+   WHERE execution_status='error' AND execution_started_at > now() - INTERVAL 1 DAY
+   GROUP BY node_slug
+   ORDER BY failures DESC"
+```
+
+Scope with `batch_uuid`/`workflow_uuid` predicates when you have them. Two shapes to distinguish:
+
+- **Concentrated** (one node owns most failures) → a config, credential, or expression defect at that node. Proceed to step 3 with that node.
+- **Spread across connector nodes, clustered in time** → third-party rate limiting. Confirm with the "signs you are being rate-limited" checklist in [`troubleshooting.md`](../../cargo-orchestration/references/troubleshooting.md); the fix is retry config + smaller sub-batches, not per-run debugging.
+
+## 3. Pick exemplars and read the actual errors
+
+```bash
+cargo-ai orchestration query execute \
+  "SELECT uuid, created_at
+   FROM runs
+   WHERE batch_uuid = '<batch-uuid>' AND status='error'
+   ORDER BY created_at ASC
+   LIMIT 3"
+```
+
+Take 2–3 exemplars per failure group and trace each with [`run-trace.md`](run-trace.md) — the error detail lives in `run get`'s `runContext`, not in the SQL tables. Failures with the same node + same error pattern are one group; resist tracing every run.
+
+## 4. Decide: fix, re-run, or report
+
+| Root cause shape | Action |
+| --- | --- |
+| Expression/branch defect (same wrong output every time) | Fix the node, re-test on exemplar record IDs, then re-run only the failed records: `run download --statuses error` → fix → `batch create --data '{"kind":"recordIds",...}'` (sequence in [`troubleshooting.md`](../../cargo-orchestration/references/troubleshooting.md), "Run error recovery") |
+| Expired connector credentials | Re-authenticate the connector (`connection connector update` or the Cargo app), then re-run failed records |
+| Provider rate limiting | Retry config + sequential sub-batches; don't chase individual rows |
+| Provider coverage (no email exists, company not found) | Expected loss — drop the rows per the over-provision rule; do **not** re-run them through more providers |
+| CLI/platform behavior contradicts the docs | File it — this is exactly what the report channel is for: `cargo-ai workspaceManagement report create --title "..." --description "<commands, errorMessage verbatim, expected vs actual, UUIDs>"` |
+
+Any re-run of paid nodes is a paid action: pilot gate + receipt per [`cost-discipline.md`](../../cargo-gtm/references/cost-discipline.md).
+
+## Presenting a sweep
+
+Per [`../../cargo/references/interaction.md`](../../cargo/references/interaction.md): conclusion first ("one root cause explains 18 of 20 failures"), then the groups table, then the recommended action per group. Example shape:
+
+```
+Batch <uuid>: 20 of 250 runs errored. Two groups:
+
+| group | runs | node        | root cause                            | action                    |
+|-------|------|-------------|----------------------------------------|---------------------------|
+| 1     | 18   | find_email  | connector token expired (401 verbatim) | re-auth, re-run 18 records |
+| 2     | 2    | enrich_co   | provider has no data for these domains | drop rows (coverage)      |
+
+Re-running group 1 ≈ <n> credits. Proceed?
+```

--- a/cargo-diagnostics/references/play-optimize-credits.md
+++ b/cargo-diagnostics/references/play-optimize-credits.md
@@ -1,0 +1,81 @@
+# Play cost profile — where credits go, and how to cut them
+
+Use this when a play costs more than expected or the user asks to reduce spend. The procedure is: attribute (which workflow → which node → which provider), then apply levers in priority order. Never propose a lever before the attribution — "use a cheaper model" is noise if 90% of the spend is a phone-lookup connector.
+
+Credit attribution needs an **admin** token (`billing` commands); the SQL steps work with any token.
+
+## 1. Attribute spend to workflows
+
+```bash
+# Credit spend by workflow this month (SQL — fast, no admin needed)
+cargo-ai orchestration query execute \
+  "SELECT workflow_uuid, sum(credits_used_count) AS credits
+   FROM batches
+   WHERE created_at >= toStartOfMonth(now())
+   GROUP BY workflow_uuid
+   ORDER BY credits DESC"
+
+# Billing source of truth, groupable by other dimensions too
+cargo-ai billing usage get-metrics --from <YYYY-MM-DD> --to <YYYY-MM-DD> --group-by workflow_uuid
+cargo-ai billing usage get-metrics --from <YYYY-MM-DD> --to <YYYY-MM-DD> --group-by integration_slug
+```
+
+Map UUIDs to names with `cargo-ai orchestration play list` / `tool list`. When SQL and billing disagree, billing wins.
+
+## 2. Attribute spend to nodes inside the top workflow
+
+Per-node cost lives on the run detail: each `run.executions[]` item carries `creditsUsedCount` (agent and connector nodes are non-zero, native nodes are zero — see [`troubleshooting.md`](../../cargo-orchestration/references/troubleshooting.md)). Pull 2–3 recent representative runs and average:
+
+```bash
+cargo-ai orchestration query execute \
+  "SELECT uuid FROM runs
+   WHERE workflow_uuid = '<workflow-uuid>' AND status = 'success'
+   ORDER BY created_at DESC LIMIT 3"
+
+cargo-ai orchestration run get <run-uuid>   # read executions[].creditsUsedCount per nodeSlug
+```
+
+Also check **waste**: credits spent on runs that errored anyway —
+
+```bash
+cargo-ai orchestration query execute \
+  "SELECT status, sum(credits_used_count) AS credits, count() AS runs
+   FROM runs
+   WHERE workflow_uuid = '<workflow-uuid>' AND created_at > now() - INTERVAL 30 DAY
+   GROUP BY status"
+```
+
+A meaningful `error`-row credit sum means expensive nodes run **before** the failure point — reordering is a free win.
+
+## 3. Apply levers, cheapest-to-implement first
+
+Work down this list; the first two usually dominate. The canonical lever table is in [`../../cargo-billing/SKILL.md`](../../cargo-billing/SKILL.md) ("Cost levers"); provider prices are in [`../../cargo-gtm/references/credits-cost-table.md`](../../cargo-gtm/references/credits-cost-table.md).
+
+| Lever | When it applies | Where documented |
+| --- | --- | --- |
+| **Filter earlier** — move `filter` nodes before expensive connector/agent nodes so ineligible records never reach them | Waste query (step 2) shows credits on errored/filtered-late runs | [`cargo-billing/SKILL.md`](../../cargo-billing/SKILL.md) |
+| **Cheaper provider for the same stage** — swap the action, keep the graph | One integration dominates the `integration_slug` grouping | [`credits-cost-table.md`](../../cargo-gtm/references/credits-cost-table.md) + [`alternatives.md`](../../cargo-gtm/references/alternatives.md) — beware cheap-but-low-hit-rate providers; total spend is dominated by misses |
+| **Cheaper model / lower `maxSteps` on agent nodes** | Agent nodes dominate per-node cost | [`cargo-billing/SKILL.md`](../../cargo-billing/SKILL.md) |
+| **Stop early on failure** (`fallbackOnFailure: false`) | Downstream nodes run after an upstream miss | [`cargo-billing/SKILL.md`](../../cargo-billing/SKILL.md) |
+| **Reshape waterfall chains** — reorder by hit-rate/price, add stop-early rules | Multi-provider enrichment stages | [`waterfall-strategy.md`](../../cargo-gtm/references/waterfall-strategy.md) |
+| **Cut phone lookup from default chains** | Phone actions present without explicit user request (3–7 credits/record, ~10× email) | [`cost-discipline.md`](../../cargo-gtm/references/cost-discipline.md) §5 |
+
+## 4. Prove the saving
+
+Changing the graph is a workflow edit + re-run: stage via draft release, pilot 1–3 records, present the before/after per-record cost, and only then fan out — the full gate is [`cost-discipline.md`](../../cargo-gtm/references/cost-discipline.md) §1, and the receipt format is §2. A cost optimization that skips the pilot is just a different way to spend credits blind.
+
+## Presenting a cost profile
+
+Per [`../../cargo/references/interaction.md`](../../cargo/references/interaction.md): lead with the attribution and the projected saving, then the lever plan as shaped choices. Example shape:
+
+```
+"Enrich EMEA leads" spent 412 credits this month; 71% is the find_phone
+connector node, which runs on every record before qualification.
+
+| change                                   | est. per-record | est. monthly |
+|------------------------------------------|-----------------|--------------|
+| move qualify filter before find_phone    | 4.1 → 1.9       | −55%         |
+| also: drop phone to on-request only      | 1.9 → 0.6       | −85%         |
+
+Pilot either variant on 3 records (~2 credits) to confirm before deploying?
+```

--- a/cargo-diagnostics/references/run-trace.md
+++ b/cargo-diagnostics/references/run-trace.md
@@ -1,0 +1,75 @@
+# Run trace — explain one run end-to-end
+
+Use this when you have (or can find) a single run UUID and need to answer "what actually happened to this record?" — a hard failure, or the more common case: `status: "success"` with wrong or empty output.
+
+> Field-by-field semantics for everything used here live in [`../../cargo-orchestration/references/troubleshooting.md`](../../cargo-orchestration/references/troubleshooting.md) ("Debugging a workflow run"). This runbook is the ordered procedure.
+
+## 0. Find the run if you only have a record or a symptom
+
+```bash
+# Recent runs for a workflow (most recent first)
+cargo-ai orchestration query execute \
+  "SELECT uuid, status, created_at, credits_used_count
+   FROM runs
+   WHERE workflow_uuid = '<workflow-uuid>'
+   ORDER BY created_at DESC
+   LIMIT 20"
+```
+
+If you're coming from a batch sweep, you already have exemplar UUIDs — skip ahead.
+
+## 1. Pull the trace
+
+```bash
+cargo-ai orchestration run get <run-uuid>
+```
+
+Read three fields, in this order:
+
+1. **`run.executions[]`** — the node-by-node path. For each node: `nodeSlug`, `status`, `nextNodeUuid`, `nodeChildIndex`, `creditsUsedCount`. This tells you **where execution went**, including which child a `branch` took (`nodeChildIndex` `0` = matched/yes, `1` = not matched/no).
+2. **`runContext`** — per-node output keyed by `nodeSlug`. This is the actual data downstream expressions saw as `{{nodes.<slug>...}}`. It is the source of truth; the `title` on an execution is a truncated summary, never evidence.
+3. **`runComputedConfigs`** — what each node was *actually called with* after expression resolution. When a node received garbage, this shows the garbage.
+
+Don't paste the raw response into the conversation — extract the two or three nodes that matter (see "Presenting" below).
+
+## 2. Diagnose by symptom
+
+| Symptom | Where to look | Typical conclusion |
+| --- | --- | --- |
+| Run `error` | First `executions[]` item with `status: "error"`; its `runContext.<slug>` entry carries the error detail | Failing node identified — match it against the error-pattern table in [`troubleshooting.md`](../../cargo-orchestration/references/troubleshooting.md) ("Run error recovery") |
+| Run `success`, output empty | `runContext.<upstreamSlug>` of the node that produced the empty value | Expression path doesn't exist — commonly agent output nested under `.answer` (`{{nodes.qualify.answer.qualified}}`, not `{{nodes.qualify.qualified}}`) |
+| Wrong branch taken | The branch node's `nodeChildIndex` + the `runContext` of the node its condition references | Condition resolved falsy because the referenced path is missing/undefined — verify the real shape in `runContext` |
+| Connector node "worked" but downstream empty | `runContext.<connectorSlug>` | Partial provider response; the real field names differ from the ones referenced (e.g. `contact.email` vs `email`) |
+| One node absurdly slow | Spans timing query below | Rate-limited or retrying connector; see the batch-sizing section of `troubleshooting.md` |
+
+Per-node timing for the slow-node case:
+
+```bash
+cargo-ai orchestration query execute \
+  "SELECT node_slug, execution_status,
+          dateDiff('second', execution_started_at, execution_finished_at) AS duration_s
+   FROM spans
+   WHERE run_uuid = '<run-uuid>'
+   ORDER BY duration_s DESC"
+```
+
+## 3. Confirm the fix on the same record
+
+Stage → approve → deploy → re-run the exact record IDs that exposed the bug — the command sequence is in [`troubleshooting.md`](../../cargo-orchestration/references/troubleshooting.md) ("Re-run a single record after fixing"). Re-running paid nodes counts as a paid action: pilot gate + receipt per [`../../cargo-gtm/references/cost-discipline.md`](../../cargo-gtm/references/cost-discipline.md).
+
+## Presenting a trace
+
+Per [`../../cargo/references/interaction.md`](../../cargo/references/interaction.md): conclusion first, then a compact path table — one row per relevant node (`nodeSlug` → status → the one field that matters), then the recommended fix. Example shape:
+
+```
+The run "succeeded" but the branch took the no-path: the condition reads
+{{nodes.qualify.qualified}}, but the agent's output is nested under .answer.
+
+| node      | status  | evidence                                        |
+|-----------|---------|--------------------------------------------------|
+| qualify   | success | runContext.qualify.answer.qualified = true       |
+| branch_1  | success | nodeChildIndex = 1 (no-path) — condition falsy   |
+
+Fix: change the condition to {{nodes.qualify.answer.qualified}} and re-run
+record <id> to confirm (1 record ≈ <n> credits).
+```

--- a/cargo-gtm/SKILL.md
+++ b/cargo-gtm/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cargo-gtm
 description: "Front door for any GTM task on Cargo — sourcing, waterfall enrichment, email/phone/LinkedIn lookup, email verification, scoring, qualification, sequencing, CRM sync, and signal monitoring (job changes, funding, tech-stack/hiring intent). Use when the user states a real-world goal involving prospects, leads, accounts, contacts, ICP lists, or campaign activation. Routes to phase guides (Level 2), recipes (Level 2.5), and per-provider playbooks (Level 3) before any action call."
-version: "1.1.0"
+version: "1.1.1"
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 homepage: https://github.com/getcargohq/cargo-skills
 metadata:
@@ -99,6 +99,8 @@ End every completed run with the receipt (above), then propose **2–3 next step
 5. **An escape hatch** — always end with "or something else entirely."
 
 When a run produced a durable, repeatable result, one of the suggestions should be **making it systematic** — see [`recipes/save-as-play.md`](recipes/save-as-play.md).
+
+When a run or batch **misbehaved** — errors, missing downstream values, cost surprises — hand off to the `cargo-diagnostics` skill (`../cargo-diagnostics/SKILL.md`): sweep the batch for root causes before re-running anything paid. Interaction defaults for plan gates, shaped choices, and presenting results live in `../cargo/references/interaction.md`.
 
 ## 5) Priority provider stack (recipes lead with these 6)
 

--- a/cargo-orchestration/SKILL.md
+++ b/cargo-orchestration/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cargo-orchestration
 description: Interact with the Cargo platform via CLI. Use when the user wants to execute an action, run a workflow, trigger a batch, message an AI agent, query orchestration runtime tables (runs/batches/spans/records) with SQL, fetch segment records, resolve an action's output schema, or inspect a model schema.
-version: "1.5.0"
+version: "1.5.1"
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 homepage: https://github.com/getcargohq/cargo-skills
 metadata:
@@ -60,6 +60,8 @@ Need to run something?
 > `references/polling.md` — async polling patterns, error handling, retry strategies
 > `references/response-shapes.md` — full JSON response structures
 > `references/troubleshooting.md` — common errors, plus a "Debugging a workflow run" section for runs that succeed but produce wrong output (wrong-branch routing, empty downstream values)
+
+> **Diagnosing after the fact?** For the ordered forensic runbooks built on these surfaces — trace one run, sweep a batch for errors grouped by root cause, profile a play's credit spend — load the [`cargo-diagnostics`](../cargo-diagnostics/SKILL.md) skill.
 
 ## Prerequisites
 

--- a/cargo/SKILL.md
+++ b/cargo/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cargo
-description: Router and overview for the Cargo CLI agent skills. Explains the thirteen skills (one onboarding skill cargo-quickstart + one outcome skill cargo-gtm + eleven capability skills, including cargo-cdk for declarative workspace-as-code), when to use the declarative CDK vs the imperative CLI, the UUID flow between them, async polling, end-to-end use cases (enrich one record, enrich and sync to CRM, AI lead scoring, custom workflow, error monitoring, fresh-workspace bootstrap, segment export, GTM context authoring), and common gotchas (`conjonction` spelling, run vs batch, model-uuid vs segment-uuid). Load first whenever working with the Cargo CLI, when unsure which sub-skill applies, when stitching multiple sub-skills together, when bootstrapping a workspace, or when the user asks about Cargo skills in general.
-version: "1.7.0"
+description: Router and overview for the Cargo CLI agent skills. Explains the fifteen skills (this router + one onboarding skill cargo-quickstart + one outcome skill cargo-gtm + twelve capability skills, including cargo-cdk for declarative workspace-as-code and cargo-diagnostics for run/batch/cost forensics), when to use the declarative CDK vs the imperative CLI, the UUID flow between them, async polling, end-to-end use cases (enrich one record, enrich and sync to CRM, AI lead scoring, custom workflow, error monitoring, fresh-workspace bootstrap, segment export, GTM context authoring), and common gotchas (`conjonction` spelling, run vs batch, model-uuid vs segment-uuid). Load first whenever working with the Cargo CLI, when unsure which sub-skill applies, when stitching multiple sub-skills together, when bootstrapping a workspace, or when the user asks about Cargo skills in general.
+version: "1.8.0"
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 homepage: https://github.com/getcargohq/cargo-skills
 metadata:
@@ -28,16 +28,18 @@ metadata:
 
 # Cargo CLI — Skills Overview
 
-This repository contains 13 skills at the repo root: one **onboarding skill** (`cargo-quickstart`), one **outcome skill** (`cargo-gtm`), and eleven **capability skills**.
+This repository contains 15 skills at the repo root: this **router** (`cargo`), one **onboarding skill** (`cargo-quickstart`), one **outcome skill** (`cargo-gtm`), and twelve **capability skills**.
 
 - **`cargo-quickstart`** — guided first-run demo. Fresh workspace → real deliverable (25 leads for the user's persona, with a cost receipt) in under two minutes, ending by saving the demo as a recurring play. Load for new users, demo/tour requests, or empty workspaces.
 - **`cargo-gtm`** — application library. The front door for any GTM task ("build a TAM list", "find 5 fintech CTOs", "monitor job changes"). Routes via internal recipes (`../cargo-gtm/recipes/*.md`) and provider playbooks (`../cargo-gtm/provider-playbooks/*.md`).
-- **Capability skills** — standard library. One per CLI domain (orchestration, storage, connection, AI, content, context, analytics, billing, hosting, cdk, workspace management). Loaded by `cargo-gtm`, or directly when you need a specific CLI domain.
+- **Capability skills** — standard library. One per CLI domain (orchestration, storage, connection, AI, content, context, analytics, billing, hosting, cdk, workspace management), plus `cargo-diagnostics` (cross-domain forensics over runs, batches, and credit spend). Loaded by `cargo-gtm`, or directly when you need a specific CLI domain.
 - **`cargo-cdk`** — the declarative one. Where the other capability skills wrap **imperative** one-off `cargo-ai <domain>` calls, `cargo-cdk` defines the whole workspace as code (`define*` builders + `cargo-ai cdk deploy`) and reconciles it. It spans every resource type — see "Declarative vs imperative" below to route between it and the imperative skills.
 
 `cargo-gtm` delegates to capability skills; capability skills never reference `cargo-gtm` (one-way dependency).
 
 **Glossary:** See [`references/glossary.md`](references/glossary.md) for term-by-term definitions (UUIDs, slugs, `conjonction`, run/batch/play/tool, signal/persona/ICP, etc.).
+
+**Interaction conventions:** See [`references/interaction.md`](references/interaction.md) for the pack-wide defaults on when to stop and ask (plan gate before building, recommended-default choices) and how to present results (narrate, summarize — never dump raw JSON).
 
 ## Installation
 
@@ -177,6 +179,7 @@ Load for a specific CLI domain. The first link in each row jumps to the actual S
 | [`cargo-orchestration`](../cargo-orchestration/SKILL.md) ([recap](#cargo-orchestration))                    | Execute actions, run workflows, trigger batches, chat with agents, query orchestration with SQL (ClickHouse) |
 | [`cargo-analytics`](../cargo-analytics/SKILL.md) ([recap](#cargo-analytics))                                | Download run results, export segment data, monitor error rates and metrics                         |
 | [`cargo-billing`](../cargo-billing/SKILL.md) ([recap](#cargo-billing))                                      | Check credit usage, view subscription details, track costs per workflow or connector               |
+| [`cargo-diagnostics`](../cargo-diagnostics/SKILL.md) ([recap](#cargo-diagnostics))                          | Diagnose after the fact: trace why one run misbehaved, sweep a batch/play for errors grouped by root cause, profile where a play's credits go |
 | [`cargo-storage`](../cargo-storage/SKILL.md) ([recap](#cargo-storage))                                      | Inspect or modify data models, columns, datasets, and relationships; query workspace storage with SQL |
 | [`cargo-connection`](../cargo-connection/SKILL.md) ([recap](#cargo-connection))                             | Manage connector authentication, discover available integrations and their actions                 |
 | [`cargo-ai`](../cargo-ai/SKILL.md) ([recap](#cargo-ai))                                                     | Create and configure agents, configure releases, attach knowledge for RAG, manage MCP servers and memories |
@@ -272,6 +275,7 @@ The CLI exposes several domains that no capability skill wraps yet. Reach for th
 - Before executing a workflow that uses an agent node, load `cargo-ai` to get `agentUuid`.
 - After runs complete, load `cargo-analytics` to download results or measure performance. **For action output retrieval, prefer `cargo-ai orchestration run download-outputs` over `run download` — the former returns a signed-URL CSV/JSON of just the output node's data.**
 - Load `cargo-billing` to understand credit consumption for any of the above.
+- When a run failed, a run "succeeded but looks wrong", a batch has errors, or a play costs too much, load `cargo-diagnostics` — it sequences the `run get` / orchestration-SQL / billing surfaces into forensic runbooks (trace one run, sweep a batch, profile credit spend).
 
 ---
 
@@ -352,6 +356,22 @@ The CLI exposes several domains that no capability skill wraps yet. Reach for th
 - `subscriptionAvailableCreditsCount - subscriptionCreditsUsedCount` from `subscription get` = remaining credits.
 
 **References:** `../cargo-billing/SKILL.md`
+
+---
+
+### cargo-diagnostics
+
+**Forensics over runs, batches, and spend.** Three runbooks that sequence existing surfaces (`run get`, `orchestration query execute`, `billing usage get-metrics`) into diagnoses: `references/run-trace.md` (explain one run end-to-end — executions, `runContext`, branch routing, per-node credits), `references/batch-error-sweep.md` (group a batch/play's failures by root cause, hand back exemplar run UUIDs), `references/play-optimize-credits.md` (attribute spend to workflows → nodes → providers, then apply cost levers in priority order).
+
+**Critical rules:**
+
+- Start with the **sweep** when you don't know which run to look at; it ends with exemplar UUIDs for the **trace**.
+- `runContext` is the source of truth for what a node produced; an execution's `title` is a truncated summary — never evidence.
+- Credit attribution (`billing …`) needs an **admin** token; the SQL and `run get` steps don't.
+- Any fix that re-runs paid nodes goes through the pilot gate in `../cargo-gtm/references/cost-discipline.md`.
+- Present conclusions first, evidence as compact tables — per `references/interaction.md` (in the `cargo` router skill).
+
+**References:** `../cargo-diagnostics/SKILL.md`
 
 ---
 

--- a/cargo/references/interaction.md
+++ b/cargo/references/interaction.md
@@ -1,0 +1,51 @@
+# Interaction conventions — plan gates, choices, and presenting
+
+How an agent working with Cargo communicates: when to stop and ask, how to offer choices, and how to present what happened. These defaults apply across every skill in this pack; recipes and runbooks link here instead of restating them.
+
+They exist because Cargo work is collaborative and (often) paid: building a play, wiring a node graph, or fanning out a batch is a back-and-forth with the user, not a fire-and-forget task.
+
+## 1. The plan gate — design approval before building
+
+Before creating or editing a node graph, deploying a release, or launching anything beyond a trivial single-node change, present the plan and **wait for approval**:
+
+- **Trigger** — how the play/workflow is launched (manual/CLI run, batch over a segment, schedule, segment change). Ask if it isn't stated; it shapes the whole graph (input shape, volume, where outputs land).
+- **Nodes and data flow** — what each node does and what feeds it, in human-readable names.
+- **Cost shape** — which nodes are paid, rough per-record estimate.
+
+Treat this as a hard gate: don't start building from an unconfirmed plan. It complements the **cost gate** in [`../../cargo-gtm/references/cost-discipline.md`](../../cargo-gtm/references/cost-discipline.md), which stays authoritative for spend (pilot → approval → full run): the plan gate approves the *design*, the pilot gate approves the *spend*. A trivial change (fix one expression, rename a node) doesn't need the ceremony — say what you changed and why.
+
+## 2. Real choices: ask, with a recommended default
+
+Many Cargo stages can be built more than one way — several providers cover the same enrichment, several actions do nearly the same thing, a step can be an agent node or a deterministic one. When alternatives genuinely differ:
+
+- **Never pick silently.** List the options by human-readable name (never raw `actionSlug`s or UUIDs), with cost and what each is best at.
+- **Mark a recommended default** and say why — the simplest option that fits the use case. The user should be able to accept in one word.
+- **Batch related questions** into one round (trigger + provider + output destination), not a drip of one-offs.
+- Don't ask when there's nothing to decide: one obvious option, or a pure read. Asking permission to look something up is friction, not collaboration.
+
+```
+How should this play be triggered?
+1. Manual / CLI runs (recommended) — start with one-off test runs; attach a
+   schedule or segment trigger later.
+2. Segment change — every record entering the segment becomes a run.
+3. Schedule — recurring batch over the segment.
+
+And for email lookup: waterfall verify-first (~0.4 cr/row, recommended) or
+FullEnrich premium (~1 cr/row, better coverage on small companies)?
+```
+
+## 3. Presenting defaults
+
+- **Narrate meaningful steps.** One or two sentences before a change (what and why) and after it (what happened). Refer to nodes, actions, and plays by name.
+- **Summarize, don't dump.** Raw JSON, full SQL results, or CSV contents are never the primary answer — turn them into a short table, a count, or a one-line takeaway, and keep large exports out of the conversation entirely (context discipline: [`../../cargo-gtm/references/cost-discipline.md`](../../cargo-gtm/references/cost-discipline.md) §6). Show raw output only when the user asks.
+- **Lead with the conclusion.** State what happened or what you found first; evidence after.
+- **Show the structure at checkpoints.** After building or editing a graph, after a pilot, and when reporting a run: a compact node-flow sketch or table beats prose.
+- **Always surface the URL.** Every created or touched resource gets its `app.getcargo.io` link (URL patterns: [`uuid-flow.md`](uuid-flow.md)) so the user can open it in the Cargo app.
+- **Receipts after paid actions** are their own convention — format in [`cost-discipline.md`](../../cargo-gtm/references/cost-discipline.md) §2.
+
+## Where these apply most
+
+- Building or editing plays/workflows (`cargo-orchestration`, and node-graph steps in `cargo-gtm` recipes).
+- Activating GTM recipes end-to-end (`cargo-gtm` — the pilot gate already encodes §1's spirit for spend).
+- Reporting diagnostics (`cargo-diagnostics` — conclusion-first tables).
+- CDK plans (`cargo-cdk` — `cdk plan` output is the plan-gate artifact; present the diff, not the raw state).


### PR DESCRIPTION
## What's in here

- **New capability skill `cargo-diagnostics`** — after-the-fact forensics over runs, batches, and credit spend: the interpretation layer on top of `run get`, orchestration SQL, and billing metrics. Three runbooks that *link* existing references instead of duplicating them:
  - `references/run-trace.md` — explain one run end-to-end (`executions[]`, `runContext` as source of truth, branch routing, per-node credits)
  - `references/batch-error-sweep.md` — group a batch/play's failures by root cause, hand back exemplar run UUIDs
  - `references/play-optimize-credits.md` — attribute spend workflow → node → provider, then apply cost levers cheapest-first
- **New shared reference `cargo/references/interaction.md`** — pack-wide interaction defaults: plan gate before building a node graph or launching a paid batch, real choices presented with a recommended default (never pick a provider/action silently), and presenting rules (narrate, summarize instead of dumping raw JSON, conclusion first, always surface the `app.getcargo.io` URL). These prose conventions are what make agents drive clean guided flows (e.g. AskUserQuestion wizards) without any tooling.
- **Catalog hygiene** — AGENTS.md still said "ten skills", the router said thirteen, README said fourteen (now fifteen everywhere, consistently framed); the ClawHub publish loop was missing `cargo-quickstart`, `cargo-content`, `cargo-hosting` (never published!); README's `--owner getcargohq` prose contradicted the workflow's `CLAWHUB_OWNER: cargo-ai`.

Versions: `cargo` 1.8.0, `cargo-diagnostics` 1.0.0 (new), `cargo-gtm` 1.1.1, `cargo-orchestration` 1.5.1, `cargo-billing` 1.0.2.

## Verification

- `node .github/scripts/skills-lint.mjs .` → 0 errors, 0 warnings (new skill passes all invariants: SKILL_DIRS, router link, internal links, JSON fences, domain allow-list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and agent-skill packaging only—no runtime code, auth, or data-path changes; CI/publish list updates reduce prior under-publish risk.
> 
> **Overview**
> Introduces **`cargo-diagnostics`** (v1.0.0), a cross-domain capability skill that turns existing `run get`, orchestration SQL, and billing metrics into three symptom-routed runbooks: single-run trace (`runContext` / branch routing), batch error sweep (group by root cause, exemplar UUIDs), and play credit attribution plus cheapest-first levers—without duplicating orchestration/billing/GTM docs.
> 
> Adds shared **`cargo/references/interaction.md`** (plan gate before building/deploying, shaped choices with a recommended default, conclusion-first presentation and no raw JSON dumps). The **`cargo`** router (1.8.0) registers diagnostics and interaction; **`cargo-gtm`**, **`cargo-orchestration`**, and **`cargo-billing`** get hand-off/cross-links and patch version bumps.
> 
> **Catalog / CI hygiene:** skill counts aligned to **15 skills** in `AGENTS.md`, `README.md`, and router frontmatter; ClawHub publish loop now includes all fifteen dirs (fixes missing publish for `cargo-quickstart`, `cargo-content`, `cargo-hosting`) and README publish prose matches workflow owner **`cargo-ai`**; `cargo-diagnostics` added to `skills-lint.mjs` `SKILL_DIRS`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c00970d330efc8f29d7fe4b9bc9d8f935b37a57d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->