### PR TITLE
Suggest integrations/provider playbooks for recurring use, not only one-offs

### DIFF
--- a/cargo-gtm/SKILL.md
+++ b/cargo-gtm/SKILL.md
@@ -54,7 +54,7 @@ These docs encode what works, what fails, and why. They contain validated parame
 | **Finding companies, finding people, building lead lists, prospecting, portfolio/VC sourcing, contact finding at known companies** | [`guides/finding-companies-and-contacts.md`](guides/finding-companies-and-contacts.md) | Provider filter schemas, cheapest-source decision tree, parallel patterns, role-based search rules, portfolio/VC shortcuts, contact-finding patterns. |
 | **Enriching companies or contacts, finding emails/phones/LinkedIn, waterfall enrichment, signal lookup (job change, funding, tech stack), coalescing data** | [`guides/enriching-and-researching.md`](guides/enriching-and-researching.md) | Waterfall patterns with fallback chains, when to use cargo-native vs waterfall vs FullEnrich vs peopleDataLabs, email/phone/LinkedIn fallback orders, signal segments, output retrieval via `run download-outputs`. |
 | **Writing cold emails, personalizing outreach, lead scoring, qualification, sequence design, campaign copy** | [`guides/writing-outreach.md`](guides/writing-outreach.md) | LLM provider routing (openAi/anthropic/perplexity/gemini), prompt templates, scoring rubrics, email length/tone rules, personalization patterns. |
-| **Building or modifying a recurring workflow** (cron / webhook / scheduled tool / play), designing step sequences, triggers, deploy/verify cycles | [`../cargo-orchestration/SKILL.md`](../cargo-orchestration/SKILL.md) (capability) + apply-patterns from this skill's recipes | Schema for tool/play workflows, node graph syntax, polling strategies, output retrieval. |
+| **Building or modifying a recurring workflow** (cron / webhook / scheduled tool / play), designing step sequences, triggers, deploy/verify cycles | [`../cargo-orchestration/SKILL.md`](../cargo-orchestration/SKILL.md) (capability) + apply-patterns from this skill's recipes + the [provider playbook](provider-playbooks/) of **every paid node** (§11, esp. its **Recurring use** section) | Schema for tool/play workflows, node graph syntax, polling strategies, output retrieval; per-provider cadence defaults and re-billing gates. |
 
 ### Recipes: step-by-step playbooks (check before executing)
 
@@ -116,7 +116,7 @@ These six credits-based providers cover the full prospecting → enrichment → 
 | **theirStack** | Tech-stack + hiring intent | `searchTechnologies` (0.5), `searchJobs` (0.5), `searchCompanies` (0.5) |
 | **peopleDataLabs** | Heavyweight backfill | `enrichPerson` (3), `enrichCompany` (3), `searchPeople` (3), `searchCompanies` (3), `queryPeople/Companies` (3) |
 
-See [`provider-playbooks/`](provider-playbooks/) for per-provider deep dives. See [`references/stage-action-map.md`](references/stage-action-map.md) for the complete cheapest-action-per-stage table across the full 120-integration catalog.
+See [`provider-playbooks/`](provider-playbooks/) for per-provider deep dives — including each provider's **Recurring use** section for when the task is a monitor, play, or scheduled pull rather than a one-off. See [`references/stage-action-map.md`](references/stage-action-map.md) for the complete cheapest-action-per-stage table across the full 120-integration catalog.
 
 > **Already holding identifiers (not sourcing)?** The stack above leads the *sourcing-first* spine. When you already have **LinkedIn URLs**, the cheapest enrich is [`linkedin`](provider-playbooks/linkedin.md) — `enrichProfile` / `enrichCompany` (0.25, URL → person/company details incl. headcount, industry, funding), *not* `waterfall.enrichContact` (which keys on email or name+company). Have a **LinkedIn event URL**? `linkedin.extractEventAttendees` sources the attendee list directly. Have **emails**? `leadMagic` / `contactOut`. See `references/stage-action-map.md` for the full input-type → cheapest-action map.
 
@@ -174,9 +174,9 @@ Every action JSON in this skill follows the rules in [`../cargo-orchestration/re
 
 If a recipe fails repeatedly and the cause isn't obvious, escalate via `cargo-ai workspaceManagement report create`. See [`../cargo-workspace-management/SKILL.md`](../cargo-workspace-management/SKILL.md) (Reports section).
 
-## 11) Provider playbooks — read before you call
+## 11) Provider playbooks — read before you call (one-off or recurring)
 
-**STOP — do not execute any paid action against a provider below until you have opened its playbook.** Each playbook carries the exact action slugs, config shapes, input quirks, and cost traps; reading it for five seconds is cheaper than one failed paid call, and a failed batch is 100 failed paid calls. **Every credits-based provider in the catalog now has a playbook**; only own-key integrations fall back to [`references/alternatives.md`](references/alternatives.md) and [`references/stage-action-map.md`](references/stage-action-map.md).
+**STOP — do not execute any paid action against a provider below, and do not wire a provider into a recurring play/tool node graph, until you have opened its playbook.** Each playbook carries the exact action slugs, config shapes, input quirks, and cost traps; reading it for five seconds is cheaper than one failed paid call, and a failed batch is 100 failed paid calls. The stakes are higher, not lower, when the provider goes into a **recurring** workflow: a bad config repeats on every scheduled run, and a wrong cadence re-bills the same rows forever — each playbook ends with a **Recurring use** section (schedule fit, cadence default, re-billing gates, extractors) for exactly this. **Every credits-based provider in the catalog now has a playbook**; only own-key integrations fall back to [`references/alternatives.md`](references/alternatives.md) and [`references/stage-action-map.md`](references/stage-action-map.md).
 
 **Priority stack (recipes lead with these):**
 - [`provider-playbooks/salesNavigator.md`](provider-playbooks/salesNavigator.md) — cheapest sourcing in the catalog (0.02–0.05/record).

--- a/cargo-gtm/provider-playbooks/FullEnrich.md
+++ b/cargo-gtm/provider-playbooks/FullEnrich.md
@@ -86,6 +86,14 @@ If `FullEnrich.findEmail` returns nothing for a row, escalate via:
 
 Don't run all four blindly — the spine is `FullEnrich` first, escalate only on misses. **Demote dynamically**: if FullEnrich misses on the pilot's first ~10 rows of a batch (some segments — e.g. non-LinkedIn-native industries — are outside its coverage), move it behind hunter for the rest of that batch.
 
+## Recurring use
+
+No scheduled fit — per-record enrichment only. A found email is stable data; re-running the finder on a timer just re-bills rows that won't change.
+
+- **In-play shape:** `findEmail` as the CONTACT node of a play triggered by rows entering the segment; gate on the email column still being empty so re-evaluation never re-bills enriched rows.
+- **Recurring niche:** `reverseEmailLookup` (2) on newly captured email-only rows (webforms, `snitcher.searchSessions`) — gate on the LinkedIn-URL column being empty.
+- **Phone stays out of recurring chains:** `findPhone` (6) is explicit-request + qualified rows only (see Anti-patterns) — never wire it into a play's default path.
+
 ## Action shape
 
 `{"kind":"connector","integrationSlug":"FullEnrich","actionSlug":"<slug>","config":{}}`. **No `connectorUuid` in `config`.** Note the capitalization: `FullEnrich` (camel-case starting with capital `F`).

--- a/cargo-gtm/provider-playbooks/aiArk.md
+++ b/cargo-gtm/provider-playbooks/aiArk.md
@@ -129,6 +129,12 @@ Conventions inside a group:
 - `reverseLookup` — **niche**: email/phone → profile, beside `FullEnrich.reverseEmailLookup` (2, email → LinkedIn URL).
 - `analyzePersonality` — **WRITE/personalization input**, outside the credits spine's find-and-verify path.
 
+## Recurring use
+
+- **Scheduled search:** `searchCompanies` / `searchPeople` fit a weekly sourcing tool (persona/company searches → weekly; cadence table: [`../recipes/save-as-play.md`](../recipes/save-as-play.md)) — but they bill 0.01/0.05 **per returned record on every run**, so dedup results against the workspace model (`cargo.matchBusiness` / `matchProspect`) before any paid downstream node.
+- **In-play gate:** `enrichPerson` runs only where `email` is still empty; `findMobilePhone` only where the phone column is empty. Misses bill 0, but a hit on an already-filled row is pure re-spend.
+- **Stable data:** profiles and emails don't decay week to week — never schedule blanket re-enrichment; `analyzePersonality` belongs in a play's WRITE step on newly qualified rows, not on a timer (see anti-patterns).
+
 ## Action shape
 
 `{"kind":"connector","integrationSlug":"aiArk","actionSlug":"<slug>","config":{}}`. **No `connectorUuid` in `config`.** For top-level `action execute` / `execute-batch`, inputs go in `--data` (single) or `--records` (batch), **not** in the action `config`.

--- a/cargo-gtm/provider-playbooks/anthropic.md
+++ b/cargo-gtm/provider-playbooks/anthropic.md
@@ -70,3 +70,10 @@ cargo-ai orchestration action execute-batch \
 
 - [`../references/prompt-library/index.md`](../references/prompt-library/index.md) — the prompt source for every `instruct` call (extraction, qualification, scoring, personalization, research, signal analysis).
 - [`../recipes/outreach-activation.md`](../recipes/outreach-activation.md) — personalize stage; [`../recipes/icp-discovery.md`](../recipes/icp-discovery.md) — pattern analysis; [`../recipes/tech-intent.md`](../recipes/tech-intent.md) — scrape → LLM extract.
+
+## Recurring use
+
+No scheduled fit — `instruct` is a transform, not a data source; it belongs **inside** plays and tools, never on its own timer.
+
+- **In-play gate:** run only where the column the prompt fills (score, personalization line, extracted JSON) is still empty — at `temperature: 0` a re-run reproduces the same output for the same token spend, so ungated re-evaluation is pure re-billing.
+- **Prompt or model changes:** to redo rows after revising the prompt or tier, clear the target column deliberately for just those rows rather than dropping the gate — the 500-row batch math above compounds on every ungated pass.

--- a/cargo-gtm/provider-playbooks/apolloio.md
+++ b/cargo-gtm/provider-playbooks/apolloio.md
@@ -82,6 +82,12 @@ cargo-ai orchestration action execute-batch \
 - `enrichOrganization` — **ENRICH (company), fallback rung** after `cargo.enrichBusinessFirmographics` (0.5) and `linkedin` (0.25–0.5).
 - Own-key sequence actions — post-VERIFY **activation**, outside the credits spine.
 
+## Recurring use
+
+- **No scheduled fit on credits** — both credits actions are per-record enrichment. The own-key `search*` actions can feed a scheduled sourcing tool on your Apollo plan's quota; dedup re-pulls there with the `prospected_by_current_team` filter.
+- **In-play gate:** `enrichPerson` only where the target contact field (`email`) is still empty; `enrichOrganization` only where firmographics are empty. Never leave `revealPhoneNumber: true` on a play node — every re-evaluated row bills 3 instead of 1.
+- **Stable data, tight ceiling:** enrichment output doesn't decay, and the 400 calls/hour limit means an ungated recurring batch both re-bills and stalls the queue.
+
 ## Action shape
 
 `{"kind":"connector","integrationSlug":"apolloio","actionSlug":"<slug>","config":{}}`. **No `connectorUuid` in `config`.**

--- a/cargo-gtm/provider-playbooks/bouncer.md
+++ b/cargo-gtm/provider-playbooks/bouncer.md
@@ -60,3 +60,9 @@ The catalog dump documents no output schema for this action — inspect the firs
 
 - [`../recipes/outreach-activation.md`](../recipes/outreach-activation.md) — the verify step before personalization; never sequence unverified emails.
 - [`../recipes/prospecting.md`](../recipes/prospecting.md) — the verify rung of the find → enrich → verify → sync spine.
+
+## Recurring use
+
+- **No scheduled fit — per-record verification only.** Recurring verification inside a play belongs on the default rung `waterfall.verifyEmail` (0.1) or bulk `icypeas.verifyEmail` (0.01); bouncer enters recurring flows only via an own-key connector.
+- **In-play gate:** run only where the bouncer verdict column is still empty **and** `email` is non-empty — an email verifies once; re-evaluation must not re-bill settled rows.
+- **Decay caveat:** deliverability does age, but scheduled re-verification of a whole list goes to the cheap rungs (or the user's Bouncer plan), never through the 0.3-credit price.

--- a/cargo-gtm/provider-playbooks/cargo.md
+++ b/cargo-gtm/provider-playbooks/cargo.md
@@ -110,6 +110,12 @@ cargo-ai orchestration action execute \
 
 **First rung for all enrichment** (match + firmographics at 0.5 each is unbeatable when the company is in-catalog). Unmatched rows fall to `waterfall.enrich*`, then `peopleDataLabs.enrich*`. If `matchBusiness` misses heavily on the pilot (niche/SMB-heavy segments), demote cargo native and lead with waterfall for that batch.
 
+## Recurring use
+
+- **Scheduled monitor:** `fetchProspectEvents` / `fetchBusinessEvents` are the native signal feed — set `timestamp_from` to the previous run's timestamp so each pull bills only the new window (Pattern C). Cadence defaults: job changes → every 2 weeks, funding events → weekly ([`../recipes/save-as-play.md`](../recipes/save-as-play.md)).
+- **In-play gate:** `matchBusiness` / `matchProspect` only where `business_id` / `prospect_id` is still empty — the matched ID is stable and never needs re-resolving; each `enrichBusiness*` / `enrichProspect*` node only where its own target columns are empty.
+- **Stable firmographics:** `enrichBusiness*` output barely moves month to month — scheduled re-enrichment mostly re-bills unchanged data; reserve recurring pulls for the event actions above.
+
 ## Action shape
 
 `{"kind":"connector","integrationSlug":"cargo","actionSlug":"<slug>","config":{}}`. **No `connectorUuid` in `config`** — single workspace connector resolves automatically.

--- a/cargo-gtm/provider-playbooks/cleon1.md
+++ b/cargo-gtm/provider-playbooks/cleon1.md
@@ -62,6 +62,13 @@ Only `firstName` + `lastName` are required — but a bare name is the weakest po
 - `findPhoneFromLinkedin` / `findPhone` — **CONTACT stage, terminal rung** of the phone chain: `prospeo` (3) → `FullEnrich` (6) → `waterfall` (7) → `datagma` (8) → **cleon1 (15)**. Explicit user request only, qualified leads only.
 - Phones don't flow to VERIFY (that's an email stage) — but the record they attach to should already be verified before you spend 15 credits on it.
 
+## Recurring use
+
+No scheduled fit — per-record phone lookup only, and at 15 credits it should barely appear in recurring infrastructure at all.
+
+- **In-play gate:** if cleon1 sits in a play, it fires only where the phone column is **still empty after the entire cheaper chain** (`prospeo` → `FullEnrich` → `waterfall` → `datagma`) has run and missed, on qualified rows only — a re-evaluation that re-fires it bills 15 per row.
+- **Stable output:** a found phone doesn't decay; there is no case for re-running cleon1 on a row that already holds one.
+
 ## Action shape
 
 `{"kind":"connector","integrationSlug":"cleon1","actionSlug":"<slug>","config":{}}`. **No `connectorUuid` in `config`.**

--- a/cargo-gtm/provider-playbooks/companyEnrich.md
+++ b/cargo-gtm/provider-playbooks/companyEnrich.md
@@ -63,6 +63,12 @@ cargo-ai orchestration action execute \
 - `enrichByDomain` — **ENRICH (company), budget rung**: cheapest of the chain (`companyEnrich` 0.25 → `linkedin` 0.25–0.5 → `cargo` 0.5 ✅ → `waterfall` 1 ✅ → `peopleDataLabs` 3).
 - `findSimilarCompanies` — **SOURCE-adjacent**: lookalike expansion feeding TAM builds, upstream of ENRICH.
 
+## Recurring use
+
+- **Scheduled lookalikes:** `findSimilarCompanies` can re-run weekly to keep a TAM growing (persona/company searches → weekly; [`../recipes/save-as-play.md`](../recipes/save-as-play.md)) — but results overlap heavily run to run and bill 1 credit **per company returned**, so keep `limit` tight and dedup against the Companies model (`cargo.matchBusiness`) before any downstream enrichment.
+- **In-play gate:** `enrichByDomain` runs only where the row's firmographic target columns are still empty — and never beside the cargo default (see anti-patterns).
+- **Stable data:** firmographics don't decay; a scheduled re-enrich of an existing TAM just re-bills unchanged data at 0.25/row.
+
 ## Action shape
 
 `{"kind":"connector","integrationSlug":"companyEnrich","actionSlug":"<slug>","config":{}}`. **No `connectorUuid` in `config`.**

--- a/cargo-gtm/provider-playbooks/contactOut.md
+++ b/cargo-gtm/provider-playbooks/contactOut.md
@@ -92,6 +92,14 @@ The `filters` array is discriminated by `name`: list-type filters (`skills`, `ed
 - Contact enrich — **mid rung** of the email/phone chain: after cargo native + FullEnrich, alongside `waterfall.enrichContact` (2); its `includePhone` tier (3) sits at the `prospeo.findPhone` price, below FullEnrich (6) and waterfall (7).
 - `search` — coverage fallback when salesNavigator/icypeas miss the segment.
 
+## Recurring use
+
+No scheduled fit — per-record enrichment only; a re-run `search` re-bills every item returned (1–3/item) for a mostly unchanged result set.
+
+- **In-play gate:** run contact `enrich` only where the target field is still empty — gate on empty `email` (1–2-tier) or empty phone (3-tier), and keep `includePhone: false` in the play config: it triples the price on every row the play re-touches.
+- **The free rung is safe to repeat:** company `enrich` (0 credits) can sit ungated in a play — it never bills. Every paid action needs the empty-field gate.
+- **Stability:** emails/phones behind a LinkedIn URL don't decay fast — re-enriching filled rows on a timer just re-bills unchanged data.
+
 ## Action shape
 
 `{"kind":"connector","integrationSlug":"contactOut","actionSlug":"<slug>","config":{}}`. **No `connectorUuid` in `config`.**

--- a/cargo-gtm/provider-playbooks/datagma.md
+++ b/cargo-gtm/provider-playbooks/datagma.md
@@ -69,6 +69,13 @@ Neither field is marked required in the schema — pass at least one identifier;
 - `findPhone` / `findPhoneAndEmail` — **CONTACT stage, last rung** of the phone chain: `prospeo` (3) → `FullEnrich` (6) → `waterfall` (7) → **datagma (8)** → `cleon1` (15, premium).
 - Every found email flows to **VERIFY** (`waterfall.verifyEmail`, 0.1) before activation.
 
+## Recurring use
+
+No scheduled fit — per-record enrichment only; every datagma action is an escalation rung, never a monitor.
+
+- **In-play gate:** `findEmail` runs only where `email` is still empty *and* the earlier rungs already missed; `findPhone` / `findPhoneAndEmail` (8) additionally gate on an empty phone field **and** the qualified-lead condition — the anti-pattern above ("ungated batch") applies doubly to a play that re-evaluates its segment.
+- **Stability:** a filled email or phone doesn't improve on re-lookup — re-running datagma on enriched rows re-bills last-rung prices for the same data.
+
 ## Action shape
 
 `{"kind":"connector","integrationSlug":"datagma","actionSlug":"<slug>","config":{}}`. **No `connectorUuid` in `config`.**

--- a/cargo-gtm/provider-playbooks/dropcontact.md
+++ b/cargo-gtm/provider-playbooks/dropcontact.md
@@ -59,6 +59,13 @@ No field is schema-required, but a call without at least a name plus a company i
 
 **CONTACT stage, geography-conditional rung.** For FR/EU-heavy lists: swap in at rung 1 alongside/instead of `FullEnrich.findEmail` (1); otherwise use only on FullEnrich misses for EU rows (see [`../references/stage-action-map.md`](../references/stage-action-map.md), Find email). Every hit still flows to VERIFY: free pre-cull → `waterfall.verifyEmail` (0.1).
 
+## Recurring use
+
+No scheduled fit — per-record enrichment only; wire `findEmail` as the FR/EU CONTACT rung inside a play, not on a timer.
+
+- **In-play gate:** run only where the stored email column is still empty (gate on the *written-back* field — the node output `email` is an array, per pitfalls) and, in the escalation variant, only where FullEnrich already missed.
+- **Trigger shape vs the rate limit:** a play fired by segment changes trickles rows naturally under the 60 calls/minute cap (see pitfalls) — a better fit than a scheduled bulk re-pull, which drains slowly and re-bills unchanged rows.
+
 ## Action shape
 
 `{"kind":"connector","integrationSlug":"dropcontact","actionSlug":"findEmail","config":{}}`. **No `connectorUuid` in `config`.**

--- a/cargo-gtm/provider-playbooks/enrichCrm.md
+++ b/cargo-gtm/provider-playbooks/enrichCrm.md
@@ -65,6 +65,13 @@ Every hit still flows to VERIFY: free pre-cull, then `waterfall.verifyEmail` (0.
 - `enrichPerson` / `enrichCompany` — **ENRICH, fallback rungs** behind the stack (`cargo` → `waterfall` → `peopleDataLabs`).
 - `getFunding` — **SIGNAL (funding), fallback** behind `cargo.enrichBusinessFundingAndAcquisitions` (0.5).
 
+## Recurring use
+
+The one action here with a real monitor shape is `getFunding` — funding is an event stream, not a static field.
+
+- **Scheduled pull:** re-run `getFunding` (1) **weekly** on the watched-companies segment as the fallback rung behind `cargo.enrichBusinessFundingAndAcquisitions` (0.5), per [`../recipes/funding-watch.md`](../recipes/funding-watch.md); cadence defaults in [`../recipes/save-as-play.md`](../recipes/save-as-play.md). Diff each pull against the stored funding fields so only *changed* rows trigger paid downstream steps.
+- **In-play gate:** the other three actions are per-record enrichment — `findEmail` only where `email` is still empty, `enrichPerson` / `enrichCompany` only where their target profile/firmographic fields are unfilled. Re-running them on a timer re-bills stable data.
+
 ## Action shape
 
 `{"kind":"connector","integrationSlug":"enrichCrm","actionSlug":"<slug>","config":{}}`. **No `connectorUuid` in `config`.**

--- a/cargo-gtm/provider-playbooks/enrichley.md
+++ b/cargo-gtm/provider-playbooks/enrichley.md
@@ -60,6 +60,14 @@ Keep an email when either verifier passes it cleanly; drop it only when both agr
 
 **VERIFY stage, alternative rung.** Default chain: `waterfall.verifyEmail` (0.1) first; `zeroBounce.verifyEmail` / `enrichley.verify` (0.1) as equal-cost second opinions; `icypeas.verifyEmail` (0.01) when volume dominates.
 
+## Recurring use
+
+Verification status decays, but re-verifying a whole list on a timer re-bills every row — the recurring shape is **verify-before-send**, not verify-on-schedule.
+
+- **In-play gate:** gate the `verify` node to rows entering a send wave whose `*_verified_at` timestamp is missing or stale (older than the send cycle) — never the full segment on each evaluation.
+- **Second-opinion discipline recurs too:** in a play, keep enrichley on the ambiguous subset only (catch-all/risky from the first verifier) — 0.2/re-checked row compounds fast on repeat.
+- **SEG rows don't ripen:** `mx_secure_email_gateway: true` domains stay structurally unverifiable — route them by risk policy once and exclude them from re-verification.
+
 ## Action shape
 
 `{"kind":"connector","integrationSlug":"enrichley","actionSlug":"verify","config":{}}`. **No `connectorUuid` in `config`.**

--- a/cargo-gtm/provider-playbooks/enrowio.md
+++ b/cargo-gtm/provider-playbooks/enrowio.md
@@ -69,6 +69,14 @@ The catalog dump documents no output schema for either action — inspect the fi
 - `findEmail` — **late escalation rung** of the CONTACT-stage find-email chain, outside the default order (see [`../references/stage-action-map.md`](../references/stage-action-map.md), Find email — "Alt mid-tier").
 - `verifyEmail` — **VERIFY stage, alternative rung** at the default 0.1 price, alongside `zeroBounce.verifyEmail` and `enrichley.verify`.
 
+## Recurring use
+
+No scheduled fit — both actions are per-record; their recurring shape is a gated play node, not a timer.
+
+- **`findEmail` gate:** run only where `email` is still empty *and* the earlier chain rungs already missed — an ungated 1-credit escalation rung re-billing on every segment re-evaluation defeats its reason for existing (see the anti-pattern above).
+- **`verifyEmail` gate:** verification decays, but a timed re-verify re-bills the list — gate the node to rows entering a send wave with a missing or stale `*_verified_at` timestamp (verify-before-send).
+- **Rate limit:** the 60 calls/minute cap (see pitfalls) suits trickle-through segment-change triggers better than scheduled bulk re-pulls.
+
 ## Action shape
 
 `{"kind":"connector","integrationSlug":"enrowio","actionSlug":"<slug>","config":{}}`. **No `connectorUuid` in `config`.**

--- a/cargo-gtm/provider-playbooks/findyMail.md
+++ b/cargo-gtm/provider-playbooks/findyMail.md
@@ -69,6 +69,14 @@ LinkedIn URL is the only accepted identifier. Output is `phone` + `line_type`.
 - `findPhone` — **rung 2** of the phone chain (prospeo → findyMail or FullEnrich → waterfall).
 - `verifyEmail` — VERIFY stage, but off-default on price; the spine verifies with `waterfall.verifyEmail` (0.1).
 
+## Recurring use
+
+No scheduled fit — per-record enrichment only; findyMail earns its recurring keep as a gated rung inside a play.
+
+- **`findEmail` gate:** run only where `email` is still empty and the alternate 0.5 rung missed — alternates in a recurring play must stay waterfall-ordered, or every re-evaluation double-spends the tier (see anti-patterns).
+- **`findPhone` gate:** empty phone field **and** the qualified-lead condition — at 5/record, an ungated phone node re-firing on segment changes is the play's biggest cost risk.
+- **Stability:** found emails/phones don't improve on re-lookup — a filled row re-entering the segment should skip the node, which is exactly what the empty-field gates guarantee.
+
 ## Action shape
 
 `{"kind":"connector","integrationSlug":"findyMail","actionSlug":"<slug>","config":{}}`. **No `connectorUuid` in `config`.** Note the capitalization: `findyMail` (camel-case with capital `M`).

--- a/cargo-gtm/provider-playbooks/firecrawl.md
+++ b/cargo-gtm/provider-playbooks/firecrawl.md
@@ -83,6 +83,12 @@ cargo-ai orchestration action execute \
 
 Firecrawl's `crawl` also exists as an **extractor** — usable to sync a website into a connector-backed knowledge library (see the `cargo-content` skill) rather than as a one-off action.
 
+## Recurring use
+
+- **Scheduled fit: yes, for decaying pages.** A scheduled `crawl` of a niche job board (daily — hiring-intent cadence, see [`../recipes/save-as-play.md`](../recipes/save-as-play.md)) or a weekly `search` sweep works — but every run re-bills 0.05 per page/result returned, so keep `limit`/`maxDepth` as tight on run 50 as on run 1.
+- **Prefer the extractor for "keep this site fresh".** A recurring site sync is what the `crawl` extractor → knowledge library path is for (see Position in the waterfall), not a cron'd one-off action.
+- **In-play gate:** never crawl per-record (see Anti-patterns). For per-record `scrape`, gate on the scraped-markdown column still being empty so play re-evaluation doesn't re-fetch pages already stored.
+
 ## Action shape
 
 `{"kind":"connector","integrationSlug":"firecrawl","actionSlug":"<slug>","config":{}}`. **No `connectorUuid` in `config`.**

--- a/cargo-gtm/provider-playbooks/forager.md
+++ b/cargo-gtm/provider-playbooks/forager.md
@@ -69,3 +69,11 @@ cargo-ai orchestration action execute \
 
 - [`../recipes/re-engagement.md`](../recipes/re-engagement.md) — personal email revives contacts whose work address went stale (CONTACT step after the SIGNAL).
 - [`../recipes/job-change-monitoring.md`](../recipes/job-change-monitoring.md) — the job-change signal that makes personal-email lookup worth 2 credits.
+
+## Recurring use
+
+No scheduled fit — per-record enrichment only, priced too high (2–5) to re-pull on a timer.
+
+- **Natural trigger:** downstream of the job-change monitor ([`../recipes/job-change-monitoring.md`](../recipes/job-change-monitoring.md), every-2-weeks cadence per [`../recipes/save-as-play.md`](../recipes/save-as-play.md)) — run `findPersonalEmail` only on rows newly entering the "changed jobs" segment.
+- **In-play gate: attempt timestamp, not empty output.** Misses bill full price (see Common pitfalls), so "run where `personal_email` is empty" re-bills the same uncoverable rows on every re-evaluation — stamp a lookup-attempted-at column and gate on it.
+- **Stable data:** a found personal mailbox doesn't decay on a schedule; re-verify it before each send wave (VERIFY chain, 0.1) instead of re-finding.

--- a/cargo-gtm/provider-playbooks/g2.md
+++ b/cargo-gtm/provider-playbooks/g2.md
@@ -68,3 +68,9 @@ cargo-ai orchestration action execute \
 
 - [`../recipes/tech-intent.md`](../recipes/tech-intent.md) — the buyer-side counterpart; g2 covers the seller/review side of the same market.
 - [`../recipes/build-tam.md`](../recipes/build-tam.md) — category vendor lists as a TAM seed.
+
+## Recurring use
+
+- **Scheduled fit: the extractor, not the action.** `fetchProducts` is already the recurring surface — a periodic category snapshot with a hard 30-day minimum interval, so its floor overrides the weekly company-search default in [`../recipes/save-as-play.md`](../recipes/save-as-play.md); don't also cron `enrichProduct` to fake a faster feed.
+- **In-play gate for `enrichProduct`:** review data decays slowly — stamp a fetched-at column and re-enrich only rows older than the snapshot rhythm, never on empty-field alone once populated.
+- **Mind the 10 calls/min limit** (see Common pitfalls): a recurring `enrichProduct` sweep over a large vendor model will crawl — keep scheduled sets to the handful of products you actually track.

--- a/cargo-gtm/provider-playbooks/gemini.md
+++ b/cargo-gtm/provider-playbooks/gemini.md
@@ -71,3 +71,10 @@ cargo-ai orchestration action execute-batch \
 
 - [`../references/prompt-library/index.md`](../references/prompt-library/index.md) — the library's extraction/qualification/personalization prompts port unchanged; keep `temperature: 0` for the deterministic families.
 - [`../recipes/build-tam.md`](../recipes/build-tam.md) / [`../recipes/tech-intent.md`](../recipes/tech-intent.md) — high-volume classify/extract stages where Flash throughput pays off.
+
+## Recurring use
+
+- **The recurring shape is a play node, not a scheduled re-pull:** `instruct` as the classify/score/personalize step, gated on rows newly entering the segment or newly enriched — never re-prompt the whole model each evaluation.
+- **Per-row cost compounds with cadence:** the 500-row math in Cost traps repeats every run — a daily play on `gemini-2.5-flash` is ≈15 credits/day. Keep recurring nodes on Flash; pilot on Pro, demote before scheduling.
+- **`withWebSearch` is the compounding trap in a recurring node** — 0.4 fixed per call, every run. Ground only rows whose facts actually went stale.
+- **Idempotence gate:** write the output to a dedicated column and run only where it's still empty (or where an input-changed timestamp is newer than the output's).

--- a/cargo-gtm/provider-playbooks/hunter.md
+++ b/cargo-gtm/provider-playbooks/hunter.md
@@ -69,6 +69,14 @@ cargo-ai orchestration action execute-batch \
 - Every hit still flows to the VERIFY stage: free pre-cull ([`../references/contact-accuracy.md`](../references/contact-accuracy.md)) → `waterfall.verifyEmail` (0.1).
 - Demote dynamically: if hunter misses on the pilot's first ~10 rows, drop it behind peopleDataLabs for the rest of that batch.
 
+## Recurring use
+
+No scheduled fit — a found email is stable data; re-running `findEmail` on a timer re-bills rows that won't change.
+
+- **In-play gate:** rung 2 stays conditional inside the play — filter to rows where the FullEnrich email column AND the hunter email column are both still empty, so each row pays the 0.5 at most once per entry into the segment.
+- **Pre-send re-verify:** before each recurring send wave, re-verify stale finds with `waterfall.verifyEmail` (0.1) — never `hunter.verifyEmail` (1), per Anti-patterns — and gate on rows entering the wave, not a blanket timer over the whole list.
+- **Don't cron `searchDomain`:** the 10-record cap at 1 credit/call makes a scheduled loop the "don't loop it to build a list" pitfall on a timer.
+
 ## Action shape
 
 `{"kind":"connector","integrationSlug":"hunter","actionSlug":"<slug>","config":{}}`. **No `connectorUuid` in `config`.**

--- a/cargo-gtm/provider-playbooks/icypeas.md
+++ b/cargo-gtm/provider-playbooks/icypeas.md
@@ -81,6 +81,13 @@ Filters are coarse (title, company, location, keyword) — nothing like salesNav
 - `verifyEmail` — VERIFY-stage alternative to `waterfall.verifyEmail` for very large lists.
 - `findPeople` / `findCompanies` — SOURCE-stage alternative when LinkedIn-anchored search isn't viable.
 
+## Recurring use
+
+- **Scheduled sourcing fits:** a weekly `findPeople`/`findCompanies` pull (persona/company-search cadence, see [`../recipes/save-as-play.md`](../recipes/save-as-play.md)) is the cheapest recurring source at 0.02/record — dedupe new rows against the model before any paid enrichment runs downstream.
+- **Re-verify before send waves:** `verifyEmail` (0.01) is the natural pre-send gate — run it on rows entering the send segment or whose last verify is stale, never on a blanket timer over the whole list; even at 0.01, the free cull comes first (see Pattern A).
+- **In-play `findEmail` gate:** the last rung stays conditional — run only where the FullEnrich, hunter, AND peopleDataLabs email columns are all still empty. Found emails are stable data; never re-find on a schedule.
+- **Cadence × rate limit:** at 30 requests/minute (see Common pitfalls), large recurring batches run long — size scheduled pulls so one run finishes before the next fires.
+
 ## Action shape
 
 `{"kind":"connector","integrationSlug":"icypeas","actionSlug":"<slug>","config":{}}`. **No `connectorUuid` in `config`.**

--- a/cargo-gtm/provider-playbooks/kitt.md
+++ b/cargo-gtm/provider-playbooks/kitt.md
@@ -54,6 +54,14 @@ cargo-ai orchestration action execute \
 
 **VERIFY stage, budget rung.** `icypeas.verifyEmail` (0.01, bulk floor) → **kitt (0.05, cheap + diagnostics)** → `waterfall.verifyEmail` (0.1, priority default) → `zeroBounce.verifyEmail` (0.1, second opinion). See [`../references/stage-action-map.md`](../references/stage-action-map.md), Verify email.
 
+## Recurring use
+
+Verification recurs per **send wave**, not per calendar — no scheduled fit beyond that.
+
+- **Re-verify gate:** run `verifyEmail` (0.05) only on rows entering a send wave whose last clean verdict is stale — never on a blanket timer that re-bills the whole list.
+- **In-play gate:** filter to rows where the kitt `validity` output is still empty, or gate on a verify-timestamp column older than the wave threshold.
+- **Time-sensitivity:** verdicts decay slowly (mailboxes churn, not daily) — and when a pre-wave pass *is* due, the 100 calls/second rate limit keeps it fast.
+
 ## Action shape
 
 `{"kind":"connector","integrationSlug":"kitt","actionSlug":"verifyEmail","config":{}}`. **No `connectorUuid` in `config`.**

--- a/cargo-gtm/provider-playbooks/leadMagic.md
+++ b/cargo-gtm/provider-playbooks/leadMagic.md
@@ -68,6 +68,13 @@ Returns `profile_url`. Validate the URL with `linkedin.enrichProfile` before tru
 - Every hit flows to the VERIFY stage: free pre-cull → `waterfall.verifyEmail` (0.1). leadMagic has **no verify action of its own**.
 - `enrichProfile` — LinkedIn-URL-resolution fallback after `FullEnrich.reverseEmailLookup`.
 
+## Recurring use
+
+No scheduled fit — **per-record enrichment only**; found emails and profile URLs are stable, so a scheduled re-pull just re-bills unchanged rows.
+
+- **In-play gate:** as a chain rung, run `findEmail` (0.5) only where the email column is still empty *and* the earlier rung already missed; gate `enrichProfile` (3) on an empty LinkedIn-URL column.
+- **Right trigger:** the recurring shape here is a play fired by rows *entering* the segment (new prospects without an email), not a cron sweep over the whole model.
+
 ## Action shape
 
 `{"kind":"connector","integrationSlug":"leadMagic","actionSlug":"<slug>","config":{}}`. **No `connectorUuid` in `config`.** Note the capitalization: `leadMagic` (camel-case with capital `M`).

--- a/cargo-gtm/provider-playbooks/linkedin.md
+++ b/cargo-gtm/provider-playbooks/linkedin.md
@@ -120,6 +120,14 @@ Chain with `extractSimilarCompanies` (0.25) for a cheap lookalike seed list, or 
 - Posts / jobs / activity extraction — **SIGNAL stage**: engagement pools and personalization inputs; `searchJobs` sits beside `theirStack.searchJobs` (both 0.5) for hiring intent.
 - Engagement actions — post-VERIFY activation touches, outside the sourcing spine.
 
+## Recurring use
+
+Split by data half-life: **posts, jobs, and activity decay — profiles and company pages don't**.
+
+- **Scheduled pulls:** `searchJobs` daily (hiring intent) and `searchPosts` weekly, with `datePosted` matched to the cadence (`Past 24 hours` / `Past week`) so each run bills only the fresh window — cadence defaults in [`../recipes/save-as-play.md`](../recipes/save-as-play.md). Per-item activity pulls (`extractProfilePostActivity` et al., 0.05/item) fit a pre-outreach refresh, sized first per the per-item pitfall above.
+- **Don't re-pull stable pages:** `enrichProfile` / `enrichCompany` (0.25) on a timer re-bills unchanged rows; in a play, gate them on an empty enriched field.
+- **In-play gate:** run `findProfileUrl` only where the LinkedIn-URL column is still empty.
+
 ## Action shape
 
 `{"kind":"connector","integrationSlug":"linkedin","actionSlug":"<slug>","config":{}}`. **No `connectorUuid` in `config`.**

--- a/cargo-gtm/provider-playbooks/linkup.md
+++ b/cargo-gtm/provider-playbooks/linkup.md
@@ -69,6 +69,14 @@ Escalate to `depth: "deep"` only when standard came back empty or shallow — de
 
 **RESEARCH / fallback SOURCE.** Web research chain: `firecrawl` (0.05) for raw pages → **linkup** (0.5–2) for synthesized/structured answers → `serper` (1) for Google-shaped results. As a people/company source it's a fallback (0.5) when no structured provider has the data — see [`../references/stage-action-map.md`](../references/stage-action-map.md).
 
+## Recurring use
+
+Research answers are point-in-time — **recur only when the question itself moves**.
+
+- **Scheduled fit:** narrow. A weekly `instruct` re-ask over an account segment works for genuinely time-sensitive questions (pricing changes, launches); for static facts a re-run re-bills the same answer. Cadence defaults: [`../recipes/save-as-play.md`](../recipes/save-as-play.md).
+- **In-play gate:** write the structured output to a dedicated column and run only where it's still empty — or where a refreshed-at timestamp is older than the cadence — since `instruct` bills a flat 1 per row on every re-evaluation.
+- **Keep `depth: "standard"` in recurring nodes** — the deep-by-default trap above compounds on a schedule.
+
 ## Action shape
 
 `{"kind":"connector","integrationSlug":"linkup","actionSlug":"<slug>","config":{}}`. **No `connectorUuid` in `config`.**

--- a/cargo-gtm/provider-playbooks/mixrank.md
+++ b/cargo-gtm/provider-playbooks/mixrank.md
@@ -59,6 +59,13 @@ Stack every identifier you have per row — more keys, better match confidence a
 
 **ENRICH stage, last rung.** Person: `linkedin.enrichProfile` (0.25) → `cargo.enrichProspectDetails` (2) → `peopleDataLabs` (3) → **mixrank (4)**. Company: `waterfall.enrichCompany` / `oceanio.enrichCompany` (1) → `peopleDataLabs.enrichCompany` (3) → **mixrank (4)**. Promote it out of order only for the phone-keyed niche. See [`../references/stage-action-map.md`](../references/stage-action-map.md).
 
+## Recurring use
+
+No scheduled fit — **last-rung, per-record backfill only**; at 4 credits a recurring blanket pass is the fastest way to torch a budget.
+
+- **In-play gate:** double gate — run only where the cheaper rungs' output fields are still empty *and* at least one identifier is present (the no-required-fields pitfall means an empty row bills 4 credits on every re-evaluation).
+- **Time-sensitivity:** identity resolution is stable — re-running `findPerson` / `findCompany` on a matched row re-buys the same answer, and fixed-cost-on-miss means even a "retry later" pass must be deliberately scoped.
+
 ## Action shape
 
 `{"kind":"connector","integrationSlug":"mixrank","actionSlug":"<slug>","config":{}}`. **No `connectorUuid` in `config`.**

--- a/cargo-gtm/provider-playbooks/neverBounce.md
+++ b/cargo-gtm/provider-playbooks/neverBounce.md
@@ -57,6 +57,14 @@ Keep an email when either verifier passes it cleanly; drop it only when both agr
 
 **VERIFY stage, mid-premium rung — outside the default chain.** Default: free pre-cull → `waterfall.verifyEmail` (0.1) → `zeroBounce.verifyEmail` (0.1) second opinion → `icypeas.verifyEmail` (0.01) for bulk. `neverBounce.verifyEmail` (0.2) enters via own key or as a deliberate extra opinion.
 
+## Recurring use
+
+Verification recurs per **send wave**, not per calendar — at 0.2/row this is the costliest list to re-sweep on a timer.
+
+- **Re-verify gate:** run `verifyEmail` only on rows entering a send wave whose last clean verdict is stale — gate on a verify-timestamp column, never the whole list.
+- **In-play gate:** as the second-opinion rung, filter to rows the first verifier flagged catch-all/ambiguous (Pattern A) and where the neverBounce `result` column is still empty.
+- **Own key for standing use:** a play that re-verifies every wave multiplies the 2×-default cost trap — wire the own-key connector before making this a recurring step.
+
 ## Action shape
 
 `{"kind":"connector","integrationSlug":"neverBounce","actionSlug":"verifyEmail","config":{}}`. **No `connectorUuid` in `config`.**

--- a/cargo-gtm/provider-playbooks/oceanio.md
+++ b/cargo-gtm/provider-playbooks/oceanio.md
@@ -89,6 +89,14 @@ cargo-ai orchestration action execute-batch \
 - **ENRICH — mid-tier rung** (both enriches at 1): peer of `waterfall.enrichCompany` (1) and `apolloio.enrichOrganization` (1); pilot 10 rows to pick by coverage.
 - Sourced people flow on to CONTACT (`FullEnrich.findEmail`, 1) and VERIFY (`waterfall.verifyEmail`, 0.1) as usual.
 
+## Recurring use
+
+Lookalike discovery compounds — **re-run `searchCompanies` weekly as the seed list grows** (cadence table: [`../recipes/save-as-play.md`](../recipes/save-as-play.md)).
+
+- **Dedup before paid nodes:** each re-discovery returns known winners again — refresh `lookalikeDomains` with new Closed-Won domains, keep owned accounts in `excludeDomains`, and dedup hits against the Companies model before any downstream enrichment bills.
+- **Per-record billing recurs too:** `searchCompanies` bills per returned record on every scheduled run — hold `limit` at the approved scope so recurring pulls bill mostly-new rows.
+- **In-play gate:** `enrichCompany` / `enrichPerson` (1) run only where the target enriched field is still empty — firmographics are stable; re-enriching a filled row re-buys the same data.
+
 ## Action shape
 
 `{"kind":"connector","integrationSlug":"oceanio","actionSlug":"<slug>","config":{}}`. **No `connectorUuid` in `config`.**

--- a/cargo-gtm/provider-playbooks/openAi.md
+++ b/cargo-gtm/provider-playbooks/openAi.md
@@ -65,6 +65,13 @@ cargo-ai orchestration action execute-batch \
 
 - **The bulk rung** of [`../references/stage-action-map.md`](../references/stage-action-map.md) LLM section: pilot the prompt on `anthropic` Sonnet (~10 rows), then demote the batch to `gpt-5-nano`/`gpt-5-mini` per [`../references/cost-discipline.md`](../references/cost-discipline.md).
 
+## Recurring use
+
+No scheduled fit — `instruct` is an offline transform; the recurring shape is **a scoring/personalization/extraction node inside a play**, never a timed re-pull.
+
+- **In-play gate:** run only where the node's output column (score, extracted field, personalization line) is still empty — with `temperature: 0`, re-prompting an unchanged row returns the same answer and just re-bills. Trigger on newly-arrived or newly-enriched rows entering the segment.
+- **Cadence compounds cost:** per-row token spend × new rows × every cycle, forever — keep the play on the nano/mini tiers per the batch math above, and never leave `withWebSearch` on in a recurring node (fixed +0.4 × rows, every run). Cadence defaults: [`../recipes/save-as-play.md`](../recipes/save-as-play.md).
+
 ## Action shape
 
 `{"kind":"connector","integrationSlug":"openAi","actionSlug":"instruct","config":{"model":"…","output":{…}}}`. **No `connectorUuid` in `config`.** Costs above are the Cargo-credits rules; a workspace can instead attach its own OpenAI key (connector config takes a single required `apiKey`) and bill the provider directly.

--- a/cargo-gtm/provider-playbooks/peopleDataLabs.md
+++ b/cargo-gtm/provider-playbooks/peopleDataLabs.md
@@ -124,3 +124,10 @@ If cargo's filter shape can't express the criteria (e.g., array-membership filte
 - Step 7 (BACKFILL): canonical last-resort for missing emails / details.
 
 Never the first stop unless the filter shape demands it.
+
+## Recurring use
+
+**Never on a timer.** At a flat 3 credits per row, scheduled re-enrichment is the expensive recurring anti-pattern — it re-bills mostly unchanged data every cycle.
+
+- **In-play gate:** last rung only — `enrichPerson`/`enrichCompany` behind a gate requiring the target field still empty AND the cargo + waterfall rungs already missed (the escalation rule from Common pitfalls, enforced as a segment filter). Stamp an attempted-at column so a row PDL missed doesn't retry at 3 credits every re-evaluation.
+- **Scheduled search:** avoid recurring `searchX`/`queryX` — billed 3 per returned row on every run, with no incremental mode; a list that must refresh on a schedule belongs on a cheaper sourcing rung, with PDL reserved for the residue. Cadence table for the play wrapper: [`../recipes/save-as-play.md`](../recipes/save-as-play.md).

--- a/cargo-gtm/provider-playbooks/perplexity.md
+++ b/cargo-gtm/provider-playbooks/perplexity.md
@@ -62,6 +62,14 @@ cargo-ai orchestration action execute-batch \
 - **The web-grounded rung** of [`../references/stage-action-map.md`](../references/stage-action-map.md) LLM section; escalation path for facts: model data → `serper.search` (0.05) + cheap extract → `perplexity.instruct` when synthesis/citations are needed.
 - Gate batch research spend through [`../references/cost-discipline.md`](../references/cost-discipline.md) — pilot ~10 rows first.
 
+## Recurring use
+
+Web-grounded answers decay — **re-research is legitimate here**, but only on rows a fresh signal touched, never the whole segment on a timer.
+
+- **Recurring shape:** a `sonar`-low `instruct` node inside a signal-triggered play (funding, job change — see [`../recipes/funding-watch.md`](../recipes/funding-watch.md)), with `searchRecencyFilter` matched to the trigger cadence (weekly funding watch → `week`) so each answer covers only the new window. Cadence defaults: [`../recipes/save-as-play.md`](../recipes/save-as-play.md).
+- **In-play gate:** gate on timestamps, not empty-only — run where the signal's detected-at is newer than the row's last-researched column; stale answers *should* refresh, but only when a signal fires.
+- **Cost compounds:** 0.3–1 per row per cycle — keep the "research the account, not the contact list" dedupe from Cost traps: one call per company per signal, fanned out to contacts.
+
 ## Action shape
 
 `{"kind":"connector","integrationSlug":"perplexity","actionSlug":"instruct","config":{"model":"…","advancedSettings":{…}}}`. **No `connectorUuid` in `config`.** Costs above are the Cargo-credits rules; a workspace can instead attach its own Perplexity key (connector config takes a single required `apiKey`) and bill the provider directly.

--- a/cargo-gtm/provider-playbooks/piloterr.md
+++ b/cargo-gtm/provider-playbooks/piloterr.md
@@ -74,6 +74,14 @@ Configure the model's extractor with the cargo filter shape (note the `conjoncti
 
 **SOURCE stage, bulk/scheduled rung.** For recurring TAM refresh: **piloterr extractor (0.01/item)** → `salesNavigator.searchAccounts` (0.05, interactive) → `oceanio.searchCompanies` (1, lookalike/technographic) → `peopleDataLabs` (3, heavyweight filters). See [`../references/stage-action-map.md`](../references/stage-action-map.md).
 
+## Recurring use
+
+Recurring is **built in** — the `fetchCompanies` extractor *is* the scheduled pull, a model sync rather than a play node.
+
+- **Scheduled pull:** the extractor re-fetches on its own schedule — 14-day minimum interval, non-incremental, billing 0.01 × rows returned per fetch (~100 credits per 10,000-row refresh) — and re-fetches dedupe into the account model on `domain`/`linkedin_url` instead of duplicating. The 14-day floor overrides the weekly company-search default in [`../recipes/save-as-play.md`](../recipes/save-as-play.md).
+- **`getG2ProductInfo` on a schedule:** legitimate when the tracked product list changes — gate on the G2 output field being empty (or a stale scraped-at timestamp) so unchanged products aren't re-scraped, and mind the 30 calls/min limit.
+- **Time-sensitivity:** firmographics move slowly — a cadence tighter than the 14-day floor buys nothing.
+
 ## Action shape
 
 `{"kind":"connector","integrationSlug":"piloterr","actionSlug":"getG2ProductInfo","config":{}}`. **No `connectorUuid` in `config`.**

--- a/cargo-gtm/provider-playbooks/prospeo.md
+++ b/cargo-gtm/provider-playbooks/prospeo.md
@@ -72,6 +72,13 @@ cargo-ai orchestration action execute-batch \
 - `findEmail` — mid-tier CONTACT alternative alongside `hunter`/`findyMail`/`leadMagic` (all 0.5); every hit flows to the VERIFY stage (`waterfall.verifyEmail`, 0.1).
 - `enrichLinkedin` / `enrichCompany` — enrich-stage fillers when the identifier you hold matches their required input.
 
+## Recurring use
+
+No scheduled fit — per-record contact lookup only; recurring use means **paid nodes inside a play**, each behind an empty-field gate.
+
+- **In-play gate:** `findEmail` only where the email column is still empty; `findPhone` only where phone is empty AND the row is qualified (the cost-discipline gate applies per-run, forever, in a play). A miss escalates to the next chain rung — stamp an attempted-at column so it never retries prospeo on the next cycle.
+- **Time-sensitivity:** a found-and-verified email or phone is stable until the person moves — re-lookup belongs downstream of a job-change signal ([`../recipes/job-change-monitoring.md`](../recipes/job-change-monitoring.md)), not on a cadence. Play wrapper + cadence table: [`../recipes/save-as-play.md`](../recipes/save-as-play.md).
+
 ## Action shape
 
 `{"kind":"connector","integrationSlug":"prospeo","actionSlug":"<slug>","config":{}}`. **No `connectorUuid` in `config`.**

--- a/cargo-gtm/provider-playbooks/reverseContact.md
+++ b/cargo-gtm/provider-playbooks/reverseContact.md
@@ -60,6 +60,13 @@ The catalog dump documents no output schema for these actions — inspect the fi
 
 **ENRICH stage, niche fallback rung.** Default company chain: `cargo.enrichBusinessFirmographics` (0.5, after `matchBusiness`) → `waterfall.enrichCompany` (1) → `peopleDataLabs.enrichCompany` (3). `reverseContact.enrichCompanyFromLinkedin` (1) slots in only when the input is a LinkedIn company URL the stack couldn't resolve.
 
+## Recurring use
+
+No scheduled fit — a niche per-record fallback rung, never a re-pull.
+
+- **In-play gate:** `enrichCompanyFromLinkedin` runs only where the target firmographic fields are still empty, a LinkedIn company URL exists, and the cheaper chain already missed — firmographics are stable, so re-running unchanged rows re-bills 1 credit for identical data. Stamp an attempted-at column so misses don't retry each cycle.
+- **Own-key actions in plays:** `enrichProfileFromEmail` and friends draw down the workspace's Reverse Contact plan quota on every cycle — apply the same empty-field gating even though no cargo credits move. Play wrapper + cadence defaults: [`../recipes/save-as-play.md`](../recipes/save-as-play.md).
+
 ## Action shape
 
 `{"kind":"connector","integrationSlug":"reverseContact","actionSlug":"enrichCompanyFromLinkedin","config":{}}`. **No `connectorUuid` in `config`.**

--- a/cargo-gtm/provider-playbooks/rocketreach.md
+++ b/cargo-gtm/provider-playbooks/rocketreach.md
@@ -65,6 +65,13 @@ cargo-ai orchestration action execute \
 - `lookupPerson` — **ENRICH (person), 1-credit fallback rung** beside `apolloio.enrichPerson` (1), behind the stack's `cargo` (2) → `waterfall` (2) → `peopleDataLabs` (3) chain; promote it per-batch only when a pilot shows better niche coverage (healthcare especially).
 - Emails it surfaces flow to **VERIFY** before activation.
 
+## Recurring use
+
+No scheduled fit — `lookupPerson` is a per-record fallback lookup; there is nothing to poll.
+
+- **In-play gate:** run only where the priority stack already missed and the target contact columns (email, phone) are still empty; stamp an attempted-at column so misses don't retry at 1 credit every re-evaluation. The 250/min rate limit suits this residue-sized gating, not full-list sweeps.
+- **Time-sensitivity:** the person + company bundle is stable between job changes — a legitimate re-lookup is signal-triggered ([`../recipes/job-change-monitoring.md`](../recipes/job-change-monitoring.md)), and the `job_history` it returns can feed that very check. Play wrapper + cadence table: [`../recipes/save-as-play.md`](../recipes/save-as-play.md).
+
 ## Action shape
 
 `{"kind":"connector","integrationSlug":"rocketreach","actionSlug":"lookupPerson","config":{}}`. **No `connectorUuid` in `config`.**

--- a/cargo-gtm/provider-playbooks/salesNavigator.md
+++ b/cargo-gtm/provider-playbooks/salesNavigator.md
@@ -98,3 +98,9 @@ For people search niches salesNavigator misses:
 - **Local SMBs**: `serper.searchPlaces` (Google Maps).
 - **Tech-stack-driven**: `theirStack.searchCompanies`.
 - **Very specific role + industry combos with low LinkedIn coverage**: `peopleDataLabs.searchPeople`.
+
+## Recurring use
+
+- **Scheduled pull:** the weekly saved persona search is the canonical recurring source — re-run `searchLeads` / `extractLeadSearch` (same saved URL) on the weekly persona-search default; new matches accumulate slowly, so tighter cadences mostly return rows you already have. Cadence table: [`../recipes/save-as-play.md`](../recipes/save-as-play.md).
+- **Dedup gate:** search bills per **returned** record with no memory of prior pulls — dedup returned lead/account IDs against the model so only net-new rows flow to paid downstream nodes (find-email, enrich, verify).
+- **Stable snapshots:** `findEmployeesCount` / `findCompanyInsights` (0.25) drift over quarters, not weeks — refresh them on tracked accounts rarely and deliberately, never inside the weekly search play.

--- a/cargo-gtm/provider-playbooks/serper.md
+++ b/cargo-gtm/provider-playbooks/serper.md
@@ -73,3 +73,9 @@ Pipe the results into an LLM step (`anthropic.instruct`) to extract the fact you
 
 - [`../recipes/build-tam.md`](../recipes/build-tam.md) — the local-SMB sourcing variant.
 - [`../recipes/outreach-activation.md`](../recipes/outreach-activation.md) — quick public-web facts feeding the personalization step.
+
+## Recurring use
+
+- **Signal-triggered, not timer-driven.** Google results are live, so re-running `search` on a row that just fired a signal (funding, job change, site visit) is legitimate re-research; a blanket scheduled re-search of a whole list is the fan-out anti-pattern above wired to a cron.
+- **In-play gate:** filter to rows where the research output column is empty or the triggering signal is newer than the last search, so segment re-evaluation never re-bills settled rows.
+- **`searchPlaces` re-pulls:** local TAM churns slowly — if scheduled at all, re-run the same fixed query set (0.05 per query either way) and dedupe places against the Companies model before any paid enrichment runs downstream.

--- a/cargo-gtm/provider-playbooks/snitcher.md
+++ b/cargo-gtm/provider-playbooks/snitcher.md
@@ -65,6 +65,12 @@ Both UUIDs are **Snitcher's** identifiers (workspace = the tracked site; organis
 
 - **SIGNAL stage** — visitor identification sits beside job-change, funding, and tech-intent as a trigger source ([`../references/stage-action-map.md`](../references/stage-action-map.md)); identified accounts then enter the normal ENRICH → CONTACT → VERIFY → activation spine.
 
+## Recurring use
+
+- **The extractors are the recurring surface** — `fetchOrganisations` / `fetchSessions` already sync incrementally via `autoFetch` (≥30 min); no cron, and never wrap `searchSessions` in a scheduled tool to simulate a feed. The recurring cost trap is the `fetchOrganisations` pitfall above — re-read it before enabling on a high-traffic site.
+- **In-play gate:** trigger plays off the synced segment (e.g. `last_seen` this week), gating paid downstream enrichment on the account's enrichment fields being empty — a returning visitor re-enters the segment but must not re-bill the ENRICH chain.
+- **Decay:** visit intent fades in days; a play on the fresh-visit segment beats any scheduled sweep over historical visitors.
+
 ## Action shape
 
 `{"kind":"connector","integrationSlug":"snitcher","actionSlug":"searchSessions","config":{}}`. **No `connectorUuid` in `config`.**

--- a/cargo-gtm/provider-playbooks/societeInfo.md
+++ b/cargo-gtm/provider-playbooks/societeInfo.md
@@ -62,6 +62,12 @@ cargo-ai orchestration action execute \
 - `enrich` — **ENRICH (company/contact), French specialist rung**: outside the default chain; promote per-batch for French entities needing registry fields.
 - `search` — **SOURCE, French specialist**: registry-filtered sourcing feeding the normal ENRICH → VERIFY path (found contacts' emails still verify via `waterfall.verifyEmail`, 0.1).
 
+## Recurring use
+
+- **No schedule fit** — registry identity (registration number, NAF code, juridical form) is near-immutable; a scheduled re-`search` or re-`enrich` just re-bills 4 credits per unchanged row.
+- **Recurring role = in-play enrich node:** run `enrich` only on net-new French rows entering a play, gated on an empty `registrationNumber` column so segment re-evaluation never re-bills resolved rows.
+- **Filed financials move yearly at most** — if `minSales`/`minProfits`-derived fields need refreshing, do it as a rare, explicitly-approved capped batch, not a cadence.
+
 ## Action shape
 
 `{"kind":"connector","integrationSlug":"societeInfo","actionSlug":"<slug>","config":{}}`. **No `connectorUuid` in `config`.**

--- a/cargo-gtm/provider-playbooks/theSwarm.md
+++ b/cargo-gtm/provider-playbooks/theSwarm.md
@@ -74,3 +74,9 @@ cargo-ai orchestration action execute \
 
 - [`../recipes/account-expansion.md`](../recipes/account-expansion.md) — multi-threading a customer account through colleagues who already know the new buyers.
 - [`../recipes/outreach-activation.md`](../recipes/outreach-activation.md) — branch send-ready records: warm path → intro request, otherwise → sequencer.
+
+## Recurring use
+
+- **Re-checks can flip "no path" to "path"** — results improve as the team maps its network (see intro), so periodically re-running `searchWarmIntrosToCompany` on strategic accounts that previously returned no path is justified; keep it slow (monthly-ish) and only after the mapped network has actually grown.
+- **In-play gate:** 2 credits path-or-no-path — gate on account tier AND an empty warm-path result column; once a path is found, that row never re-bills, and re-checks target only the tier-1 no-path subset.
+- **Never a whole-TAM cron** — the whole-TAM-sweep warning above compounds on a schedule (10,000 credits per sweep, mostly "no path", every interval).

--- a/cargo-gtm/provider-playbooks/theirStack.md
+++ b/cargo-gtm/provider-playbooks/theirStack.md
@@ -112,3 +112,11 @@ After sourcing with theirStack, **enrich with cargo** rather than running theirS
 3. `cargo.enrichBusinessFirmographics` + `cargo.enrichBusinessTechnographics` → fill firmographic/tech detail (750 credits combined).
 
 Total: ~1,250 credits for 500 fully-enriched companies with intent signal. Cheaper than running peopleDataLabs (3 credits/record × 3 actions = 4,500 credits).
+
+## Recurring use
+
+Hiring intent decays in days — theirStack is **built for the monitor shape, not the one-off pull**.
+
+- **Scheduled pull:** re-run `searchJobs` / `searchCompanies` on the daily hiring-intent default, with `posted_at_max_age_days` matched to the cadence (daily → 1–2 days) so each run bills only postings that appeared since the last one, never the same window twice. Cadence table: [`../recipes/save-as-play.md`](../recipes/save-as-play.md).
+- **In-play gate:** dedup discovered companies against the Companies model via `cargo.matchBusiness` (the "combine with cargo native" pattern above) before any paid enrichment — a company re-posting the same role must not re-enter the enrich chain.
+- **Postings expire; stacks don't.** `searchTechnologies`-derived tech-stack fields are slow-moving — re-pull them on demand for a batch, not on the daily intent cadence.

--- a/cargo-gtm/provider-playbooks/waterfall.md
+++ b/cargo-gtm/provider-playbooks/waterfall.md
@@ -93,6 +93,12 @@ cargo-ai orchestration action execute-batch \
 - `enrichContact` / `enrichCompany` — **second rung**, after cargo native, before peopleDataLabs.
 - `findPhone` — **last rung** of the phone chain (after prospeo, FullEnrich). Demote any rung that misses on the pilot's first ~10 rows for the rest of the batch.
 
+## Recurring use
+
+- **`detectJobChange` is the canonical recurring signal** — save it as a play over the tracked-contact segment at the every-2-weeks default; the fresh-cadence anti-pattern above explains why tighter is pure re-billing at 3 credits/record. Cadence table: [`../recipes/save-as-play.md`](../recipes/save-as-play.md); full pattern: [`../recipes/job-change-monitoring.md`](../recipes/job-change-monitoring.md).
+- **`verifyEmail` recurs as verify-before-send** — a node at the top of each send-wave play, gated to rows entering the wave with a missing or stale verdict; never a standing timer over the whole model.
+- **In-play gate for enrichment:** `enrichContact` / `enrichCompany` (1–2 credits) gate on the target enrichment column being empty — segment re-evaluation must not re-bill filled rows; the underlying person/company data is stable enough that a blanket refresh buys nothing.
+
 ## Action shape
 
 `{"kind":"connector","integrationSlug":"waterfall","actionSlug":"<slug>","config":{}}`. **No `connectorUuid` in `config`.**

--- a/cargo-gtm/provider-playbooks/zeroBounce.md
+++ b/cargo-gtm/provider-playbooks/zeroBounce.md
@@ -74,3 +74,9 @@ Read `status` + `sub_status` for the verdict, `catchall_domain` / `free_email` f
 
 - [`../recipes/outreach-activation.md`](../recipes/outreach-activation.md) — the verify step before personalization; never sequence unverified emails.
 - [`../recipes/prospecting.md`](../recipes/prospecting.md) — the verify rung of the find → enrich → verify → sync spine.
+
+## Recurring use
+
+- **Re-verify before the send wave, not on a timer** — deliverability decays as people change jobs, so the recurring shape is a verify node inside each send play, gated to rows whose last verdict is missing or stale; a blanket cron over the whole model re-bills 0.1/row on addresses nobody is about to email.
+- **In-play gate:** filter on empty/stale `status` — plus the first verifier's ambiguous verdicts, per Pattern A — so play re-evaluation never re-bills freshly-verified rows.
+- **Second-opinion discipline holds on a schedule too:** recurring double-verification of rows waterfall already passed cleanly is the "double-verifying everything" pitfall above, compounding every cycle.

--- a/cargo-gtm/recipes/save-as-play.md
+++ b/cargo-gtm/recipes/save-as-play.md
@@ -30,6 +30,8 @@ Cadence defaults by signal type:
 
 A saved play spends credits **every run, forever**. Before deploying, extend the [approval gate](../references/cost-discipline.md): state *per-run cost × cadence = monthly burn* ("~1.1 credits/run, weekly → ~4.4/month") and get an explicit yes on the recurring number, not just the one-off.
 
+Also open the [provider playbook](../provider-playbooks/) of **every paid node** and read its **Recurring use** section — it carries the provider-specific cadence default, the filter gate that keeps re-runs from re-billing already-enriched rows, and any extractor alternative that replaces the scheduled pull entirely.
+
 ## Path A — save as a tool with a cron trigger
 
 ```bash

--- a/cargo-gtm/skill-metadata.json
+++ b/cargo-gtm/skill-metadata.json
@@ -468,5 +468,5 @@
       "kind": "script"
     }
   ],
-  "contentHash": "81161c6cd95b923c1a0f5944361639a4aa56f49d1b668140ad9db4aac04edd05"
+  "contentHash": "c79baf9f47cb4843585f19556f97eb66de2f91aac44b19e09091718780bd6e93"
 }

--- a/cargo/SKILL.md
+++ b/cargo/SKILL.md
@@ -279,7 +279,7 @@ The CLI exposes several domains that no capability skill wraps yet. Reach for th
 - `cargo-context` is **orthogonal** to the workflow-execution flow. It touches the git-backed GTM knowledge base (markdown/MDX), not storage or workflow runs. Use it for capturing/editing the workspace's prose context — personas, plays, proof, objections, signals — and for inspecting the typed knowledge graph.
 - For SQL queries against storage, use `cargo-ai storage query execute "<sql>"` (tables as `<datasetSlug>.<modelSlug>`). Load `cargo-storage` to discover dataset and model slugs, and to fetch the DDL when you need column types or the SQL dialect.
 - For SQL queries against orchestration runtime tables (`runs`, `batches`, `spans`, `records`) — error rates, per-node failures, time-series — use `cargo-ai orchestration query execute "<sql>"`. Workspace scoping is automatic; tables are referenced without a schema prefix.
-- Before building a workflow node graph, load `cargo-connection` to get `connectorUuid` and `actionSlug`.
+- Before building a workflow node graph, load `cargo-connection` to get `connectorUuid` and `actionSlug`. If any node calls a **credits-based provider action**, also load `cargo-gtm` and read that provider's playbook (`../cargo-gtm/provider-playbooks/<slug>.md`) — including its **Recurring use** section whenever the workflow is a scheduled tool or play, since a bad config or wrong cadence re-bills on every run. This applies even when the task arrived through `cargo-orchestration` or `cargo-cdk` directly, without a GTM framing.
 - Before executing a workflow that uses an agent node, load `cargo-ai` to get `agentUuid`.
 - After runs complete, load `cargo-analytics` to download results or measure performance. **For action output retrieval, prefer `cargo-ai orchestration run download-outputs` over `run download` — the former returns a signed-URL CSV/JSON of just the output node's data.**
 - Load `cargo-billing` to understand credit consumption for any of the above.
@@ -514,6 +514,10 @@ against the workspace) → author `define*` files → `cdk plan` (offline diff) 
 - **`--yes`** is required for non-interactive `deploy`/`destroy` (CI).
 - **Run `cargo-ai cdk types`** after workspace integrations change so config
   type-checks; typing is a bonus, deploy works without it.
+- **`definePlay`/`defineTool` graphs with credits-based connector actions:** read
+  the provider's playbook in `../cargo-gtm/provider-playbooks/` (esp. its
+  **Recurring use** section) before `cdk deploy` — a deployed play re-bills its
+  nodes on every scheduled run.
 
 **Recipes shipped:** `recipes/scaffold-a-workspace.md`, `add-connector-and-model.md`,
 `build-an-agent.md`, `migrate-existing-workspace.md`, `deploy-from-ci.md`.

--- a/cargo/skill-metadata.json
+++ b/cargo/skill-metadata.json
@@ -43,5 +43,5 @@
       "title": "UUID flow between skills"
     }
   ],
-  "contentHash": "5c7aa0b6f6a5f433c314a25e9e5883bfe6397fe3ae511504018c4566c534350c"
+  "contentHash": "d08c5791424d8859fd3404df7bfe0ba5191dc63efedac5caad6daee647fd7e8d"
 }


### PR DESCRIPTION
## What

Provider/integration suggestions in the pack were framed entirely around one-off `action execute` calls — only `waterfall.md` and `snitcher.md` said anything about recurring behavior, while the recipes route users into plays and monitors with no provider-level recurring guidance.

- **All 43 provider playbooks** now end with a `## Recurring use` section, tailored to each provider's actions and costs:
  - **Schedule fit** — whether a scheduled pull/monitor makes sense, which action, and the cadence default (linked to the `save-as-play.md` cadence table). Extractor-backed providers (snitcher, g2, piloterr) route recurring sync through the extractor instead of a cron.
  - **In-play gate** — the segment-filter that keeps a paid node idempotent so re-evaluation doesn't re-bill already-enriched rows (empty-field gates, attempted-at stamps, `cargo.matchBusiness` dedup).
  - **Data decay** — decaying data (postings, visits, web answers) justifies a cadence; stable data (emails, firmographics, registry records) on a timer is pure re-billing. Verification providers get the verify-before-send shape; LLM providers the gated scoring/personalization node; peopleDataLabs is explicitly "never on a timer".
- **`cargo-gtm/SKILL.md`** — §11 becomes "read before you call (one-off or recurring)": the playbook gate now applies before wiring a provider into a play/tool node graph, and the recurring-workflow routing row mandates the playbook of every paid node. §5 points at the new sections.
- **`recipes/save-as-play.md`** — the recurring-cost gate now sends you to each paid node's Recurring use section for cadence defaults, re-billing gates, and extractor alternatives.

## Why

A bad config in a one-off wastes one call; the same config in a play repeats every scheduled run, and a wrong cadence re-bills the same rows forever. The suggestion surfaces should carry that guidance where the provider choice is made.

## Verification

- All 43 playbooks carry exactly one `## Recurring use` section; existing content untouched (the only modified lines are the three SKILL.md framing edits and the save-as-play addition).
- All `../recipes/save-as-play.md` links resolve; costs/slugs cited come from each playbook's own tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to skill markdown and metadata hashes; no application code or API behavior changes.
> 
> **Overview**
> Provider suggestions were framed around one-off `action execute` calls while recipes push users into plays and cron tools—where a bad node config or cadence re-bills the same rows every run.
> 
> **Every credits-based provider playbook** now ends with a **`## Recurring use`** section: whether a scheduled pull/monitor fits (with links to `save-as-play.md` cadence defaults), **in-play gates** (empty-field filters, attempt timestamps, dedup via `cargo.match*`), and when data is stable vs decaying (emails/firmographics vs postings, visits, web answers). Extractor-backed providers (e.g. snitcher, g2, piloterr) steer recurring sync through extractors instead of fake cron actions.
> 
> **`cargo-gtm/SKILL.md`** extends the recurring-workflow routing row and §11 so playbooks—including **Recurring use**—must be read before wiring paid nodes; §5 points at those sections. **`recipes/save-as-play.md`**’s cost gate now sends deployers to each paid node’s playbook for cadence and re-billing gates.
> 
> **`cargo/SKILL.md`** requires reading the relevant playbook (especially **Recurring use**) before building node graphs with credits-based actions and before **`cdk deploy`** on `definePlay`/`defineTool` graphs. Skill metadata **content hashes** update accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb83b2577fb2e05c2886d259deb27bff072967b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->