### PR TITLE
feat(gtm): provider playbooks 6 → 20 + read-first gate

### DIFF
--- a/.github/scripts/skills-lint.mjs
+++ b/.github/scripts/skills-lint.mjs
@@ -354,6 +354,22 @@ function main() {
       }
     }
   }
+  // Same drift guard for provider playbooks: the router's read-first gate only
+  // works if every playbook on disk is discoverable from the SKILL.md catalog.
+  const playbooksDir = join(repoRoot, "cargo-gtm", "provider-playbooks");
+  if (existsSync(playbooksDir)) {
+    const gtmSkillPath = join(repoRoot, "cargo-gtm", "SKILL.md");
+    const gtmSkill = existsSync(gtmSkillPath) ? readFileSync(gtmSkillPath, "utf8") : "";
+    for (const f of readdirSync(playbooksDir).filter((n) => n.endsWith(".md"))) {
+      if (!gtmSkill.includes(`provider-playbooks/${f}`)) {
+        err(
+          gtmSkillPath,
+          0,
+          `Playbook \`provider-playbooks/${f}\` exists on disk but is not referenced in cargo-gtm/SKILL.md — add it to the playbook catalog.`
+        );
+      }
+    }
+  }
 
   // 4. The CLI pin: cargo/cli-version is the source of truth the SessionStart
   //    hook and install.sh consume. It must exist and be a bare semver line.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ## [Unreleased]
 
+### `cargo-gtm` → 1.3.0
+
+- **Provider playbooks: 6 → 20.** Fourteen new per-provider deep dives grounded in `connection integration get` output: sourcing/company-data (`linkedin`, `proxycurl`, `apolloio`, `oceanio`, `datagma`), email/contact specialists (`hunter`, `prospeo`, `icypeas`, `findyMail`, `leadMagic`, `contactOut`, `zeroBounce`), research/scraping (`firecrawl`, `serper`). Each carries the action table with credit costs, real config-shape examples, input quirks, cost traps, and its place in the recipe spine.
+- **Read-first gate.** Router §11 now opens with a hard stop: no paid action against a covered provider until its playbook is open — one playbook read is cheaper than one failed paid call. Linter gains the matching drift guard: every playbook on disk must be catalogued in `cargo-gtm/SKILL.md`.
+- **Fixed:** `recipes/linkedin-url-lookup.md` documented `findProfileUrl` inputs as `firstName`/`lastName`/`companyName`/`companyDomain` — the live schema takes `fullName` (required) + `companyName` only. Caught while grounding the playbooks in `connection integration get`; known-stale rows in `credits-cost-table.md`/`stage-action-map.md` (`prospeo.verifyEmail` no longer exists; `serper.*` now 0.05, not 1) are flagged for the next table regeneration.
+
 ### `cargo-gtm` → 1.2.0
 
 - **Executable QA layer.** New [`cargo-gtm/scripts/`](cargo-gtm/scripts/) — four deterministic, fixture-tested TypeScript scripts (Node ≥ 22.18 native type-stripping, zero deps in file mode) that replace in-context row checking: `validate-emails.ts` (free syntax/risk/duplicate cull before paid `verifyEmail`), `select-current-role.ts` (current role from an experiences array; catches job changers), `validate-linkedin-names.ts` (name↔profile match; catches same-name decoys), and `contact-accuracy-audit.ts` (final per-row `SEND/VERIFY/REVIEW/REMOVE` stamp). Each supports `--input` files or **API mode** (`--workflow-uuid`, fetching outputs via `@cargo-ai/api` with the CLI's stored login) and a `--fixtures` self-test. Doctrine in [`references/contact-accuracy.md`](cargo-gtm/references/contact-accuracy.md): *run the script, don't re-derive its logic in-context*. Wired into the router (new §8, spine step 8) and the `prospecting` / `outreach-activation` recipes' verify steps.

--- a/cargo-gtm/SKILL.md
+++ b/cargo-gtm/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cargo-gtm
 description: "Front door for any GTM task on Cargo — sourcing, waterfall enrichment, email/phone/LinkedIn lookup, email verification, scoring, qualification, sequencing, CRM sync, and signal monitoring (job changes, funding, tech-stack/hiring intent). Use when the user states a real-world goal involving prospects, leads, accounts, contacts, ICP lists, or campaign activation. Routes to phase guides (Level 2), recipes (Level 2.5), and per-provider playbooks (Level 3) before any action call."
-version: "1.2.0"
+version: "1.3.0"
 compatibility: Requires @cargo-ai/cli (npm) and a Cargo account (browser sign-in via --oauth, or an API token)
 homepage: https://github.com/getcargohq/cargo-skills
 metadata:
@@ -170,17 +170,37 @@ Every action JSON in this skill follows the rules in [`../cargo-orchestration/re
 
 If a recipe fails repeatedly and the cause isn't obvious, escalate via `cargo-ai workspaceManagement report create`. See [`../cargo-workspace-management/SKILL.md`](../cargo-workspace-management/SKILL.md) (Reports section).
 
-## 11) Provider playbooks
+## 11) Provider playbooks — read before you call
 
-Per-provider deep dives for the priority stack. Long-tail providers don't have dedicated playbooks yet — fall back to [`references/alternatives.md`](references/alternatives.md) and [`references/stage-action-map.md`](references/stage-action-map.md).
+**STOP — do not execute any paid action against a provider below until you have opened its playbook.** Each playbook carries the exact action slugs, config shapes, input quirks, and cost traps; reading it for five seconds is cheaper than one failed paid call, and a failed batch is 100 failed paid calls. Providers with no playbook: fall back to [`references/alternatives.md`](references/alternatives.md) and [`references/stage-action-map.md`](references/stage-action-map.md).
 
-**Priority stack:**
+**Priority stack (recipes lead with these):**
 - [`provider-playbooks/salesNavigator.md`](provider-playbooks/salesNavigator.md) — cheapest sourcing in the catalog (0.02–0.05/record).
 - [`provider-playbooks/cargo.md`](provider-playbooks/cargo.md) — 22 native enrichment + signal actions; the `match*` actions are key for dedup.
 - [`provider-playbooks/waterfall.md`](provider-playbooks/waterfall.md) — swiss-army-knife: enrichment, verification, and the cargo-unique `detectJobChange` signal.
 - [`provider-playbooks/FullEnrich.md`](provider-playbooks/FullEnrich.md) — premium contact lookup; `reverseEmailLookup` is unique.
 - [`provider-playbooks/theirStack.md`](provider-playbooks/theirStack.md) — tech-stack + hiring-intent signals.
 - [`provider-playbooks/peopleDataLabs.md`](provider-playbooks/peopleDataLabs.md) — heavyweight backfill at flat 3-credit tier.
+
+**Sourcing & company-data specialists:**
+- [`provider-playbooks/linkedin.md`](provider-playbooks/linkedin.md) — the native LinkedIn integration's action set (profiles, companies, posts, jobs).
+- [`provider-playbooks/proxycurl.md`](provider-playbooks/proxycurl.md) — LinkedIn-data lookups by URL when the native integration misses.
+- [`provider-playbooks/apolloio.md`](provider-playbooks/apolloio.md) — person/organization enrichment alternative; investor-niche coverage.
+- [`provider-playbooks/oceanio.md`](provider-playbooks/oceanio.md) — lookalike-company discovery from seed domains.
+- [`provider-playbooks/datagma.md`](provider-playbooks/datagma.md) — lightweight person/company enrichment alternative.
+
+**Email & contact specialists** (all feed the VERIFY step — see [`references/waterfall-strategy.md`](references/waterfall-strategy.md)):
+- [`provider-playbooks/hunter.md`](provider-playbooks/hunter.md) — domain-search email finding + verification.
+- [`provider-playbooks/prospeo.md`](provider-playbooks/prospeo.md) — email/phone lookup, LinkedIn-URL input path.
+- [`provider-playbooks/icypeas.md`](provider-playbooks/icypeas.md) — budget email find/verify.
+- [`provider-playbooks/findyMail.md`](provider-playbooks/findyMail.md) — email finding alternative.
+- [`provider-playbooks/leadMagic.md`](provider-playbooks/leadMagic.md) — email + mobile lookup alternative.
+- [`provider-playbooks/contactOut.md`](provider-playbooks/contactOut.md) — contact info from LinkedIn profiles.
+- [`provider-playbooks/zeroBounce.md`](provider-playbooks/zeroBounce.md) — email-verification second opinion to `waterfall.verifyEmail`.
+
+**Research & scraping:**
+- [`provider-playbooks/firecrawl.md`](provider-playbooks/firecrawl.md) — web scraping for research/personalization stages.
+- [`provider-playbooks/serper.md`](provider-playbooks/serper.md) — Google SERP queries for research and URL discovery.
 
 ## 12) References
 

--- a/cargo-gtm/provider-playbooks/apolloio.md
+++ b/cargo-gtm/provider-playbooks/apolloio.md
@@ -1,0 +1,87 @@
+---
+provider: apolloio
+category: enrichment
+last-reviewed: 2026-07-09
+---
+
+# apolloio (Apollo.io)
+
+Apollo-anchored person and organization enrichment. Only **two of its eleven actions are credits-based** — `enrichPerson` (1, or 3 with phone reveal) and `enrichOrganization` (1); everything else (searches, contact CRUD, sequences) runs **only on your own Apollo API key** connector. Use the credits pair as an ENRICH alternative when Apollo's coverage is stronger for the niche ([`../references/alternatives.md`](../references/alternatives.md)) — e.g. its investor coverage in [`../recipes/portfolio-prospecting.md`](../recipes/portfolio-prospecting.md). Don't route generic enrichment here first: the priority stack (`cargo` native → `waterfall`) leads.
+
+## Credits-based actions
+
+| Action | Cost | Inputs | Use for |
+|---|---|---|---|
+| `enrichPerson` | 1 (**3** if `revealPhoneNumber: true`) | `parameters` object (`first_name, last_name, organization_name, email, domain, linkedin_url, id, email_md5, email_sha256`), `revealPersonalEmails`, `revealPhoneNumber` | Person enrichment when Apollo coverage beats the stack for the niche. |
+| `enrichOrganization` | 1 | `domain` (required) | Company enrichment when cargo's match misses and LinkedIn doesn't have it. |
+
+## Own-API-key actions (no credits — require your Apollo account connector)
+
+| Action | What it does |
+|---|---|
+| `searchPeople` | Search Apollo's people database (`filters` required: `person_titles, person_seniorities, person_locations, organization_locations, organization_num_employees_ranges, q_organization_domains_list, q_keywords, contact_email_status, prospected_by_current_team`; `shouldEnrich`, `limit` — default 10, max 100). |
+| `searchOrganizations` | Search organizations (`filters` required: `q_organization_name, q_organization_keyword_tags, organization_locations, organization_not_locations, organization_num_employees_ranges, prospected_by_current_team`; `limit`). |
+| `searchContacts` | Search contacts saved in your Apollo account (`filters` required). |
+| `createContact` / `updateContact` / `upsertContact` | Contact CRUD in your Apollo account (`email` required for create/upsert, `id` for update; field `mappings` + `customMappings`). |
+| `addContactToSequence` | Add a contact to a sequence (`sequenceId`, `contactId`, `sendEmailFromEmailAccountId` required). |
+| `removeContactFromSequence` | Remove a contact from a sequence (`sequenceId`, `contactId`, `mode` required). |
+| `searchEmailAccounts` | List email accounts (needed to get `sendEmailFromEmailAccountId` for sequencing). |
+
+These consume your Apollo plan's quota, not cargo credits — recipes stay on credits-based actions, so treat this block as an **activation surface for users who already run Apollo sequences** (sequencer handoff in [`../recipes/outreach-activation.md`](../recipes/outreach-activation.md)).
+
+## What it's for
+
+- ✅ **Niche-coverage person enrichment** — 1 credit when a pilot shows Apollo hits where `cargo.enrichProspectDetails` (2) / `waterfall.enrichContact` (2) miss.
+- ✅ **Domain → company fallback** — `enrichOrganization` (1) after cargo's match misses and `linkedin.enrichCompanyFromDomain` (0.5) comes back empty.
+- ✅ **Sequencer handoff** — send verified leads into Apollo sequences via the own-key actions when the user's outbound already lives there.
+- ❌ **Sourcing on credits** — `searchPeople` / `searchOrganizations` are own-key only; credits-based sourcing is `salesNavigator` (0.02–0.05).
+
+## Patterns
+
+### Pattern A — Person enrichment (fallback rung)
+
+```bash
+# Only on rows the priority stack missed
+cargo-ai orchestration action execute-batch \
+  --action '{"kind":"connector","integrationSlug":"apolloio","actionSlug":"enrichPerson","config":{}}' \
+  --records '[
+    {"parameters":{"first_name":"Alice","last_name":"Smith","organization_name":"Acme"}},
+    {"parameters":{"linkedin_url":"https://linkedin.com/in/bobjones","domain":"globex.com"}}
+  ]' \
+  --wait-until-finished
+```
+
+Identifiers nest under `parameters` and are **snake_case**. Any combination works — LinkedIn URL + domain gives the best match rate. Hashed-email inputs (`email_md5`, `email_sha256`) are accepted when you only hold a hash.
+
+### Pattern B — Domain → organization
+
+```bash
+cargo-ai orchestration action execute-batch \
+  --action '{"kind":"connector","integrationSlug":"apolloio","actionSlug":"enrichOrganization","config":{}}' \
+  --records '[{"domain":"acme.com"},{"domain":"globex.com"}]' \
+  --wait-until-finished
+```
+
+`domain` is the only accepted input — no name- or LinkedIn-based lookup on this action.
+
+## Common pitfalls
+
+- **`revealPhoneNumber: true` triples the price** (1 → 3). Gate it like any phone action — and the phone chain starts cheaper at `prospeo.findPhone` (3, [`../references/stage-action-map.md`](../references/stage-action-map.md)), so reveal only when you're enriching the person anyway. `revealPersonalEmails` does **not** change the cost.
+- **Own-key actions fail without an Apollo connector.** The nine non-credits actions need a connector authenticated with your Apollo `apiKey` — they can't run on cargo's managed connection.
+- **Rate limit: 400 calls/hour** (spread) — the tightest in this group; large batches stretch over hours, so prefer the stack for volume enrichment.
+- **Sequencing needs three IDs** — `sequenceId`, `contactId` (create/upsert the contact first), and `sendEmailFromEmailAccountId` (from `searchEmailAccounts`).
+
+## Anti-patterns
+
+- **Top-level identifier fields on `enrichPerson`.** `first_name` etc. must sit inside `parameters` — top-level keys (except the two reveal flags) are ignored.
+- **Reveal flags at scale "to be safe".** Found personal emails and phones still flow through VERIFY (`waterfall.verifyEmail`, 0.1) — revealing on unqualified rows is pure spend.
+
+## Position in the waterfall
+
+- `enrichPerson` — **ENRICH (person), fallback rung** beside the stack's `cargo` → `waterfall` → `peopleDataLabs` chain; promote it for a batch only when the pilot shows better niche coverage.
+- `enrichOrganization` — **ENRICH (company), fallback rung** after `cargo.enrichBusinessFirmographics` (0.5) and `linkedin` (0.25–0.5).
+- Own-key sequence actions — post-VERIFY **activation**, outside the credits spine.
+
+## Action shape
+
+`{"kind":"connector","integrationSlug":"apolloio","actionSlug":"<slug>","config":{}}`. **No `connectorUuid` in `config`.**

--- a/cargo-gtm/provider-playbooks/contactOut.md
+++ b/cargo-gtm/provider-playbooks/contactOut.md
@@ -1,0 +1,97 @@
+---
+provider: contactOut
+category: contact
+last-reviewed: 2026-07-09
+---
+
+# contactOut (ContactOut)
+
+LinkedIn-URL-anchored contact info — emails and phones from a profile URL, plus a filter-based people/company search. **Mid-tier fallback**: reach for it when the priority stack (cargo native → FullEnrich → waterfall) misses, or for its free company-domain lookup.
+
+## Credits-based actions
+
+| Action | Cost | Inputs | Use for |
+|---|---|---|---|
+| `enrich` (company) | **0** | `objectType:"company"`, `companyDomain` | Free company profile from a domain (size, industry, revenue, funding, …). |
+| `enrich` (contact) | 1 / 2 / 3 | `objectType:"contact"`, `linkedinUrl`, `includePhone`, `emailType` | Contact from a LinkedIn URL. 1 = profile only; 2 = + emails (`emailType` set); 3 = `includePhone: true`. |
+| `search` | 1 or 3 **per item** | `objectType:"people"|"company"`, `filters`, `dataTypes`, `revealInfo` | People/company search. People: 1/item; `revealInfo: true` (emails + phones in response) = 3/item. |
+
+Cost is driven by the **config you request**, not the data returned: asking for phone (`includePhone: true`) prices the contact enrich at 3 even before you know a phone exists.
+
+## What it's for
+
+- ✅ **Emails/phone when you already hold the LinkedIn URL** — `enrich` is keyed on `linkedinUrl` only; no name/domain fallback inputs.
+- ✅ **Free company lookup** — `enrich` with `objectType: "company"` costs 0 credits and returns firmographics (`size`, `industry`, `revenue`, `employees`, `funding`, …).
+- ✅ **Phone at the prospeo price point** — contact enrich with `includePhone` is 3, the same as `prospeo.findPhone`, and returns emails in the same call.
+- ❌ **Primary people sourcing** — `search` at 1/item (3/item revealed) vs `salesNavigator.searchLeads` at 0.02. Mid-tier when other sources miss (see [`../references/stage-action-map.md`](../references/stage-action-map.md)).
+- ❌ **Enrichment without a LinkedIn URL** — resolve the URL first ([`../recipes/linkedin-url-lookup.md`](../recipes/linkedin-url-lookup.md)) or use `waterfall.enrichContact` (2), which accepts name/domain/email.
+
+## Patterns
+
+### Pattern A — Contact enrich from a LinkedIn URL
+
+```bash
+cargo-ai orchestration action execute \
+  --action '{"kind":"connector","integrationSlug":"contactOut","actionSlug":"enrich","config":{}}' \
+  --data '{
+    "objectType": "contact",
+    "linkedinUrl": "https://linkedin.com/in/alicesmith",
+    "includePhone": false,
+    "emailType": ["work"]
+  }' \
+  --wait-until-finished
+```
+
+`emailType` takes `"work"` and/or `"personal"`. Always pass `includePhone` and `emailType` explicitly — the contact branch of the schema requires them, and each one you add moves the price tier (base 1 → +emails 2 → +phone 3).
+
+### Pattern B — Free company profile
+
+```bash
+cargo-ai orchestration action execute \
+  --action '{"kind":"connector","integrationSlug":"contactOut","actionSlug":"enrich","config":{}}' \
+  --data '{"objectType":"company","companyDomain":"acme.com"}' \
+  --wait-until-finished
+```
+
+Zero credits. Worth a probe before paying `waterfall.enrichCompany` (1) on unmatched-by-cargo companies.
+
+### Pattern C — People search, reveal only the keepers
+
+```bash
+# Step 1 — search WITHOUT revealing (1/item): filter and shortlist first
+cargo-ai orchestration action execute \
+  --action '{"kind":"connector","integrationSlug":"contactOut","actionSlug":"search","config":{}}' \
+  --data '{
+    "objectType": "people",
+    "filters": [
+      {"name": "job_title", "values": ["VP Sales", "Head of Sales"]},
+      {"name": "location", "values": ["Germany"]},
+      {"name": "current_titles_only", "booleanValue": true}
+    ],
+    "dataTypes": ["work_email"]
+  }' \
+  --wait-until-finished
+# Step 2 — enrich only the shortlist via Pattern A (or re-search with revealInfo: true)
+```
+
+The `filters` array is discriminated by `name`: list-type filters (`skills`, `education`, `location`, `company`, `domain`, `job_title`) take `values`; catalog filters (`industry`, `company_size`, `years_of_experience`, `years_in_current_role`) take `autocompleteValues`; toggles (`current_titles_only`, `current_company_only`, `include_related_job_titles`) take `booleanValue`; `name` (person name) takes `value`. `dataTypes` (`personal_email` / `work_email` / `phone`) filters to profiles that *have* that data without revealing it.
+
+## Common pitfalls
+
+- **`revealInfo: true` on a broad search.** Search is billed **per item returned** — 3/item revealed. Search unrevealed (1/item), shortlist, then reveal or enrich only the keepers.
+- **Wrong value key for a filter.** Putting `values` where the filter wants `autocompleteValues` (or vice versa) fails validation — match the key to the filter name per the table above.
+- **`includePhone: true` "just in case."** It triples the enrich price and deducts phone credits whether or not you need the number. Default `false`; escalate only for phone-first plays.
+
+## Anti-patterns
+
+- **contactOut for bulk sourcing.** At 1–3/item, a 1,000-row search costs 1,000–3,000 credits; `salesNavigator.searchLeads` covers the same B2B ground at 0.02. Use contactOut search only when LinkedIn-anchored and priority sources miss.
+- **Skipping verification.** Returned emails still go through `waterfall.verifyEmail` (0.1) — or `zeroBounce.verifyEmail` (0.1) as a second opinion — before any send.
+
+## Position in the waterfall
+
+- Contact enrich — **mid rung** of the email/phone chain: after cargo native + FullEnrich, alongside `waterfall.enrichContact` (2); its `includePhone` tier (3) sits at the `prospeo.findPhone` price, below FullEnrich (6) and waterfall (7).
+- `search` — coverage fallback when salesNavigator/icypeas miss the segment.
+
+## Action shape
+
+`{"kind":"connector","integrationSlug":"contactOut","actionSlug":"<slug>","config":{}}`. **No `connectorUuid` in `config`.**

--- a/cargo-gtm/provider-playbooks/datagma.md
+++ b/cargo-gtm/provider-playbooks/datagma.md
@@ -1,0 +1,74 @@
+---
+provider: datagma
+category: enrichment
+last-reviewed: 2026-07-09
+---
+
+# datagma
+
+Contact-info finder: one mid-tier email action and two premium phone actions. `findEmail` (1) is an **alt mid-tier rung** of the find-email chain ([`../references/stage-action-map.md`](../references/stage-action-map.md)) — same price as the `FullEnrich` default, so it earns a slot only as an escalation with a different underlying source. `findPhone` / `findPhoneAndEmail` (8) are the **second-most-expensive phone tier in the catalog** — last resort before `cleon1` (15), never the first stop.
+
+## Credits-based actions
+
+| Action | Cost | Inputs | Use for |
+|---|---|---|---|
+| `findEmail` | 1 | `firstName, lastName, companyName` (all required) | Escalation rung on the find-email chain when cheaper sources miss. |
+| `findPhone` | 8 | `email`, `personLinkedInUrl` | Phone lookup from an email or LinkedIn URL. **Last-rung pricing.** |
+| `findPhoneAndEmail` | 8 | `firstName, lastName, companyName` (all required) | Phone + email in one call from name + company. |
+
+## What it's for
+
+- ✅ **Find-email escalation** — a different index than `FullEnrich` / `hunter`, so it can hit where the standard chain (FullEnrich 1 → hunter 0.5 → peopleDataLabs 3) misses. Slot it beside the other 1-credit alternates ([`../references/alternatives.md`](../references/alternatives.md), "Alt mid-tier").
+- ✅ **Phone from an identifier the cheaper rungs rejected** — `findPhone` takes `email` or `personLinkedInUrl`; useful for the handful of high-value leads left after `prospeo` → `FullEnrich` → `waterfall` all missed.
+- ❌ **First-stop anything** — every datagma action has a cheaper chain-leader: email starts at `FullEnrich.findEmail` (1, best hit rate) with `hunter` (0.5) behind it; phone starts at `prospeo.findPhone` (3).
+
+## Patterns
+
+### Pattern A — Escalation rung of the find-email chain
+
+```bash
+# Only on rows where the earlier rungs returned nothing
+cargo-ai orchestration action execute-batch \
+  --action '{"kind":"connector","integrationSlug":"datagma","actionSlug":"findEmail","config":{}}' \
+  --records '[
+    {"firstName":"Alice","lastName":"Smith","companyName":"Acme"},
+    {"firstName":"Bob","lastName":"Jones","companyName":"Globex"}
+  ]' \
+  --wait-until-finished
+```
+
+All three fields are required — no domain-only or full-name variants. Every hit still flows to VERIFY: free pre-cull, then `waterfall.verifyEmail` (0.1).
+
+### Pattern B — Last-rung phone lookup (gated)
+
+```bash
+# Qualified, high-value leads only — 8 credits each
+cargo-ai orchestration action execute-batch \
+  --action '{"kind":"connector","integrationSlug":"datagma","actionSlug":"findPhone","config":{}}' \
+  --records '[{"personLinkedInUrl":"https://linkedin.com/in/alicesmith","email":"alice@acme.com"}]' \
+  --wait-until-finished
+```
+
+Neither field is marked required in the schema — pass at least one identifier; both together give the best match odds.
+
+## Common pitfalls
+
+- **camelCase inputs** — `firstName`, `lastName`, `companyName`, `personLinkedInUrl` (note the capital `In`). Don't reuse the snake_case shapes from `waterfall` / `hunter` here.
+- **`findPhoneAndEmail` saves nothing.** 8 credits — more than `FullEnrich.findPhoneAndEmail` (7) and the same as `findPhone` alone, so the "free" email is only worth it if you'd otherwise pay both. If the email rung already ran, calling it re-bills work you've done.
+- **`companyName`, not domain** — `findEmail` / `findPhoneAndEmail` key on the company **name**; there is no domain input, so ambiguous names ("Apex") depress the hit rate.
+- **8 credits buys a lot elsewhere** — the whole cheaper phone chain (`prospeo` 3 + `FullEnrich` 6 escalation is 9 for two independent attempts) or 80 verifications. Gate per [`../references/cost-discipline.md`](../references/cost-discipline.md).
+
+## Anti-patterns
+
+- **Phone actions in a default pipeline.** Phone lookup is gated to qualified leads in every recipe; at 8/record an ungated batch is the fastest way to burn a budget.
+- **Skipping verification because the email "came with" the phone.** `findPhoneAndEmail` output is a finder result like any other — VERIFY stage (`waterfall.verifyEmail`, 0.1) still applies.
+
+## Position in the waterfall
+
+- `findEmail` — **CONTACT stage, escalation rung**: after `FullEnrich` (1) and the 0.5 mid-tiers (`hunter` / `prospeo` / `findyMail` / `leadMagic`), beside the other 1-credit alternates. Demote it for the batch if it misses on the pilot's first ~10 rows.
+- `findPhone` / `findPhoneAndEmail` — **CONTACT stage, last rung** of the phone chain: `prospeo` (3) → `FullEnrich` (6) → `waterfall` (7) → **datagma (8)** → `cleon1` (15, premium).
+- Every found email flows to **VERIFY** (`waterfall.verifyEmail`, 0.1) before activation.
+
+## Action shape
+
+`{"kind":"connector","integrationSlug":"datagma","actionSlug":"<slug>","config":{}}`. **No `connectorUuid` in `config`.**

--- a/cargo-gtm/provider-playbooks/findyMail.md
+++ b/cargo-gtm/provider-playbooks/findyMail.md
@@ -1,0 +1,74 @@
+---
+provider: findyMail
+category: contact (email)
+last-reviewed: 2026-07-09
+---
+
+# findyMail
+
+Mid-tier email finder with a phone lookup and a verify on the side. `findEmail` (0.5) is an alternative rung to `hunter.findEmail` in the find-email chain — sometimes finds what hunter misses ([`../references/alternatives.md`](../references/alternatives.md)) — and is the only 0.5-tier finder that also accepts a **LinkedIn URL** as input. Not the default: that's `FullEnrich.findEmail` (1) per [`../references/waterfall-strategy.md`](../references/waterfall-strategy.md). `findPhone` (5) sits mid-chain between prospeo (3) and FullEnrich (6).
+
+## Credits-based actions
+
+| Action | Cost | Inputs | Use for |
+|---|---|---|---|
+| `verifyEmail` | 0.25 | `email` | Bounce-risk check. Off-default — `waterfall.verifyEmail` (0.1) is cheaper. |
+| `findEmail` | 0.5 | `name, domain, linkedinUrl` | Mid-tier email finder; the 0.5-tier option that takes a LinkedIn URL. |
+| `findPhone` | 5 | `linkedinUrl` (required) | Mid-rung phone lookup between prospeo (3) and FullEnrich (6). |
+
+## What it's for
+
+- ✅ **Chain rung when hunter misses** — different underlying source at the same 0.5 price; swap it in for (or after) hunter on segments where hunter under-covers.
+- ✅ **Email from a LinkedIn URL at the cheap tier** — when the row has a profile URL but no clean name/domain pair, `findEmail` takes `linkedinUrl` directly.
+- ✅ **Rich hit payload** — output includes `job_title`, `company`, `linkedin_url`, and person/company geo fields alongside the email, useful for coalescing.
+
+## Patterns
+
+### Pattern A — Email finder rung
+
+```bash
+# Run on the rows the earlier rung missed
+cargo-ai orchestration action execute-batch \
+  --action '{"kind":"connector","integrationSlug":"findyMail","actionSlug":"findEmail","config":{}}' \
+  --records '[
+    {"name":"Alice Smith","domain":"acme.com"},
+    {"linkedinUrl":"https://linkedin.com/in/bobjones"}
+  ]' \
+  --wait-until-finished
+```
+
+`name` is a **single full-name string** — not `firstName`/`lastName`. Pass `name` + `domain`, or `linkedinUrl`, per row.
+
+### Pattern B — Mid-rung phone lookup
+
+```bash
+# Only on qualified leads that prospeo.findPhone missed
+cargo-ai orchestration action execute-batch \
+  --action '{"kind":"connector","integrationSlug":"findyMail","actionSlug":"findPhone","config":{}}' \
+  --records '[{"linkedinUrl":"https://linkedin.com/in/alicesmith"}]' \
+  --wait-until-finished
+```
+
+LinkedIn URL is the only accepted identifier. Output is `phone` + `line_type`.
+
+## Common pitfalls
+
+- **`findPhone` at 5 credits is a mid-rung, not a starting point.** The phone chain opens with `prospeo.findPhone` (3); phone lookups run on qualified leads only, after explicit user request ([`../references/cost-discipline.md`](../references/cost-discipline.md)).
+- **`verifyEmail` at 0.25 is 2.5× the default.** Use `waterfall.verifyEmail` (0.1) — or `icypeas.verifyEmail` (0.01) for very large lists — unless the user's own findyMail API key makes it free to them.
+- **A found email is not a safe email.** Free pre-cull with `validate-emails.ts` ([`../references/contact-accuracy.md`](../references/contact-accuracy.md)), then `waterfall.verifyEmail` (0.1) on every hit before it reaches a sequencer.
+
+## Anti-patterns
+
+- **`firstName`/`lastName` or `first_name`/`last_name` fields.** findyMail's finder takes `name` (one string), `domain`, `linkedinUrl` — nothing else. Wrong field names are silently ignored and the row misses.
+- **Running findyMail AND hunter on the same rows by default.** They're alternates at the same tier — waterfall on misses, don't double-spend on hits ([`../references/waterfall-strategy.md`](../references/waterfall-strategy.md)).
+- **Trusting the finder's hit as verified.** Verification is an independent step, always.
+
+## Position in the waterfall
+
+- `findEmail` — CONTACT-stage mid-tier rung, interchangeable with `hunter.findEmail` / `leadMagic.findEmail` (all 0.5); pick by segment coverage and demote whichever misses on the pilot's first ~10 rows.
+- `findPhone` — **rung 2** of the phone chain (prospeo → findyMail or FullEnrich → waterfall).
+- `verifyEmail` — VERIFY stage, but off-default on price; the spine verifies with `waterfall.verifyEmail` (0.1).
+
+## Action shape
+
+`{"kind":"connector","integrationSlug":"findyMail","actionSlug":"<slug>","config":{}}`. **No `connectorUuid` in `config`.** Note the capitalization: `findyMail` (camel-case with capital `M`).

--- a/cargo-gtm/provider-playbooks/firecrawl.md
+++ b/cargo-gtm/provider-playbooks/firecrawl.md
@@ -1,0 +1,88 @@
+---
+provider: firecrawl
+category: research (scraping)
+last-reviewed: 2026-07-09
+---
+
+# firecrawl (Firecrawl)
+
+Web scraping, crawling, and web search at **0.05 credits per item** — the default web-research provider for the personalization and niche-research stages. It fetches pages as clean markdown for downstream LLM extraction; it is **not** a bulk-enrichment provider.
+
+## Credits-based actions
+
+| Action | Cost | Inputs | Use for |
+|---|---|---|---|
+| `scrape` | 0.05 / item | `url` | Turn one URL into clean data (markdown, html, links, metadata). |
+| `search` | 0.05 / item | `query`, `limit` (1–100) | Web search when no structured provider has the data. |
+| `crawl` | 0.05 / **page** | `url`, `maxDepth`, `limit`, `includesPaths`, `excludesPaths`, `options` | Recursively gather a site's pages (docs, job boards, portfolio pages). |
+
+All three bill **per item returned**, not per call. In credits mode the connector is rate-limited (15/min, spread), so large crawls take time as well as credits.
+
+## What it's for
+
+- ✅ **Personalization research** — scrape a prospect's site/blog/case-study page, then extract angles with an LLM (`anthropic.instruct`) for the first-line step of [`../recipes/outreach-activation.md`](../recipes/outreach-activation.md).
+- ✅ **Niche signals no structured provider covers** — industry job boards ([`../recipes/tech-intent.md`](../recipes/tech-intent.md)), investor portfolio pages ([`../recipes/portfolio-prospecting.md`](../recipes/portfolio-prospecting.md)), "companies that mention X on their site".
+- ✅ **Cheap web search** — `search` at 0.05/result is the lowest-cost web-search rung in the sourcing map.
+- ❌ **Firmographics / tech stack at scale** — `cargo.enrichBusinessFirmographics` (0.5) and `cargo.enrichBusinessTechnographics` (1) return structured fields directly; scraping + LLM-extracting the same facts costs more end-to-end and parses worse.
+- ❌ **Jobs on major boards** — `theirStack.searchJobs` (0.5) already covers LinkedIn, Indeed, etc. Crawl only the niche boards theirStack misses.
+
+## Patterns
+
+### Pattern A — Scrape one page → LLM extract
+
+```bash
+cargo-ai orchestration action execute \
+  --action '{"kind":"connector","integrationSlug":"firecrawl","actionSlug":"scrape","config":{}}' \
+  --data '{"url":"https://acme.com/customers"}' \
+  --wait-until-finished
+```
+
+Feed the returned markdown to `anthropic.instruct` for structured extraction — the scrape is 0.05; the LLM call usually dominates the cost of this pair.
+
+### Pattern B — Web search fallback
+
+```bash
+cargo-ai orchestration action execute \
+  --action '{"kind":"connector","integrationSlug":"firecrawl","actionSlug":"search","config":{}}' \
+  --data '{"query":"\"built on Stripe Atlas\" fintech startup","limit":20}' \
+  --wait-until-finished
+```
+
+Billed per result: `limit: 20` ≈ 1 credit. Size `limit` to what you'll actually read.
+
+### Pattern C — Bounded crawl of a niche site
+
+```bash
+cargo-ai orchestration action execute \
+  --action '{"kind":"connector","integrationSlug":"firecrawl","actionSlug":"crawl","config":{}}' \
+  --data '{
+    "url": "https://jobs.nicheboard.io",
+    "maxDepth": 1,
+    "limit": 50,
+    "includesPaths": ["/jobs/*"]
+  }' \
+  --wait-until-finished
+```
+
+`maxDepth` semantics: `0` scrapes only the entered URL; `1` adds pages one level deep; `2` two levels; and so on. `options` accepts `ignoreSitemap`, `allowBackwardLinks`, `allowExternalLinks`.
+
+## Common pitfalls
+
+- **Unbounded crawls.** `crawl` bills 0.05 per page crawled — an uncapped crawl of a large site burns hundreds of credits. **Always set `limit`** and start with `maxDepth: 1`; widen only if the pilot shows you need more.
+- **Path-filter key spelling.** The action's input schema names the filters `includesPaths` / `excludesPaths` (note the plural "includes"), while the UI labels them include/exclude paths. If a filter appears ignored, check the spelling against the schema.
+- **`allowExternalLinks` on a crawl.** It lets the crawler leave the target domain — combined with a loose `limit` this is the fastest way to pay for pages you didn't want.
+
+## Anti-patterns
+
+- **Scraping what a structured provider sells cheaper.** Company facts, tech stack, keywords, and website changes all exist as cargo native actions (0.5–1) with typed outputs. Scrape only for data no structured provider has.
+- **Crawling per-record in a batch.** A crawl inside a 500-record workflow multiplies pages × records. Crawl once, store the result, and join it to records instead.
+
+## Position in the waterfall
+
+**Web-research default** (see [`../references/stage-action-map.md`](../references/stage-action-map.md), Web research): `firecrawl` first at 0.05/item, escalating to `linkup.search` (0.5) when you need structured answers, or `perplexity.instruct` (0.3) for cited synthesis. As a sourcing rung, `search` is the last-resort coverage fallback after salesNavigator / theirStack / serper.
+
+Firecrawl's `crawl` also exists as an **extractor** — usable to sync a website into a connector-backed knowledge library (see the `cargo-content` skill) rather than as a one-off action.
+
+## Action shape
+
+`{"kind":"connector","integrationSlug":"firecrawl","actionSlug":"<slug>","config":{}}`. **No `connectorUuid` in `config`.**

--- a/cargo-gtm/provider-playbooks/hunter.md
+++ b/cargo-gtm/provider-playbooks/hunter.md
@@ -1,0 +1,74 @@
+---
+provider: hunter
+category: contact (email)
+last-reviewed: 2026-07-09
+---
+
+# hunter
+
+Mid-tier email finder. Its `findEmail` (0.5) is **rung 2 of the find-email waterfall** — a different underlying source than `FullEnrich.findEmail` (1), so it often finds what FullEnrich misses. Prefer it as the escalation step on FullEnrich misses, or as the lead finder when budget is critical and a lower hit rate is acceptable ([`../references/alternatives.md`](../references/alternatives.md)). Avoid its `verifyEmail` — at 1 credit it is the most expensive verify tier in the catalog.
+
+## Credits-based actions
+
+| Action | Cost | Inputs | Use for |
+|---|---|---|---|
+| `findEmail` | 0.5 | `first_name, last_name, full_name, domain, company` | Rung-2 email finder in the spine ([`../references/waterfall-strategy.md`](../references/waterfall-strategy.md)). |
+| `enrichPerson` | 1 | `email` | Email → person info. Cheap mid-tier alternative to heavier person enrichers. |
+| `searchDomain` | 1 | `domain, type, seniorities, departments, requiredFields, limit` | List people at one domain, filtered by seniority/department. Max **10 records per call**. |
+| `verifyEmail` | 1 | `email` | **Avoid.** 10× `waterfall.verifyEmail` (0.1), 100× `icypeas.verifyEmail` (0.01). |
+
+## What it's for
+
+- ✅ **Escalation on FullEnrich misses** — the canonical find-email chain is FullEnrich (1) → hunter (0.5) → peopleDataLabs (3) → icypeas (0.1); hunter's independent index is the whole point of running it second.
+- ✅ **Budget-constrained lead finder** — half FullEnrich's price when the user accepts a lower hit rate.
+- ✅ **Small per-domain people lists** — `searchDomain` filters by seniority and department when you need a handful of contacts at one known company.
+
+## Patterns
+
+### Pattern A — Rung 2 of the find-email chain
+
+```bash
+# Run ONLY on the rows where FullEnrich.findEmail returned nothing
+cargo-ai orchestration action execute-batch \
+  --action '{"kind":"connector","integrationSlug":"hunter","actionSlug":"findEmail","config":{}}' \
+  --records '[
+    {"first_name":"Alice","last_name":"Smith","domain":"acme.com"},
+    {"full_name":"Bob Jones","company":"Globex"}
+  ]' \
+  --wait-until-finished
+```
+
+`domain` beats `company` for accuracy — pass the domain whenever you have it. Output includes `email`, a confidence `score`, an `accept_all` boolean (catch-all flag), `position`, `linkedin_url`, the public-web `sources` it was extracted from, and a `verification.status` block.
+
+### Pattern B — People at one domain
+
+```bash
+cargo-ai orchestration action execute-batch \
+  --action '{"kind":"connector","integrationSlug":"hunter","actionSlug":"searchDomain","config":{}}' \
+  --records '[{"domain":"acme.com","type":"personal","seniorities":["executive"],"departments":["sales","marketing"],"limit":10}]' \
+  --wait-until-finished
+```
+
+`domain` and `type` (`all`/`personal`/`generic`) are required. `limit` caps at 10 — this is a spot-check tool, not a sourcing engine; for volume sourcing use `salesNavigator.searchLeads` (0.02) or `icypeas.findPeople` (0.02).
+
+## Common pitfalls
+
+- **`accept_all: true` means catch-all.** The domain accepts any address, so a "found" email proves nothing. Ship it only if a second independent finder returned the exact same string; otherwise flag "unverified".
+- **The embedded `verification` block is the provider grading its own homework.** Run `waterfall.verifyEmail` (0.1) on every found email regardless — verification hard rules in [`../references/waterfall-strategy.md`](../references/waterfall-strategy.md).
+- **`searchDomain` returns at most 10 records** and costs 1 credit per call — don't loop it to build a list.
+
+## Anti-patterns
+
+- **camelCase field names.** hunter inputs are **snake_case**: `first_name`, `last_name`, `full_name`, `domain`, `company`. Do NOT reuse FullEnrich's `firstName`/`domainName` shape here.
+- **`hunter.verifyEmail` in any chain.** 1 credit buys 10 `waterfall.verifyEmail` calls or 100 `icypeas.verifyEmail` calls for the same job.
+- **Paid verify before the free cull.** Run the `validate-emails.ts` script from [`../references/contact-accuracy.md`](../references/contact-accuracy.md) first — dropping invalid/disposable/duplicate rows is free and shrinks the paid batch.
+
+## Position in the waterfall
+
+- `findEmail` — **rung 2** of the find-email chain (after FullEnrich, before peopleDataLabs). CONTACT stage of the prospecting spine.
+- Every hit still flows to the VERIFY stage: free pre-cull ([`../references/contact-accuracy.md`](../references/contact-accuracy.md)) → `waterfall.verifyEmail` (0.1).
+- Demote dynamically: if hunter misses on the pilot's first ~10 rows, drop it behind peopleDataLabs for the rest of that batch.
+
+## Action shape
+
+`{"kind":"connector","integrationSlug":"hunter","actionSlug":"<slug>","config":{}}`. **No `connectorUuid` in `config`.**

--- a/cargo-gtm/provider-playbooks/icypeas.md
+++ b/cargo-gtm/provider-playbooks/icypeas.md
@@ -1,0 +1,86 @@
+---
+provider: icypeas
+category: contact + verification
+last-reviewed: 2026-07-09
+---
+
+# icypeas
+
+The **cheap tier** of the contact stack, three ways: `verifyEmail` at **0.01** is the cheapest verification in the entire catalog (10× cheaper than the `waterfall.verifyEmail` default), `findEmail` at 0.1 is the cheap last resort of the find-email chain, and `findPeople`/`findCompanies` at 0.02/record are the cheapest non-LinkedIn sourcing alternative to `salesNavigator`. Prefer it for very large lists where unit cost dominates; avoid it as the lead email finder when hit rate matters — that's `FullEnrich.findEmail` ([`../references/alternatives.md`](../references/alternatives.md)).
+
+## Credits-based actions
+
+| Action | Cost | Inputs | Use for |
+|---|---|---|---|
+| `verifyEmail` | **0.01** | `email` | **Cheapest verify in the catalog.** Very large verify batches. |
+| `findEmail` | 0.1 | `firstName, lastName, domainOrCompany` (all required) | Cheap last-resort rung of the find-email chain. |
+| `scanDomain` | 0.1 | `domainOrCompany` | Discover **role-based** addresses on a domain (contact@, admin@, …). |
+| `findPeople` | 0.02/record | `currentJobTitle, currentCompanyName, location, keyword, limit` | Cheapest non-LinkedIn people sourcing. |
+| `findCompanies` | 0.02/record | `name, industry, location, keyword, headcountMin, headcountMax, limit` | Cheapest company sourcing. |
+
+`findPeople`/`findCompanies` are package-billed per 100 records and paginated (`paginationToken` in the response meta); `limit` defaults to 100, max 10,000.
+
+## What it's for
+
+- ✅ **Verification at scale** — 10,000 emails = 100 credits. Use over `waterfall.verifyEmail` (0.1) when the list is large enough for the 10× saving to matter.
+- ✅ **Last-resort email finding** — rung 4 of the chain (FullEnrich → hunter → peopleDataLabs → icypeas), per [`../references/waterfall-strategy.md`](../references/waterfall-strategy.md).
+- ✅ **Cheap sourcing when LinkedIn coverage is thin** — `findPeople` (0.02) matches `salesNavigator.searchLeads` pricing with a different database; useful for privacy-focused industries.
+- ✅ **Role-based address discovery** — `scanDomain` is the only action in the stack that enumerates generic mailboxes on a domain.
+
+## Patterns
+
+### Pattern A — Bulk verify
+
+```bash
+cargo-ai orchestration action execute-batch \
+  --action '{"kind":"connector","integrationSlug":"icypeas","actionSlug":"verifyEmail","config":{}}' \
+  --records '[{"email":"alice@acme.com"},{"email":"bob@globex.com"}]' \
+  --wait-until-finished
+```
+
+Run the free `validate-emails.ts` cull first ([`../references/contact-accuracy.md`](../references/contact-accuracy.md)) — even at 0.01/row, paying to verify syntactically invalid or disposable addresses is waste.
+
+### Pattern B — Last-resort email finder
+
+```bash
+# Only on rows that FullEnrich, hunter, AND peopleDataLabs all missed
+cargo-ai orchestration action execute-batch \
+  --action '{"kind":"connector","integrationSlug":"icypeas","actionSlug":"findEmail","config":{}}' \
+  --records '[{"firstName":"Alice","lastName":"Smith","domainOrCompany":"acme.com"}]' \
+  --wait-until-finished
+```
+
+All three fields are **required**; `domainOrCompany` accepts either a domain or a company name (domain is more reliable). The output nests results under `emails[]`, each with a `certainty` grade plus MX records/provider — take the top entry, don't assume a flat `email` field.
+
+### Pattern C — Cheap sourcing sweep
+
+```bash
+cargo-ai orchestration action execute \
+  --action '{"kind":"connector","integrationSlug":"icypeas","actionSlug":"findPeople","config":{}}' \
+  --data '{"currentJobTitle":"CTO","location":"FR","limit":200}' \
+  --wait-until-finished
+```
+
+Filters are coarse (title, company, location, keyword) — nothing like salesNavigator's facets. Use alpha-2 country codes (`US`, `FR`) for `location`.
+
+## Common pitfalls
+
+- **30 requests/minute rate limit** — the slowest connector in this group (hunter and leadMagic run at 300/min). Large `findEmail`/`verifyEmail` batches take time; the platform spreads and retries automatically, so don't cancel a slow batch.
+- **`emails[].certainty` is the provider grading its own homework.** A found email still goes through independent verification before use.
+- **`scanDomain` returns role accounts** — contact@/admin@ addresses are REVIEW-tier for outreach (see the audit verdicts in [`../references/contact-accuracy.md`](../references/contact-accuracy.md)), not sequencer-ready contacts.
+
+## Anti-patterns
+
+- **Leading the find-email chain with icypeas.** 0.1 credits buys the lowest hit rate in the chain — it's the mop-up rung, not the opener.
+- **snake_case field names.** icypeas inputs are **camelCase**: `firstName`, `lastName`, `domainOrCompany`.
+- **Skipping verification because the finder is cheap.** Every found email — icypeas included — flows to a verify step (`waterfall.verifyEmail` 0.1, or icypeas's own 0.01 for bulk).
+
+## Position in the waterfall
+
+- `findEmail` — **rung 4 (last)** of the find-email chain. Often skipped: if hit rate after rung 2–3 is > 90%, the remaining misses are mostly uncoverable rows.
+- `verifyEmail` — VERIFY-stage alternative to `waterfall.verifyEmail` for very large lists.
+- `findPeople` / `findCompanies` — SOURCE-stage alternative when LinkedIn-anchored search isn't viable.
+
+## Action shape
+
+`{"kind":"connector","integrationSlug":"icypeas","actionSlug":"<slug>","config":{}}`. **No `connectorUuid` in `config`.**

--- a/cargo-gtm/provider-playbooks/leadMagic.md
+++ b/cargo-gtm/provider-playbooks/leadMagic.md
@@ -1,0 +1,73 @@
+---
+provider: leadMagic
+category: contact (email + mobile)
+last-reviewed: 2026-07-09
+---
+
+# leadMagic
+
+Mid-tier email finder whose hits come **pre-annotated**: `findEmail` (0.5) returns a `status` field, full MX diagnostics (provider, security gateway, records), and bonus company firmographics in the same payload. An alternative rung to `hunter.findEmail` at the same price — the default finder remains `FullEnrich.findEmail` (1) per [`../references/waterfall-strategy.md`](../references/waterfall-strategy.md). Also carries `enrichProfile` (3): email → LinkedIn profile URL. No verify or phone actions — pair with `waterfall`/`prospeo` for those stages.
+
+## Credits-based actions
+
+| Action | Cost | Inputs | Use for |
+|---|---|---|---|
+| `findEmail` | 0.5 | `firstName, lastName` (required), `domain, companyName` | Mid-tier email finder; MX-annotated output. |
+| `enrichProfile` | 3 | `email` (required), `isPersonal` | Email → LinkedIn `profile_url`. |
+
+## What it's for
+
+- ✅ **Chain rung at the 0.5 tier** — interchangeable with `hunter.findEmail` / `findyMail.findEmail`; run it on the rows the earlier rung missed ([`../references/alternatives.md`](../references/alternatives.md)).
+- ✅ **MX-aware triage** — `mx_provider`, `mx_security_gateway`, and `has_mx` in the hit payload help flag risky domains before paid verification.
+- ✅ **Firmographics for free on hits** — company name, industry, size, founded, location, and LinkedIn URL ride along with each found email; useful when coalescing chain results.
+- ✅ **Email → LinkedIn URL** — `enrichProfile` de-anonymizes an email-only row when `FullEnrich.reverseEmailLookup` (2) missed; set `isPersonal: true` for personal addresses.
+
+## Patterns
+
+### Pattern A — Email finder rung
+
+```bash
+# Run on the rows the earlier rung missed
+cargo-ai orchestration action execute-batch \
+  --action '{"kind":"connector","integrationSlug":"leadMagic","actionSlug":"findEmail","config":{}}' \
+  --records '[
+    {"firstName":"Alice","lastName":"Smith","domain":"acme.com"},
+    {"firstName":"Bob","lastName":"Jones","companyName":"Globex"}
+  ]' \
+  --wait-until-finished
+```
+
+`firstName` and `lastName` are both **required** — full-name-only rows must be split first. Add `domain` (preferred) or `companyName`; domain-anchored lookups are more reliable.
+
+### Pattern B — Email → LinkedIn profile
+
+```bash
+cargo-ai orchestration action execute-batch \
+  --action '{"kind":"connector","integrationSlug":"leadMagic","actionSlug":"enrichProfile","config":{}}' \
+  --records '[{"email":"alice@acme.com"},{"email":"bob.jones@gmail.com","isPersonal":true}]' \
+  --wait-until-finished
+```
+
+Returns `profile_url`. Validate the URL with `linkedin.enrichProfile` before trusting it, per the strict-validation pattern in [`../recipes/linkedin-url-lookup.md`](../recipes/linkedin-url-lookup.md).
+
+## Common pitfalls
+
+- **`status` is the provider grading its own homework.** Whatever `findEmail.status` claims, the hit still goes through `waterfall.verifyEmail` (0.1) before any sequencer — verification hard rules in [`../references/waterfall-strategy.md`](../references/waterfall-strategy.md).
+- **`mx_security_gateway: true` is a deliverability warning**, not a reason to auto-drop — route those rows to REVIEW rather than silently discarding (verdict semantics in [`../references/contact-accuracy.md`](../references/contact-accuracy.md)).
+- **`enrichProfile` at 3 credits is pricier than `FullEnrich.reverseEmailLookup` (2)** for the same email → LinkedIn job. Use it as the fallback, not the opener.
+
+## Anti-patterns
+
+- **snake_case field names.** leadMagic inputs are **camelCase**: `firstName`, `lastName`, `domain`, `companyName`. (Its *outputs* are snake_case — don't mirror them back into inputs.)
+- **Name-only records.** Without at least `domain` or `companyName`, `firstName` + `lastName` alone match too many people — expect junk hits.
+- **Paid verify before the free cull.** Run `validate-emails.ts` ([`../references/contact-accuracy.md`](../references/contact-accuracy.md)) on the enriched list first; only survivors go to `waterfall.verifyEmail`.
+
+## Position in the waterfall
+
+- `findEmail` — CONTACT-stage mid-tier rung alongside `hunter`/`findyMail` (all 0.5), behind the `FullEnrich.findEmail` default. Demote whichever 0.5-tier finder misses on the pilot's first ~10 rows.
+- Every hit flows to the VERIFY stage: free pre-cull → `waterfall.verifyEmail` (0.1). leadMagic has **no verify action of its own**.
+- `enrichProfile` — LinkedIn-URL-resolution fallback after `FullEnrich.reverseEmailLookup`.
+
+## Action shape
+
+`{"kind":"connector","integrationSlug":"leadMagic","actionSlug":"<slug>","config":{}}`. **No `connectorUuid` in `config`.** Note the capitalization: `leadMagic` (camel-case with capital `M`).

--- a/cargo-gtm/provider-playbooks/linkedin.md
+++ b/cargo-gtm/provider-playbooks/linkedin.md
@@ -1,0 +1,125 @@
+---
+provider: linkedin
+category: sourcing + enrichment
+last-reviewed: 2026-07-09
+---
+
+# linkedin
+
+LinkedIn page-level enrichment, URL resolution, and activity signals. **Cheapest LinkedIn-anchored enrichment in the catalog** — `enrichProfile` / `enrichCompany` at 0.25, and `findProfileUrl` (0.25) is the **default for the LinkedIn-URL lookup stage** ([`../references/stage-action-map.md`](../references/stage-action-map.md)). Where `salesNavigator` searches at scale, `linkedin` resolves and deepens **one known page at a time** — plus post/job/activity extraction for signals and a set of identity-driven engagement actions.
+
+## Credits-based actions
+
+### Enrichment & resolution
+
+| Action | Cost | Inputs | Use for |
+|---|---|---|---|
+| `enrichProfile` | 0.25 | `linkedinUrl` | Profile URL → person details. Cheapest person enrich in the catalog; also the validation step after `findProfileUrl`. |
+| `findProfileUrl` | 0.25 | `fullName` (required), `companyName` | Name → LinkedIn profile URL. **Default LinkedIn resolver** — see [`../recipes/linkedin-url-lookup.md`](../recipes/linkedin-url-lookup.md). |
+| `enrichProfileFromName` | 0.5 | `name`, `companyName` (both required) | Name+company → profile details in one call. |
+| `enrichCompany` | 0.25 | `linkedinUrl` | Company page URL → firmographics. |
+| `enrichCompanyFromDomain` | 0.5 | `domain` | Domain → LinkedIn-anchored company details. |
+| `enrichJob` | 0.25 | `linkedinUrl` | Job posting URL → job details. |
+| `extractCompanyEmployeesInsights` | 0.25 | `linkedinUrl`, `affiliates` | Headcount by function, location, and seniority for a company page. |
+| `extractSimilarCompanies` | 0.25 | `linkedinUrl` | LinkedIn's "similar companies" recommendations — cheap lookalike seed. |
+| `findCustomHeadcount` | 0.5 | `companyLinkedinUrl`, `keywords`, `includeSubsidiaries` (all required) | Count employees matching a keyword (e.g. "how many SDRs?"). |
+
+### Posts, jobs & activity (signals)
+
+| Action | Cost | Inputs | Use for |
+|---|---|---|---|
+| `searchPosts` | 0.25 | `searchKeywords, sortBy, datePosted, contentType, fromMemberUrns, fromCompanyIds, mentioningMemberUrns, mentioningCompanyIds, authorIndustry, authorKeyword` | Find posts by keyword / author / mention. |
+| `searchPostComments` | 0.05/item | `urn`, `sortBy` (required) | Commenters on a post → engagement-based sourcing. |
+| `searchPostReactions` | 0.05/item | `urn`, `type` (required) | Reactors on a post. |
+| `extractProfilePostActivity` | 0.05/item | `linkedinProfileUrl` | Posts a person published — personalization fodder. |
+| `extractProfileCommentActivity` | 0.05/item | `linkedinProfileUrl` | Posts a person commented on. |
+| `extractProfileReactionActivity` | 0.05/item | `linkedinProfileUrl` | Posts a person reacted to. |
+| `searchJobs` | 0.5 | `keywords, geoCodes, datePosted, experienceLevels, companyIds, titleIds, jobTypes, onsiteRemote, functions, industryCodes, sortBy, easyApply, under10Applicants` | Job-posting search — hiring-intent alternative to `theirStack.searchJobs` (0.5). |
+| `extractEventAttendees` | 0.05/item | `linkedinEventUrl`, `identityIds` (required) | Attendees of a LinkedIn event → event-based sourcing. |
+| `extractProfileViewers` | 0.05/item | `identityIds`, `limit` (required) | Who viewed **your** connected identity's profile recently. |
+
+### Engagement (identity-driven — acts as a real LinkedIn user)
+
+| Action | Cost | Inputs | Use for |
+|---|---|---|---|
+| `visitProfile` | 0.25 | `linkedinProfileUrl`, `identityIds` | Visit a profile (shows up in their notifications). |
+| `followProfile` | 0.25 | `linkedinProfileUrl`, `unfollow`, `identityIds` | Follow / unfollow a profile. |
+| `connectProfile` | 0.25 | `linkedinProfileUrl`, `message`, `identityIds` | Send a connection request. |
+| `likePost` | 0.25 | `linkedinPostUrl`, `interactionType`, `identityIds` | React to a post. |
+| `commentPost` | 0.25 | `linkedinPostUrl`, `comment`, `identityIds` | Comment on a post. |
+| `commentPostComment` | 0.25 | `linkedinCommentUrl`, `comment`, `identityIds` | Reply to a comment. |
+
+`identityIds` ("Linkedin Users") are the workspace's connected LinkedIn identities — discover them via the `listIdentityIds` autocomplete on `connection integration get linkedin`.
+
+## What it's for
+
+- ✅ **LinkedIn URL resolution** — `findProfileUrl` (0.25) then `enrichProfile` (0.25) as the mandatory validation gate ([`../recipes/linkedin-url-lookup.md`](../recipes/linkedin-url-lookup.md)).
+- ✅ **Cheap page-level enrichment** — 0.25 vs `cargo.enrichProspectDetails` (2) when LinkedIn-anchored details are sufficient and you already have the URL ([`../references/alternatives.md`](../references/alternatives.md)).
+- ✅ **Engagement-based sourcing** — commenters/reactors on a competitor-topic post, event attendees: warm pools no search filter can express.
+- ✅ **Personalization signal** — a lead's recent post/comment/reaction activity feeds openers (SIGNAL stage before outreach).
+- ❌ **At-scale search** — no people/company search here; that's `salesNavigator.searchLeads` (0.02) / `searchAccounts` (0.05).
+
+## Patterns
+
+### Pattern A — Resolve + validate a LinkedIn URL
+
+```bash
+cargo-ai orchestration action execute-batch \
+  --action '{"kind":"connector","integrationSlug":"linkedin","actionSlug":"findProfileUrl","config":{}}' \
+  --records '[{"fullName":"Alice Smith","companyName":"Acme"},{"fullName":"Bob Jones","companyName":"Globex"}]' \
+  --wait-until-finished
+```
+
+Then run `enrichProfile` on each returned URL and cross-check name + company — the unvalidated hit rate is ~50%, validated ~70% ([`../recipes/linkedin-url-lookup.md`](../recipes/linkedin-url-lookup.md)). `fullName` is the only required field; always pass `companyName` when known — it improves matching.
+
+### Pattern B — Post engagement → warm source pool
+
+```bash
+# 1. Find the post(s)
+cargo-ai orchestration action execute \
+  --action '{"kind":"connector","integrationSlug":"linkedin","actionSlug":"searchPosts","config":{}}' \
+  --data '{"searchKeywords":"revenue operations benchmarks","sortBy":"Latest","datePosted":"Past week"}' \
+  --wait-until-finished
+# 2. Pull who engaged (billed per item — cap the pull)
+cargo-ai orchestration action execute \
+  --action '{"kind":"connector","integrationSlug":"linkedin","actionSlug":"searchPostReactions","config":{}}' \
+  --data '{"urn":"7181234567890123456","type":"ALL"}' \
+  --wait-until-finished
+```
+
+`searchPosts` enums: `sortBy` = `Top match`/`Latest`; `datePosted` = `Past 24 hours`/`Past week`/`Past month`/`past-year`/`past-2y`/`past-3y`/`anytime`; `fromCompanyIds`/`mentioningCompanyIds` only accept company **IDs**, `fromMemberUrns`/`mentioningMemberUrns` take member URNs.
+
+### Pattern C — Company deep-dive
+
+```bash
+cargo-ai orchestration action execute \
+  --action '{"kind":"connector","integrationSlug":"linkedin","actionSlug":"extractCompanyEmployeesInsights","config":{}}' \
+  --data '{"linkedinUrl":"https://linkedin.com/company/acme","affiliates":false}' \
+  --wait-until-finished
+```
+
+Chain with `extractSimilarCompanies` (0.25) for a cheap lookalike seed list, or `findCustomHeadcount` (0.5) for "how many people matching *keyword* work there".
+
+## Common pitfalls
+
+- **Profile URL shape is enforced.** `linkedinProfileUrl` must start with `linkedin.com/in/`, `/pub/`, `/sales/people/`, or `/sales/lead/`. Company URLs are `/company/...`, jobs `/jobs/view/...`, events `/events/...` — pass the wrong shape and the call fails.
+- **Per-item billing on activity pulls.** Comments, reactions, event attendees, profile activity, and viewers bill **0.05 per returned item** — a viral post can have thousands of reactions. Size first, then pull the approved scope ([`../references/cost-discipline.md`](../references/cost-discipline.md)).
+- **`searchJobs` filter IDs are LinkedIn enums.** `geoCodes`, `titleIds`, `industryCodes`, `experienceLevels`, `functions`, `jobTypes`, `onsiteRemote` come from the integration's autocompletes (`listTitles`, `listIndustries`, `listExperienceLevels`, …) — not free-text strings.
+- **Rate limit: 250 calls/minute** (spread) — relevant on large validation batches.
+
+## Anti-patterns
+
+- **`enrichProfileFromName` instead of the two-step.** Same 0.5 total as `findProfileUrl` + `enrichProfile`, but the two-step gives you the validation gate between resolution and enrichment — the recipe's mandatory pattern.
+- **Engagement actions as a bulk channel.** `connectProfile` / `commentPost` act **as a real member identity** — batch-blasting them burns the identity. Gate to qualified, personalized touches only.
+- **`extractProfileViewers` on a lead's URL.** It only works on your own connected identities (`identityIds` + `limit` required) — it is not a lead-enrichment action.
+
+## Position in the waterfall
+
+- `findProfileUrl` + `enrichProfile` — **default for the LinkedIn-URL lookup stage**; `FullEnrich.reverseEmailLookup` (2) only when all you have is an email.
+- `enrichProfile` / `enrichCompany` — **first rung of ENRICH** when the input is a LinkedIn URL; escalate to `cargo` native, then `waterfall`, then `peopleDataLabs` for non-LinkedIn fields.
+- Posts / jobs / activity extraction — **SIGNAL stage**: engagement pools and personalization inputs; `searchJobs` sits beside `theirStack.searchJobs` (both 0.5) for hiring intent.
+- Engagement actions — post-VERIFY activation touches, outside the sourcing spine.
+
+## Action shape
+
+`{"kind":"connector","integrationSlug":"linkedin","actionSlug":"<slug>","config":{}}`. **No `connectorUuid` in `config`.**

--- a/cargo-gtm/provider-playbooks/oceanio.md
+++ b/cargo-gtm/provider-playbooks/oceanio.md
@@ -1,0 +1,94 @@
+---
+provider: oceanio
+category: sourcing (lookalikes)
+last-reviewed: 2026-07-09
+---
+
+# oceanio (Ocean.io)
+
+Mid-tier company/people search and enrichment — four actions, all 1 credit. Its edge is **lookalike sourcing** (`searchCompanies` with `lookalikeDomains`: "companies like these three customers") plus technographic / web-traffic / e-commerce filters, and **cross-filtered search** (people filters and company filters combined in one call). Not in the priority stack: `salesNavigator` (0.02–0.05) stays the sourcing default; come here when the filter is lookalike- or technographic-shaped, before escalating to `peopleDataLabs` (3). See [`../references/stage-action-map.md`](../references/stage-action-map.md) (mid-tier rows).
+
+## Credits-based actions
+
+| Action | Cost | Inputs | Use for |
+|---|---|---|---|
+| `searchCompanies` | 1 **per returned record** | `companiesFilters`, `peopleFilters`, `limit` | Company search: lookalikes, technographics, web traffic, revenue, e-commerce flags. |
+| `searchPeople` | 1 | `peopleFilters`, `companiesFilters`, `limit` | People search cross-filtered by their company's attributes. |
+| `enrichCompany` | 1 | `company` object (`domain, name, linkedin, email, phone, countryCode, city, address, …` + socials) | Company enrichment from weak identifiers. |
+| `enrichPerson` | 1 | `person` object (`email, linkedin, firstName, lastName, jobTitle, phone, …`) + `company` object | Person enrichment; company context improves matching. |
+
+## What it's for
+
+- ✅ **Lookalike TAM** — `companiesFilters.lookalikeDomains` seeds a search from best-customer domains; no priority-stack action does this.
+- ✅ **Technographic + traffic filters** — `technologies`, `webTrafficVisitsFrom/To`, `ecommerce`, `mobileAppsFrom/To`, `revenues`, `companySizes` in one filter object (vs `theirStack` for job-posting-derived tech intent).
+- ✅ **"People at companies like X"** — `searchPeople` accepts both filter objects: `peopleFilters` (`jobTitles`, `seniorities`, `departments`, `emailStatuses`, `keywords`, `countries`, …) AND `companiesFilters` in the same call.
+- ✅ **Dedupe-aware sourcing** — `includeDomains` / `excludeDomains` (companies) and `includeIds` / `excludeIds`, `excludeJobTitles` (people) keep already-owned records out of the paid pull.
+- ❌ **Plain industry/size/geo sourcing** — `salesNavigator.searchAccounts` (0.05) is 20× cheaper.
+- ❌ **First-stop enrichment** — the ENRICH chain leads with `cargo` native and `linkedin` (0.25); oceanio is a same-price peer of `waterfall.enrichCompany` (1), so pick by pilot coverage.
+
+## Patterns
+
+### Pattern A — Lookalike company sourcing
+
+```bash
+cargo-ai orchestration action execute \
+  --action '{"kind":"connector","integrationSlug":"oceanio","actionSlug":"searchCompanies","config":{}}' \
+  --data '{
+    "companiesFilters": {
+      "lookalikeDomains": ["acme.com", "globex.com", "initech.com"],
+      "countries": ["US"],
+      "companySizes": ["11-50", "51-200"],
+      "excludeDomains": ["bigco.com"]
+    },
+    "limit": 100
+  }' \
+  --wait-until-finished
+```
+
+Billed per returned record — set `limit` to the approved scope ([`../references/cost-discipline.md`](../references/cost-discipline.md)).
+
+### Pattern B — People at companies matching a technographic filter
+
+```bash
+cargo-ai orchestration action execute \
+  --action '{"kind":"connector","integrationSlug":"oceanio","actionSlug":"searchPeople","config":{}}' \
+  --data '{
+    "peopleFilters": {"jobTitles": ["VP Marketing", "CMO"], "seniorities": ["vp", "c_suite"]},
+    "companiesFilters": {"technologies": ["shopify"], "countries": ["US"]},
+    "limit": 50
+  }' \
+  --wait-until-finished
+```
+
+Enum values in both examples (`companySizes`, `seniorities`, `technologies`, …) are **illustrative** — fetch the real accepted values from the `listObjectFieldValues` autocomplete before building the filter (see pitfalls).
+
+### Pattern C — Enrichment from weak identifiers
+
+```bash
+cargo-ai orchestration action execute-batch \
+  --action '{"kind":"connector","integrationSlug":"oceanio","actionSlug":"enrichPerson","config":{}}' \
+  --records '[
+    {"person":{"firstName":"Alice","lastName":"Smith","jobTitle":"CTO"},"company":{"domain":"acme.com"}},
+    {"person":{"linkedin":"https://linkedin.com/in/bobjones"}}
+  ]' \
+  --wait-until-finished
+```
+
+`enrichCompany` mirrors this: identifiers nest under a `company` object (plus an optional `people` array for known contacts) — accepts `domain`, `name`, `linkedin`, socials, a registration number, or a postal address, which makes it useful when domain-only enrichers miss.
+
+## Common pitfalls
+
+- **Inputs are nested objects.** Filters go inside `peopleFilters` / `companiesFilters`; enrich identifiers inside `person` / `company`. Flat top-level fields express nothing.
+- **Filter values are opaque enums.** `companySizes`, `revenues`, `seniorities`, `departments`, `emailStatuses`, `industries`, `technologies` take provider-defined string values — inspect them via the `listObjectFieldValues` autocomplete on `connection integration get oceanio` before building the filter; guessed strings silently mismatch.
+- **`searchCompanies` bills per item, `searchPeople` per call** — the dump prices `searchCompanies` per returned record (`limit` = budget cap) while `searchPeople` is a fixed 1/execution.
+- **Rate limit: 60 calls/minute** (spread) — the slowest in this group; batch accordingly.
+
+## Position in the waterfall
+
+- **SOURCE — mid-tier rung** (both searches at 1): after `salesNavigator` / `icypeas` (0.02–0.05), before `peopleDataLabs` / `waterfall.searchProspects` (3). Promote it when the filter is lookalike- or technographic-first.
+- **ENRICH — mid-tier rung** (both enriches at 1): peer of `waterfall.enrichCompany` (1) and `apolloio.enrichOrganization` (1); pilot 10 rows to pick by coverage.
+- Sourced people flow on to CONTACT (`FullEnrich.findEmail`, 1) and VERIFY (`waterfall.verifyEmail`, 0.1) as usual.
+
+## Action shape
+
+`{"kind":"connector","integrationSlug":"oceanio","actionSlug":"<slug>","config":{}}`. **No `connectorUuid` in `config`.**

--- a/cargo-gtm/provider-playbooks/prospeo.md
+++ b/cargo-gtm/provider-playbooks/prospeo.md
@@ -1,0 +1,77 @@
+---
+provider: prospeo
+category: contact (email + phone)
+last-reviewed: 2026-07-09
+---
+
+# prospeo
+
+Contact-lookup specialist whose standout is **the cheapest phone finder in the priority stack** — `findPhone` (3) is the default first stop of the phone chain, ahead of `FullEnrich.findPhone` (6) and `waterfall.findPhone` (7). Its `findEmail` (0.5) is a mid-tier alternative to the `FullEnrich.findEmail` (1) default; prefer it only when budget-constrained or as a waterfall rung ([`../references/alternatives.md`](../references/alternatives.md)). Also carries cheap LinkedIn-profile and company enrichment at 0.5.
+
+## Credits-based actions
+
+| Action | Cost | Inputs | Use for |
+|---|---|---|---|
+| `findEmail` | 0.5 | `firstName, lastName, fullName, companyDomain` (**`companyDomain` required**) | Mid-tier email finder. |
+| `enrichLinkedin` | 0.5 | `url` | Cheapest LinkedIn URL → person details in the enrich stage ([`../references/stage-action-map.md`](../references/stage-action-map.md)). |
+| `enrichCompany` | 0.5 | `companyName, companyWebsite, companyLinkedinUrl` | B2B firmographics; prefer website or LinkedIn URL over name. |
+| `findPhone` | 3 | `url` (LinkedIn URL, required) | **Default first stop of the phone chain.** |
+
+## What it's for
+
+- ✅ **Phone chain, rung 1** — prospeo (3) → FullEnrich (6) → waterfall (7); escalate only on misses ([`../references/waterfall-strategy.md`](../references/waterfall-strategy.md)).
+- ✅ **Budget email finding** — 0.5 vs FullEnrich's 1, when a lower hit rate is acceptable or as a chain rung.
+- ✅ **Cheap LinkedIn-URL enrichment** — `enrichLinkedin` when you already hold a validated profile URL and need title/role details.
+
+## Patterns
+
+### Pattern A — Phone lookup on qualified leads only
+
+```bash
+# Phone is the expensive lever — qualified rows only, never the full list
+cargo-ai orchestration action execute-batch \
+  --action '{"kind":"connector","integrationSlug":"prospeo","actionSlug":"findPhone","config":{}}' \
+  --records '[
+    {"url":"https://linkedin.com/in/alicesmith"},
+    {"url":"https://linkedin.com/in/bobjones"}
+  ]' \
+  --wait-until-finished
+```
+
+The only accepted identifier is a LinkedIn URL (`url`). No URL → no lookup; resolve one first via the [`../recipes/linkedin-url-lookup.md`](../recipes/linkedin-url-lookup.md) recipe.
+
+### Pattern B — Budget email finding
+
+```bash
+cargo-ai orchestration action execute-batch \
+  --action '{"kind":"connector","integrationSlug":"prospeo","actionSlug":"findEmail","config":{}}' \
+  --records '[
+    {"firstName":"Alice","lastName":"Smith","companyDomain":"acme.com"},
+    {"fullName":"Bob Jones","companyDomain":"globex.com"}
+  ]' \
+  --wait-until-finished
+```
+
+`companyDomain` is **required** — a domain, not a company name. Rows with only a company name need domain resolution first (e.g. `cargo.matchBusiness` or `prospeo.enrichCompany`).
+
+## Common pitfalls
+
+- **`findPhone` at 3 credits is still the ~10×-email lever.** Run it on qualified leads after explicit user request only ([`../references/cost-discipline.md`](../references/cost-discipline.md)); escalate misses to `FullEnrich.findPhone`, don't re-run.
+- **`findEmail` without `companyDomain` fails** — it's the one required field. Name-only or name+company-name records don't run.
+- **`enrichCompany` with name only is a weak match.** The schema's own guidance: prefer `companyWebsite` or `companyLinkedinUrl` when possible.
+
+## Anti-patterns
+
+- **snake_case field names.** prospeo inputs are **camelCase**: `firstName`, `lastName`, `fullName`, `companyDomain`. Do NOT reuse waterfall's `first_name`/`domain` shape here.
+- **Shipping a found email unverified.** No finder's output skips verification: free pre-cull with `validate-emails.ts` ([`../references/contact-accuracy.md`](../references/contact-accuracy.md)), then `waterfall.verifyEmail` (0.1) on the survivors.
+- **Using `findEmail` as the default over FullEnrich.** The spine default is `FullEnrich.findEmail` (better hit rate); prospeo is the budget alternative, not the starting point.
+
+## Position in the waterfall
+
+- `findPhone` — **rung 1** of the phone chain. CONTACT stage, gated to qualified leads.
+- `findEmail` — mid-tier CONTACT alternative alongside `hunter`/`findyMail`/`leadMagic` (all 0.5); every hit flows to the VERIFY stage (`waterfall.verifyEmail`, 0.1).
+- `enrichLinkedin` / `enrichCompany` — enrich-stage fillers when the identifier you hold matches their required input.
+
+## Action shape
+
+`{"kind":"connector","integrationSlug":"prospeo","actionSlug":"<slug>","config":{}}`. **No `connectorUuid` in `config`.**

--- a/cargo-gtm/provider-playbooks/proxycurl.md
+++ b/cargo-gtm/provider-playbooks/proxycurl.md
@@ -1,0 +1,77 @@
+---
+provider: proxycurl
+category: enrichment
+last-reviewed: 2026-07-09
+---
+
+# proxycurl
+
+Generalist LinkedIn-data enrichment and search behind a single **`objectType` discriminator** — person, company, job, or role — everything at 1 credit. Not in the priority stack: reach for it when `salesNavigator` can't express your filter (education, past roles, funding ranges, follower counts) and the criteria don't yet justify `peopleDataLabs` (3). Skip it when a LinkedIn URL is already in hand — `linkedin.enrichProfile` / `linkedin.enrichCompany` (0.25) cover that for a quarter of the price.
+
+## Credits-based actions
+
+| Action | Cost | Inputs | Use for |
+|---|---|---|---|
+| `enrich` | 1 | `objectType` + `filters` (name/value pairs); `objectType: "job"` takes `url` | Resolve one person / company / role-holder / job from identifying filters. |
+| `search` | 1 **per returned record** | `objectType` + `filters` + `limit` | Filter-rich person / company / job search. |
+
+Both actions share one shape: `objectType` picks the entity, `filters` is an **array of `{name, value}` objects** (not a flat key/value map).
+
+## What it's for
+
+- ✅ **Filter-rich people search** — `search` (person) filters include education (`education_school_name`, `education_degree_name`), past roles (`past_role_title`, `past_company_name`), tenure windows (`current_role_before` / `current_role_after`), `skills`, `languages`, `headline`, and current-company firmographics (employee/follower counts, `current_company_funding_amount_min/max`, `current_company_funded_after/before`-style ranges).
+- ✅ **Company search with funding filters** — founded-year, employee-count, follower-count, and funding-amount/date ranges at 1/record vs `peopleDataLabs.queryCompanies` (3).
+- ✅ **Role-based resolution** — `enrich` with `objectType: "role"` takes `role` + `company_name` filters: "find the Head of Sales at Acme" in one call.
+- ❌ **At-scale generic sourcing** — `salesNavigator.searchLeads` (0.02) / `searchAccounts` (0.05) are 20–50× cheaper for industry/size/geo filters.
+- ❌ **URL-in-hand enrichment** — `linkedin.enrichProfile` (0.25) beats `enrich` when you already have the LinkedIn URL.
+
+## Patterns
+
+### Pattern A — Resolve a role-holder at a known company
+
+```bash
+cargo-ai orchestration action execute-batch \
+  --action '{"kind":"connector","integrationSlug":"proxycurl","actionSlug":"enrich","config":{}}' \
+  --records '[{"objectType":"role","filters":[{"name":"role","value":"Head of Sales"},{"name":"company_name","value":"Acme"}]}]' \
+  --wait-until-finished
+```
+
+Per `objectType`, `enrich` accepts different filter names — person: `company_domain, first_name, last_name, location, title`; company: `company_domain, company_name` (+ `company_location` via `autocompleteValue`); role: `role, company_name`; job: a `url` field instead of filters.
+
+### Pattern B — Person search on filters salesNavigator can't express
+
+```bash
+cargo-ai orchestration action execute \
+  --action '{"kind":"connector","integrationSlug":"proxycurl","actionSlug":"search","config":{}}' \
+  --data '{
+    "objectType": "person",
+    "filters": [
+      {"name": "current_role_title", "value": "CTO"},
+      {"name": "past_company_name", "value": "Acme"},
+      {"name": "current_company_employee_count_max", "value": "200"},
+      {"name": "country", "autocompleteValue": "US"}
+    ],
+    "limit": 50
+  }' \
+  --wait-until-finished
+```
+
+Billed per returned record — **always set `limit`**. Exclusion lists use `values`: `{"name":"public_identifier_not_in_list","values":["alice-smith-123", ...]}` (also available as `public_identifier_in_list`) — useful for deduping against contacts you already have.
+
+## Common pitfalls
+
+- **`value` vs `autocompleteValue`.** Enum-backed filters — person: `country, current_company_country, current_company_industry, current_company_type`; company: `country, type, industry`; job: `job_type, experience_level, when, flexibility` — require `autocompleteValue`; free-text filters require `value`. Mixing them up fails the call.
+- **`search` bills per item.** `limit` is your budget cap; size the pool first per [`../references/cost-discipline.md`](../references/cost-discipline.md).
+- **Filters are an array**, not an object — `"filters": [{"name": ..., "value": ...}]`. A `{title: "CTO"}` map shape silently expresses nothing.
+- **Numeric ranges are string values** — `current_company_employee_count_min/max`, `funding_amount_min/max`, `founded_after_year/before_year` all take their number as a string `value`.
+- **Rate limit: 300 calls/minute** (spread).
+
+## Position in the waterfall
+
+- **SOURCE — escalation rung** between salesNavigator (0.02–0.05) and peopleDataLabs (3): use when the filter needs education / past-role / funding criteria; see [`../references/stage-action-map.md`](../references/stage-action-map.md).
+- **ENRICH — niche rung**: role-based resolution and job-URL enrichment; for plain person/company enrichment prefer `linkedin.*` (0.25) or the priority stack (`cargo` → `waterfall`).
+- Found people still flow through CONTACT (`FullEnrich.findEmail`, 1) and VERIFY (`waterfall.verifyEmail`, 0.1).
+
+## Action shape
+
+`{"kind":"connector","integrationSlug":"proxycurl","actionSlug":"<slug>","config":{}}`. **No `connectorUuid` in `config`.**

--- a/cargo-gtm/provider-playbooks/serper.md
+++ b/cargo-gtm/provider-playbooks/serper.md
@@ -1,0 +1,75 @@
+---
+provider: serper
+category: research (search)
+last-reviewed: 2026-07-09
+---
+
+# serper (Serper)
+
+Google search results and Google Places, **0.05 credits fixed per query** (up to 100 records per call). Two jobs: `searchPlaces` is the **default sourcing action for local SMBs / storefronts** — the segment the LinkedIn-shaped priority stack skips — and `search` is Google-results research for personalization and fact-finding.
+
+## Credits-based actions
+
+| Action | Cost | Inputs | Use for |
+|---|---|---|---|
+| `searchPlaces` | 0.05 (fixed) | `query`, `country`, `locale`, `limit` (default 10, max 100) | Google Maps-style local business results. Default for SMB / storefront / service-area sourcing. |
+| `search` | 0.05 (fixed) | `query`, `country`, `locale`, `limit` (default 10, max 100) | Google search results for research and lookups. |
+
+Billing is **fixed per query, not per record** — a `limit: 100` call costs the same 0.05 as a `limit: 10` call, so raise `limit` and lower the query count, never the reverse.
+
+## What it's for
+
+- ✅ **Local / SMB TAM** — "dentists in Austin", "HVAC contractors in Lyon": `searchPlaces` is the sourcing rung the priority stack lacks (see [`../recipes/build-tam.md`](../recipes/build-tam.md), local-SMB variant, and [`../guides/finding-companies-and-contacts.md`](../guides/finding-companies-and-contacts.md)).
+- ✅ **Google lookups mid-pipeline** — recent news, a company's public footprint, resolving an official website before enrichment.
+- ✅ **Geo-targeted results** — `country` (autocomplete-backed country list) plus `locale` (Google interface-language codes like `en`, `fr`, `de`) localize results properly.
+- ❌ **Standard B2B sourcing** — `salesNavigator.searchLeads` (0.02) / `searchAccounts` (0.05) return structured, LinkedIn-anchored records; Google results need parsing.
+- ❌ **Reading a page you already know** — that's `firecrawl.scrape` (0.05/item); serper returns result listings, not page content.
+
+## Patterns
+
+### Pattern A — Local-SMB sourcing
+
+```bash
+cargo-ai orchestration action execute \
+  --action '{"kind":"connector","integrationSlug":"serper","actionSlug":"searchPlaces","config":{}}' \
+  --data '{"query":"dentists in Austin, TX","country":"us","limit":100}' \
+  --wait-until-finished
+```
+
+One query = 0.05 credits for up to 100 places. To build a bigger TAM, fan out **queries** (by city, neighborhood, or category) rather than paging one query — each geo variant is its own 0.05 call.
+
+### Pattern B — Research lookup for personalization
+
+```bash
+cargo-ai orchestration action execute \
+  --action '{"kind":"connector","integrationSlug":"serper","actionSlug":"search","config":{}}' \
+  --data '{"query":"Acme GmbH funding announcement","country":"de","locale":"de","limit":10}' \
+  --wait-until-finished
+```
+
+Pipe the results into an LLM step (`anthropic.instruct`) to extract the fact you need; serper hands back result listings, not answers.
+
+## Common pitfalls
+
+- **Paying per record in your head.** Cost is per **query**. Ten queries at `limit: 10` cost 10× more than one query at `limit: 100` for the same volume — always max out `limit` before adding queries.
+- **Skipping `country`/`locale` for local sourcing.** Without them Google decides the geography for you; SMB lists come back skewed. Set `country` (from the country autocomplete) and put the city in the query.
+- **Treating place results as enriched records.** `searchPlaces` output is a raw local listing — dedupe it and enrich (website → `cargo.matchBusiness` → firmographics) before it enters a model.
+
+## Anti-patterns
+
+- **serper for LinkedIn-shaped B2B lists.** If the segment is companies/people that salesNavigator covers, serper adds a parsing step and loses structure — it earns its place only where Google is the best index (local SMBs, public-web facts).
+- **Fanning out searches without a cap.** Fixed-per-query pricing is cheap until an agent loops one query per record over a 5,000-row segment (250 credits of searches). Batch the distinct queries first; run each once.
+
+## Position in the waterfall
+
+- `searchPlaces` — **first (and effectively only) rung for local-SMB sourcing** (see [`../references/stage-action-map.md`](../references/stage-action-map.md), Sourcing — Local SMBs), with `firecrawl.search` as the web-search fallback.
+- `search` — a web-research rung alongside `firecrawl.search`; pick serper when you specifically want Google's ranking/geo behavior, firecrawl when you want to continue into scraping.
+
+## Action shape
+
+`{"kind":"connector","integrationSlug":"serper","actionSlug":"<slug>","config":{}}`. **No `connectorUuid` in `config`.**
+
+## Pairs with
+
+- [`../recipes/build-tam.md`](../recipes/build-tam.md) — the local-SMB sourcing variant.
+- [`../recipes/outreach-activation.md`](../recipes/outreach-activation.md) — quick public-web facts feeding the personalization step.

--- a/cargo-gtm/provider-playbooks/zeroBounce.md
+++ b/cargo-gtm/provider-playbooks/zeroBounce.md
@@ -1,0 +1,76 @@
+---
+provider: zeroBounce
+category: verification
+last-reviewed: 2026-07-09
+---
+
+# zeroBounce (ZeroBounce)
+
+Dedicated email verification. **One credits-based action, 0.1 credits** — same price as the priority-stack default `waterfall.verifyEmail`, but a **different underlying provider**, which makes it the standard second opinion when waterfall's verdict is ambiguous.
+
+## Credits-based actions
+
+| Action | Cost | Inputs | Use for |
+|---|---|---|---|
+| `verifyEmail` | 0.1 | `email` | Verify a single email's deliverability status, with rich diagnostics. |
+
+## What it's for
+
+- ✅ **Second opinion on ambiguous verdicts** — re-check emails that `waterfall.verifyEmail` flagged as catch-all or risky before discarding them. Different underlying provider = independent signal at the same 0.1 price.
+- ✅ **Typo rescue** — the output includes `did_you_mean`; a "bad" email is sometimes one transposed character away from a deliverable one.
+- ✅ **Diagnostic depth** — output carries `sub_status`, `free_email`, `catchall_domain`, `mx_found`, `mx_record`, `smtp_provider`, and `domain_age_days`, useful when you need to *explain* a verdict, not just filter on it.
+- ❌ **Default verify step** — `waterfall.verifyEmail` (0.1) is the priority-stack default; use zeroBounce as the alternative, not the first rung (see [`../references/alternatives.md`](../references/alternatives.md), Verify email alternatives).
+- ❌ **Very large lists** — `icypeas.verifyEmail` (0.01) is 10× cheaper for bulk verification where per-row diagnostics don't matter.
+
+## Patterns
+
+### Pattern A — Second-opinion re-verify
+
+```bash
+# Only on rows where the first verifier returned catch-all / ambiguous
+cargo-ai orchestration action execute-batch \
+  --action '{"kind":"connector","integrationSlug":"zeroBounce","actionSlug":"verifyEmail","config":{}}' \
+  --records '[{"email":"alice@acme.com"},{"email":"bob@globex.com"}]' \
+  --wait-until-finished
+```
+
+Keep an email when either verifier passes it cleanly; drop it only when both agree it's bad. This roughly doubles cost per re-checked row (0.1 + 0.1), so run it on the ambiguous subset, not the whole list.
+
+### Pattern B — Single lookup with diagnostics
+
+```bash
+cargo-ai orchestration action execute \
+  --action '{"kind":"connector","integrationSlug":"zeroBounce","actionSlug":"verifyEmail","config":{}}' \
+  --data '{"email":"alice@acme.com"}' \
+  --wait-until-finished
+```
+
+Read `status` + `sub_status` for the verdict, `catchall_domain` / `free_email` for risk context, and `did_you_mean` for a suggested correction when the address looks mistyped.
+
+## Output fields
+
+`address, status, sub_status, free_email, catchall_domain, did_you_mean, account, domain, domain_age_days, smtp_provider, mx_found, mx_record, firstname, lastname, gender, country, region, city, zipcode, processed_at`. Filter on `status`; use the rest for triage and reporting.
+
+## Common pitfalls
+
+- **Double-verifying everything by default.** Running zeroBounce on rows waterfall already passed cleanly doubles verify spend for near-zero information gain. Reserve it for the ambiguous subset.
+- **Ignoring `did_you_mean`.** When present, re-verify the suggested address before writing the contact off — a corrected typo is the cheapest "found email" there is.
+- **Treating catch-all as valid.** `catchall_domain: true` means the domain accepts everything; the mailbox itself is unproven. Route catch-alls per your sequencer's risk tolerance, don't blanket-send.
+
+## Anti-patterns
+
+- **zeroBounce as the first verify rung.** Same price as the priority default but outside the priority stack — swap it in deliberately (second opinion, provider outage, coverage test), not by default.
+- **Skipping verification because the finder said "verified".** Providers grade their own homework — every found email goes through a verify step regardless of the finder's flag (see [`../references/waterfall-strategy.md`](../references/waterfall-strategy.md)).
+
+## Position in the waterfall
+
+**VERIFY stage, alternative rung.** Default chain: `waterfall.verifyEmail` (0.1) first; `zeroBounce.verifyEmail` (0.1) as the equivalent-cost second opinion; `icypeas.verifyEmail` (0.01) when volume dominates and diagnostics don't matter (see [`../references/stage-action-map.md`](../references/stage-action-map.md), Verify email).
+
+## Action shape
+
+`{"kind":"connector","integrationSlug":"zeroBounce","actionSlug":"verifyEmail","config":{}}`. **No `connectorUuid` in `config`.**
+
+## Pairs with
+
+- [`../recipes/outreach-activation.md`](../recipes/outreach-activation.md) — the verify step before personalization; never sequence unverified emails.
+- [`../recipes/prospecting.md`](../recipes/prospecting.md) — the verify rung of the find → enrich → verify → sync spine.

--- a/cargo-gtm/recipes/linkedin-url-lookup.md
+++ b/cargo-gtm/recipes/linkedin-url-lookup.md
@@ -25,7 +25,7 @@ Use `linkedin.findProfileUrl` (0.25 cred) — cheapest credible source.
 cargo-ai orchestration action execute-batch \
   --action '{"kind":"connector","integrationSlug":"linkedin","actionSlug":"findProfileUrl","config":{}}' \
   --records '[
-    {"firstName":"John","lastName":"Smith","companyName":"Acme","companyDomain":"acme.com"},
+    {"fullName":"John Smith","companyName":"Acme"},
     ...
   ]' \
   --wait-until-finished > /tmp/candidates.json
@@ -88,4 +88,4 @@ Only the rows that passed the validation gate get written back. Mark unresolved 
 
 ## Action shape rules
 
-`{"kind":"connector","integrationSlug":"linkedin","actionSlug":"findProfileUrl","config":{}}`. **No `connectorUuid` in config.** Per-record data: `firstName`, `lastName`, `companyName`, `companyDomain` (any combination accepted).
+`{"kind":"connector","integrationSlug":"linkedin","actionSlug":"findProfileUrl","config":{}}`. **No `connectorUuid` in config.** Per-record data: `fullName` (required), `companyName` (optional — improves matching). If the source data has separate first/last columns, concatenate them into `fullName` first (see [`../provider-playbooks/linkedin.md`](../provider-playbooks/linkedin.md)).


### PR DESCRIPTION
## What

Grows `cargo-gtm/provider-playbooks/` from 6 to 20, and adds a **read-first gate** to the router: no paid action against a covered provider until its playbook has been opened.

**New playbooks** (all grounded in live `cargo-ai connection integration get` output — no invented slugs or costs):
- Sourcing/company data: `linkedin` (all 24 actions), `proxycurl`, `apolloio`, `oceanio`, `datagma`
- Email/contact: `hunter`, `prospeo`, `icypeas`, `findyMail`, `leadMagic`, `contactOut`, `zeroBounce`
- Research/scraping: `firecrawl`, `serper`

Each: action table with credit costs (fixed vs per-item), real config-shape examples (`connectorUuid` never in config), input quirks (URL shapes, required fields, rate limits), cost traps + cheaper alternatives, recipe-spine position. Consistent frontmatter (`provider`/`category`/`last-reviewed`) across all 20.

**Linter**: new drift guard — a playbook on disk missing from the `SKILL.md` catalog is a lint error (mirrors the existing recipe rule).

## Bugs surfaced by grounding

- **Fixed here**: `recipes/linkedin-url-lookup.md` documented `findProfileUrl` inputs (`firstName`/`lastName`/`companyDomain`) that don't exist — live schema is `fullName` (required) + `companyName`.
- **Flagged for follow-up** (auto-generated tables, not hand-edited piecemeal): `credits-cost-table.md`/`stage-action-map.md` list `prospeo.verifyEmail` which no longer exists, and price `serper.*` at 1 credit vs 0.05 live. The referenced `scripts/gen-credits-table.py` doesn't exist in the repo — regeneration tooling should be rebuilt (in TypeScript) in a follow-up.

## Verification

- `skills-lint.mjs`: 0 errors, 0 warnings (including the new playbook-catalog guard against all 20 files).
- Every cited action slug/cost spot-checked against the integration dumps by the authoring pass.
- Policy sweep on the staged diff: clean.

Stacked on #53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and agent-guidance only; no application runtime changes. The read-first gate intentionally changes agent behavior before paid connector calls, which is the desired cost/safety outcome.
> 
> **Overview**
> **`cargo-gtm` 1.3.0** adds **14 provider playbooks** (catalog **6 → 20**) for sourcing, email/contact, and research providers, each with credit costs, config shapes, pitfalls, and waterfall placement. **`cargo-gtm/SKILL.md` §11** now requires opening a provider’s playbook before any **paid** action against that provider, with the playbook list grouped beyond the original priority stack.
> 
> **`skills-lint.mjs`** gains a catalog drift check: every `provider-playbooks/*.md` on disk must be linked from `cargo-gtm/SKILL.md` (same pattern as recipes).
> 
> **`recipes/linkedin-url-lookup.md`** fixes `linkedin.findProfileUrl` inputs to **`fullName` (required) + `companyName`**, replacing incorrect `firstName`/`lastName`/`companyDomain` docs. **CHANGELOG** records 1.3.0 and notes follow-up for stale auto-generated cost tables.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bc84e01b9494f0d6d8742ba116a5a58c1e1c118. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->