### PR TITLE
docs(gtm): cite schema-JSON exports (ClayMate Lite) in the import recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ## [Unreleased]
 
+### `cargo-gtm` → 1.6.1
+
+- Import recipe step 5 now points at schema-as-JSON exports as the mapping input for rebuilding source-tool logic, citing [ClayMate Lite](https://github.com/GTM-Base/claymate-lite) for Clay tables (third-party MIT extension, with a review-before-loading caution). Explicit exception to the no-competitor-names convention, approved 2026-07-10.
+
 ### `cargo-gtm` → 1.7.0
 
 - **Provider playbooks: 20 → 43 — every credits-based provider covered.** Twenty-three more playbooks grounded in `connection integration get`: the LLM tier (`anthropic`, `openAi`, `gemini`, `perplexity` — per-model cost tiers and bulk-vs-judgment routing), verification/contact long tail (`bouncer`, `neverBounce`, `dropcontact`, `enrichley`, `enrowio`, `reverseContact`, `rocketreach`, `forager`, `cleon1`, `mixrank`, `kitt`), enrichment (`companyEnrich`, `enrichCrm`, `societeInfo`, `snitcher`), and sourcing/signal (`piloterr`, `g2`, `theSwarm`, `linkup`). The §11 read-first gate now covers the whole credits catalog; the "no playbook → alternatives.md" fallback remains only for own-key integrations.

--- a/cargo-gtm/recipes/import-gtm-data.md
+++ b/cargo-gtm/recipes/import-gtm-data.md
@@ -63,7 +63,7 @@ Report the SEND/VERIFY/REVIEW/REMOVE counts — then **write the verdicts back t
 
 For each recurring enrichment/workflow in the source tool, decide with the user: **retire, keep manual, or rebuild**. For rebuilds:
 
-1. Identify what each source column *did* (find email, enrich firmographics, score, personalize).
+1. Identify what each source column *did* (find email, enrich firmographics, score, personalize). If the source tool can export its table/workflow **schema as JSON**, use that as the mapping input instead of eyeballing the UI — e.g. for Clay tables, [ClayMate Lite](https://github.com/GTM-Base/claymate-lite) (MIT Chrome extension) exports column structures as portable JSON. *Third-party code: review it before loading — it runs on your logged-in session.*
 2. Map it to the cheapest Cargo action for that stage — [`../references/stage-action-map.md`](../references/stage-action-map.md), then the provider's playbook (§11 gate applies).
 3. LLM prompt columns: check [`../references/prompt-library/index.md`](../references/prompt-library/index.md) for a proven equivalent before porting the prompt text.
 4. Compose the chain per the recipe spine and save it as a play — [`save-as-play.md`](save-as-play.md).

--- a/cargo-gtm/skill-metadata.json
+++ b/cargo-gtm/skill-metadata.json
@@ -468,5 +468,5 @@
       "kind": "script"
     }
   ],
-  "contentHash": "dfbb8bfc47c162fbe08fdf585ba09f9f1c254f42e62b4bebde6958da55a659ed"
+  "contentHash": "ba031313fe6335930963d3877c4a9f13bcd5394c7e52f02faf0246e7169ab7a6"
 }


### PR DESCRIPTION
Step 5 of `import-gtm-data.md` now tells the agent to prefer a **schema-as-JSON export** from the source tool as the mapping input when rebuilding recurring logic, and names [ClayMate Lite](https://github.com/GTM-Base/claymate-lite) (MIT Chrome extension exporting Clay table schemas as portable JSON) as the concrete example for Clay tables — with a review-before-loading caution since it's third-party code running on the user's logged-in session.

This is a deliberate, maintainer-approved exception to the repo's no-competitor-names convention (recorded in the CHANGELOG entry). The recipe still ships no extractors of its own.

`cargo-gtm` → 1.6.1. Note: will need the usual metadata refresh against #58 (whichever merges second).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and metadata hash only; no CLI, scripts, or runtime behavior changes.
> 
> **Overview**
> **`cargo-gtm` import recipe (step 5)** now tells agents to use a **schema-as-JSON export** from the source tool as the mapping input when rebuilding recurring logic, instead of inferring column behavior only from the UI. For Clay tables it names **[ClayMate Lite](https://github.com/GTM-Base/claymate-lite)** (MIT Chrome extension) as a concrete exporter, with a **review-before-loading** warning because third-party code runs on the user’s logged-in session.
> 
> **CHANGELOG** records **`cargo-gtm` → 1.6.1** and documents this as a **maintainer-approved exception** to the repo’s usual no-competitor-names convention. **`skill-metadata.json`** only updates the **content hash** to match the edited docs; no scripts or extractors are added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aeff2929ecca619f4417b4d1dd602165f45da9f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->