### PR TITLE
Document folder organization best practice for CDK resources

### DIFF
--- a/cargo-cdk/SKILL.md
+++ b/cargo-cdk/SKILL.md
@@ -161,9 +161,9 @@ state) · `cargo-ai cdk rollback` (restore the pre-deploy state snapshot).
   each builder so everything CDK owns lands in a dedicated folder whose name signals
   "owned by code — don't hand-edit" to anyone in the UI (manual UI edits read back as
   drift on the next `plan`). Folders are per-kind, so give each kind its own but share
-  one recognizable name/prefix — recommended: **`⚙️ Managed by CDK — do not edit`**
-  (or a `[CDK]` prefix, e.g. `[CDK] Models`, `[CDK] Agents`). A lock/gear emoji plus a
-  "do not edit" hint is the clearest cue in the folder tree. See
+  one short, recognizable prefix — recommended: **`🔒 CDK`** (e.g. `🔒 CDK Models`,
+  `🔒 CDK Agents`). Keep names short (long labels truncate in the folder tree); the
+  lock emoji is the "don't touch" cue. See
   [`guides/authoring-resources.md`](guides/authoring-resources.md).
 
 ## Prerequisites

--- a/cargo-cdk/SKILL.md
+++ b/cargo-cdk/SKILL.md
@@ -157,6 +157,14 @@ state) · `cargo-ai cdk rollback` (restore the pre-deploy state snapshot).
   land in the wrong directory. Use `--dir <path>` to be explicit.
 - **`--yes` in CI.** `deploy` and `destroy` prompt for confirmation; non-interactive
   runs must pass `--yes`.
+- **Route CDK-managed resources into a clearly-labelled folder.** Set `folder:` on
+  each builder so everything CDK owns lands in a dedicated folder whose name signals
+  "owned by code — don't hand-edit" to anyone in the UI (manual UI edits read back as
+  drift on the next `plan`). Folders are per-kind, so give each kind its own but share
+  one recognizable name/prefix — recommended: **`⚙️ Managed by CDK — do not edit`**
+  (or a `[CDK]` prefix, e.g. `[CDK] Models`, `[CDK] Agents`). A lock/gear emoji plus a
+  "do not edit" hint is the clearest cue in the folder tree. See
+  [`guides/authoring-resources.md`](guides/authoring-resources.md).
 
 ## Prerequisites
 

--- a/cargo-cdk/guides/authoring-resources.md
+++ b/cargo-cdk/guides/authoring-resources.md
@@ -142,11 +142,11 @@ export const modelsFolder = defineFolder("crm-models", { kind: "model", name: "C
 // labelled folder (via each builder's `folder:`), so a human in the UI sees at a
 // glance that these resources are owned by code and shouldn't be hand-edited —
 // manual UI changes read back as drift on the next `plan`. Because folders are
-// per-kind, give each kind its own but share ONE recognizable name/prefix, e.g.
-// `⚙️ Managed by CDK` (or `[CDK] Models`, `[CDK] Agents`, …). A lock/gear emoji
-// plus a "do not edit" signal in the name is the clearest cue in the folder tree.
-export const cdkModels = defineFolder("cdk-models", { kind: "model", name: "⚙️ Managed by CDK — do not edit" });
-export const cdkAgents = defineFolder("cdk-agents", { kind: "agent", name: "⚙️ Managed by CDK — do not edit" });
+// per-kind, give each kind its own but share ONE short, recognizable prefix, e.g.
+// `🔒 CDK` (or `🔒 CDK Models`, `🔒 CDK Agents`). Keep names short — long labels
+// truncate in the folder tree; the lock emoji is the "don't touch" cue.
+export const cdkModels = defineFolder("cdk-models", { kind: "model", name: "🔒 CDK Models" });
+export const cdkAgents = defineFolder("cdk-agents", { kind: "agent", name: "🔒 CDK Agents" });
 
 // File — content uploaded from a local path (hashed at define time, so edits show as drift).
 export const playbook = defineFile("playbook", {

--- a/cargo-cdk/guides/authoring-resources.md
+++ b/cargo-cdk/guides/authoring-resources.md
@@ -138,6 +138,16 @@ Organization & knowledge:
 // Folder — per-kind (a "model" folder and an "agent" folder are separate).
 export const modelsFolder = defineFolder("crm-models", { kind: "model", name: "CRM" });
 
+// RECOMMENDED: route every CDK-managed resource into a dedicated, clearly
+// labelled folder (via each builder's `folder:`), so a human in the UI sees at a
+// glance that these resources are owned by code and shouldn't be hand-edited —
+// manual UI changes read back as drift on the next `plan`. Because folders are
+// per-kind, give each kind its own but share ONE recognizable name/prefix, e.g.
+// `⚙️ Managed by CDK` (or `[CDK] Models`, `[CDK] Agents`, …). A lock/gear emoji
+// plus a "do not edit" signal in the name is the clearest cue in the folder tree.
+export const cdkModels = defineFolder("cdk-models", { kind: "model", name: "⚙️ Managed by CDK — do not edit" });
+export const cdkAgents = defineFolder("cdk-agents", { kind: "agent", name: "⚙️ Managed by CDK — do not edit" });
+
 // File — content uploaded from a local path (hashed at define time, so edits show as drift).
 export const playbook = defineFile("playbook", {
   path: new URL("./playbook.md", import.meta.url).pathname,

--- a/cargo-cdk/skill-metadata.json
+++ b/cargo-cdk/skill-metadata.json
@@ -69,5 +69,5 @@
       "title": "Troubleshooting"
     }
   ],
-  "contentHash": "18dd0e1c7381c1b1dad2c8d1fe31fc42146cfc1563502bf48b7371306fb1dec6"
+  "contentHash": "8af479a313bb01f866d0e6e43d831e8ac73463b0b57a63e71a154f78492036c5"
 }


### PR DESCRIPTION
## Summary
Add guidance on organizing CDK-managed resources into clearly-labelled folders to prevent accidental manual edits and drift detection issues.

## Changes
- **`guides/authoring-resources.md`**: Added recommended pattern for routing CDK resources into dedicated folders with a recognizable prefix (e.g., `🔒 CDK Models`, `🔒 CDK Agents`) to signal code ownership in the UI
- **`SKILL.md`**: Added best practice note under the CLI tips section linking to the folder organization guidance with rationale and naming conventions

## Details
The documentation now recommends using a consistent, short prefix (lock emoji + "CDK") across per-kind folders to make it visually obvious to UI users that these resources are code-managed and shouldn't be hand-edited. This prevents drift issues where manual UI changes would be detected as drift on the next `plan` run. The guidance includes concrete examples and emphasizes keeping folder names short to avoid truncation in the UI tree.

https://claude.ai/code/session_01WQq9CVTLfaX2FHsrojoWny

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown and generated metadata only; no runtime, deploy, or API behavior changes.
> 
> **Overview**
> Adds **documentation-only** guidance for putting CDK-owned resources in dedicated UI folders via each builder’s **`folder:`** field, so teams can signal “code-owned — don’t hand-edit” and avoid surprise **drift** on the next **`plan`**.
> 
> **`SKILL.md`** gains a new critical-rule bullet (with a link to the authoring guide) covering per-kind folders, a shared **`🔒 CDK`** naming prefix, and short display names so labels don’t truncate in the folder tree.
> 
> **`guides/authoring-resources.md`** adds a recommended **`defineFolder`** pattern with concrete examples (`🔒 CDK Models`, `🔒 CDK Agents`) alongside the existing CRM folder sample.
> 
> **`skill-metadata.json`** **`contentHash`** is updated to match the edited docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02539f6328f5b7c14bacba125a88f50a8d08e0e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->