### PR TITLE
Document the analytics/diagnostics boundary; surface both in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,9 @@ Built-in recipes:
 | `account-expansion.md` | Multi-thread existing customer accounts — net-new buyers, deduped against the Contacts model. |
 | `save-as-play.md` | Convert a successful ad-hoc run into a durable scheduled play or cron tool. |
 
-### Capabilities — CLI surface
+### Capabilities
 
-Load when you need the syntax for a specific CLI domain.
+The standard library. Load when you need the syntax for a specific CLI domain — plus the two cross-cutting entries: **CDK** (the declarative mode) and **Diagnostics** (forensic runbooks over the other surfaces).
 
 | Domain            | What the agent learns                                                                                                                                              |
 | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -147,8 +147,9 @@ Load when you need the syntax for a specific CLI domain.
 | **Analytics**     | Download run results and outputs, export segment data, monitor error rates and success metrics                                                                     |
 | **Billing**       | Track credit consumption per workflow or connector, check subscription status, view invoices                                                                       |
 | **Hosting**       | Scaffold, deploy, and promote hosted apps (Vite SPAs on `*.cargo.app`) and edge workers (serverless HTTP handlers), and manage their deployments                   |
-| **CDK** *(declarative)* | Define an entire workspace in code (`define*` builders) and deploy it with `cargo-ai cdk` (init → types → plan → deploy → destroy). Spans every resource type; use for workspace-as-code / reproducible / version-controlled setups |
 | **Workspace**     | Invite users, create and rotate API tokens, organize resources into folders, manage roles                                                                          |
+| **CDK** *(declarative)* | Define an entire workspace in code (`define*` builders) and deploy it with `cargo-ai cdk` (init → types → plan → deploy → destroy). Spans every resource type; use for workspace-as-code / reproducible / version-controlled setups |
+| **Diagnostics** *(cross-domain)* | Explain workflow behavior after the fact: trace why one run misbehaved, sweep a batch or play for errors grouped by root cause, profile where a play's credits go. Forensic runbooks over the run / orchestration-SQL / billing surfaces |
 
 ## What can I ask for?
 

--- a/cargo-analytics/SKILL.md
+++ b/cargo-analytics/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cargo-analytics
-description: Download workflow run results, export segment data, and monitor run metrics using the Cargo CLI. Use when the user wants run metrics, error rates, data export, or download results for their Cargo workspace. For billing and credit usage, use the cargo-billing skill instead.
-version: "1.4.1"
+description: Download workflow run results, export segment data, and monitor run metrics using the Cargo CLI. Use when the user wants run metrics, error rates, data export, or download results for their Cargo workspace. For billing and credit usage, use the cargo-billing skill instead. For explaining WHY a run failed or a batch has errors, use the cargo-diagnostics skill instead.
+version: "1.4.2"
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 homepage: https://github.com/getcargohq/cargo-skills
 metadata:
@@ -27,6 +27,19 @@ Measurement and export: monitoring run metrics, downloading run and batch result
 > See `references/examples/run-analytics.md` for run metrics and error monitoring.
 > See `references/examples/exports.md` for data export and download examples.
 > For billing, usage metrics, and subscription: use the `cargo-billing` skill.
+
+## Scope — measure and export, not explain
+
+This skill answers **"what happened"** and **"give me the data"**: metrics, counts, downloads, exports. The moment the question becomes **"why"** — why did this run fail, why is the output wrong or empty, which root cause explains these errors, why is this play so expensive — switch to the `cargo-diagnostics` skill; its runbooks sequence the raw surfaces into a diagnosis.
+
+| The question sounds like… | Load |
+| --- | --- |
+| "What's the error rate?" / "How many runs failed this week?" / "Export the results / segment" | **this skill** |
+| "Why did this run fail?" / "Run succeeded but the output looks wrong" | `cargo-diagnostics` → `references/run-trace.md` |
+| "Why does this batch have errors? Which node keeps failing, and is it one cause or many?" | `cargo-diagnostics` → `references/batch-error-sweep.md` |
+| "Why is this play so expensive? Where do the credits go?" | `cargo-diagnostics` → `references/play-optimize-credits.md` |
+
+The two skills chain naturally: analytics **detects** (error rate spiked, batch reports failures), diagnostics **explains** (18 of 20 failures share one root cause), then analytics **retrieves** the clean results once the cause is fixed and the runs re-executed.
 
 ## Prerequisites
 
@@ -182,27 +195,25 @@ cargo-ai orchestration batch get <batch-uuid>
 # → .failedRunsCount    = records that errored
 ```
 
-**Step 2 — Count errors for the batch:**
+**Step 2 — Count and download the failed runs:**
 
 ```bash
 cargo-ai orchestration run count \
   --workflow-uuid <uuid> \
   --batch-uuid <batch-uuid> \
   --statuses error
-```
 
-**Step 3 — Download failed runs to inspect root causes:**
-
-```bash
 cargo-ai orchestration run download \
   --workflow-uuid <uuid> \
   --batch-uuid <batch-uuid> \
   --statuses error
 ```
 
+**Step 3 — Diagnose.** Working out *why* they failed — grouping failures by root cause, picking exemplar runs, reading `runContext` — is the `cargo-diagnostics` skill's job: load `../cargo-diagnostics/references/batch-error-sweep.md` and feed it the batch UUID.
+
 **Step 4 — Re-run only the failed records:**
 
-After fixing the underlying issue (connector credentials, bad input data, rate limits):
+After the diagnosis and fixing the underlying issue (connector credentials, bad input data, rate limits):
 
 ```bash
 # Extract record IDs from the failed run download, then:

--- a/cargo-analytics/references/examples/run-analytics.md
+++ b/cargo-analytics/references/examples/run-analytics.md
@@ -154,6 +154,8 @@ cargo-ai orchestration run get-metrics \
 # → High error rate on a specific node = that step is failing
 ```
 
+This flow ends at **detection** — you now know how many runs fail and which node is the hotspot. To explain *why* (group failures by root cause, trace exemplar runs through `runContext`), continue with the `cargo-diagnostics` skill: `../../../cargo-diagnostics/references/batch-error-sweep.md`, then `run-trace.md` on the exemplars it hands back.
+
 ## List runs with filters
 
 ```bash

--- a/cargo-diagnostics/SKILL.md
+++ b/cargo-diagnostics/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cargo-diagnostics
 description: Diagnose and explain Cargo workflow behavior after the fact — trace why a single run produced the wrong output, sweep a batch or play for errors and group them by root cause, and profile where a play's credits go and how to cut the cost. Use when a run failed or "succeeded but looks wrong", a batch has errors, records are missing downstream values, or a play costs more than expected.
-version: "1.0.0"
+version: "1.0.1"
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 homepage: https://github.com/getcargohq/cargo-skills
 metadata:
@@ -41,6 +41,8 @@ What are you diagnosing?
 ```
 
 Rule of thumb: start with the **sweep** when you don't yet know which run to look at — it ends by handing you exemplar run UUIDs to feed into the **trace**.
+
+**Boundary with `cargo-analytics`:** analytics *measures and exports* ("what's the error rate?", "download the batch results", "export this segment"); this skill *explains* ("why is the error rate up?", "why is this record's output empty?"). A diagnosis often starts from an analytics signal (error count spiked, batch reports `failedRunsCount > 0`) and ends back in analytics — once the cause is fixed and runs re-executed, bulk retrieval goes through `run download-outputs` / `batch download` / `segment download`, all documented in `../cargo-analytics/SKILL.md`. This skill's evidence surfaces (`run get`, orchestration SQL, billing metrics) are for diagnosis, not bulk export.
 
 ## References
 

--- a/cargo/SKILL.md
+++ b/cargo/SKILL.md
@@ -348,6 +348,7 @@ The CLI exposes several domains that no capability skill wraps yet. Reach for th
 - `segment download` requires `--model-uuid`, not `--segment-uuid`.
 - For batch result download, get the `output-node-slug` from `release get <release-uuid>` → `nodes[].slug`.
 - For billing and credit usage, use `cargo-billing` instead.
+- Analytics answers "what happened" (metrics, counts, exports). When the question is **why** — a failing run, a batch full of errors, surprising cost — hand off to `cargo-diagnostics`; its sweep runbook picks up exactly where analytics' error counts leave off.
 
 **References:** `../cargo-analytics/SKILL.md`
 
@@ -377,6 +378,7 @@ The CLI exposes several domains that no capability skill wraps yet. Reach for th
 - `runContext` is the source of truth for what a node produced; an execution's `title` is a truncated summary — never evidence.
 - Credit attribution (`billing …`) needs an **admin** token; the SQL and `run get` steps don't.
 - Any fix that re-runs paid nodes goes through the pilot gate in `../cargo-gtm/references/cost-discipline.md`.
+- Diagnostics explains; it doesn't export. For bulk retrieval after the diagnosis (`run download-outputs`, `batch download`, `segment download`) go back to `cargo-analytics`.
 - Present conclusions first, evidence as compact tables — per `references/interaction.md` (in the `cargo` router skill).
 
 **References:** `../cargo-diagnostics/SKILL.md`


### PR DESCRIPTION
## Why

`cargo-analytics` and `cargo-diagnostics` overlapped on error handling with no routing between them: analytics' "Handling partial batch failures" section was a mini error-sweep ("download failed runs to inspect root causes"), duplicating what the diagnostics batch-error-sweep runbook now does properly. Meanwhile the README's capability table predated diagnostics entirely — it listed 11 skills while the intro promised twelve.

The line drawn: **analytics measures and exports ("what happened"); diagnostics explains ("why")**. A diagnosis typically starts from an analytics signal (error count spiked) and ends back in analytics for bulk retrieval once the cause is fixed.

## Changes

**`cargo-analytics`** (1.4.1 → 1.4.2)
- New **"Scope — measure and export, not explain"** section: a routing table mapping question shapes ("what's the error rate?" vs "why did this run fail?") to the right skill and runbook, plus the detect → explain → retrieve chain.
- "Handling partial batch failures" trimmed to mechanics; root-causing now hands off explicitly to `cargo-diagnostics/references/batch-error-sweep.md`.
- Frontmatter description routes "why did it fail" questions to diagnostics (same pattern as the existing billing hand-off).
- The error-monitoring example in `run-analytics.md` notes it ends at *detection* and points at the sweep-then-trace sequence.

**`cargo-diagnostics`** (1.0.0 → 1.0.1)
- Mirror **"Boundary with cargo-analytics"** note under the runbook flowchart: analytics detects and exports; this skill explains; bulk retrieval after the fix goes back through `run download-outputs` / `batch download` / `segment download`.

**`cargo` router**
- One reciprocal critical-rule line in each recap (analytics → "when the question is why, hand off"; diagnostics → "explains, doesn't export").

**`README.md`**
- Capability section renamed "Capabilities — CLI surface" → **"Capabilities"** (diagnostics documents no commands of its own, so the old heading over-claimed), with an intro naming the two cross-cutting entries.
- Missing **Diagnostics** row added *(cross-domain)*, and CDK + Diagnostics moved to the bottom so the table reads as ten plain CLI domains + two marked cross-cutting entries — now consistent with the intro's "twelve capability skills".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only skill and README updates; no runtime, CLI, or security behavior changes.
> 
> **Overview**
> **Draws a clear line:** `cargo-analytics` measures and exports (“what happened”); `cargo-diagnostics` explains (“why”). Docs now route agents through **detect → explain → retrieve** instead of duplicating error-sweep guidance in analytics.
> 
> **`cargo-analytics` (1.4.2)** adds a **Scope** section with a question-shape routing table, updates frontmatter to send “why” failures to diagnostics, trims **Handling partial batch failures** so step 3 explicitly loads `batch-error-sweep.md`, and notes in `run-analytics.md` that error monitoring stops at detection.
> 
> **`cargo-diagnostics` (1.0.1)** adds a reciprocal **Boundary with cargo-analytics** note (bulk export after a fix stays in analytics).
> 
> **`cargo` router** adds one critical-rule line in each skill recap for the handoff in both directions.
> 
> **`README.md`** renames the capabilities section, introduces CDK and Diagnostics as cross-cutting entries, adds the missing **Diagnostics** table row, and reorders so ten CLI domains sit above CDK and Diagnostics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3cdbf6fe2ea2048651b994eeee95744ab835222. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->