### PR TITLE
Record which skills a session actually loaded

### DIFF
--- a/.github/workflows/skills-lint.yml
+++ b/.github/workflows/skills-lint.yml
@@ -55,6 +55,11 @@ jobs:
       - name: Check integration/provider names in descriptions are in sync
         run: node .github/scripts/sync-trigger-slugs.ts --check
 
+      # The session hooks write this marker into every Cargo session row, so a
+      # regression here corrupts telemetry silently rather than failing loudly.
+      - name: Run the skill-load detector's self-test
+        run: bash hooks/skill-loads.sh --self-test
+
   routing-evals:
     name: Route prompts to the right skill
     runs-on: ubuntu-latest

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,66 @@
+# Routing evals — and where the next cases come from
+
+An agent sees exactly one thing before deciding whether to load a skill: its `description`. Seventeen of them compete for every prompt. These evals are the regression test for that decision.
+
+## Running them
+
+```bash
+node .github/scripts/routing-eval.ts             # structural + lexical (gates CI)
+node .github/scripts/routing-eval.ts --verbose   # per-case scores
+node .github/scripts/routing-eval.ts --llm       # real model (needs ANTHROPIC_API_KEY)
+node .github/scripts/routing-eval.ts --strict    # gate on the hard tier too
+```
+
+The `--llm` tier runs in its own workflow (`.github/workflows/routing-evals-llm.yml`) on PRs touching a `SKILL.md`, weekly, and on demand. It reports to the run summary and fails below `--llm-min=93`.
+
+## The case file
+
+`routing.jsonl`, one JSON object per line:
+
+```json
+{"prompt": "…", "expect": "cargo-gtm", "why": "what this guards", "tier": "hard"}
+```
+
+- `expect` — the skill that should win.
+- `why` — optional, printed on failure. Write one whenever the case is non-obvious.
+- `tier` — `core` (default) gates CI; `hard` is a deep paraphrase reported but not gated, because the offline lexical ranker cannot judge those fairly. The `--llm` tier judges both.
+
+**Add a case whenever you change a description.** That is the whole contract: the change is the hypothesis, the case is the test.
+
+## The ceiling problem, and the fix
+
+The suite currently scores 100% on the model tier. That is a **ceiling effect, not a victory** — every prompt in here was written by someone who could see the descriptions they were grading, and several were added specifically to pin behavior that had just been implemented. A suite that always passes has stopped discovering anything.
+
+Prompts nobody wrote to pass have to come from real sessions. That is what `hooks/skill-loads.sh` is for.
+
+### Harvesting real cases
+
+The session hooks append a marker to each Cargo session's summary naming the skills and reference docs that session actually loaded:
+
+```
+[cargo-skills: cargo-gtm | docs: build-tam,waterfall]
+```
+
+Sessions live in `workspace_management.sessions`, so the marker is queryable:
+
+```bash
+# Which skills are actually loading, and how often?
+cargo-ai storage query execute "
+  SELECT title, summary
+  FROM workspace_management.sessions
+  WHERE summary LIKE '%cargo-skills:%'
+  ORDER BY created_at DESC
+  LIMIT 50"
+```
+
+Three questions worth asking of that data, each of which produces eval cases:
+
+1. **Which skills never load?** A skill with real usage everywhere else and zero loads has a description problem, not a capability problem. Its absence is the finding.
+2. **Which sessions loaded two or more skills before settling?** The first one loaded is a candidate misroute — the title tells you the prompt, and that pairing is a `hard` case with a known-correct answer.
+3. **Which skills load without any doc read following?** Either the skill answered on its own, or the agent bounced. Compare against sessions where a recipe was opened.
+
+Turn what you find into cases here, with a `why` that names the session it came from. Cases sourced from real transcripts are worth more than a dozen written from the descriptions, because they are the only ones that can surprise us.
+
+## What the marker does not contain
+
+Skill and document names only — all of them already public in this repository. Never a prompt, a file's contents, an argument, a record, or anything a user typed. See the header of `hooks/skill-loads.sh` for the exact matching rules.

--- a/hooks/session-checkpoint.sh
+++ b/hooks/session-checkpoint.sh
@@ -91,6 +91,16 @@ if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
   fi
 fi
 
+# Which skills this session has loaded so far — see hooks/skill-loads.sh.
+# Recomputed each checkpoint rather than accumulated, so the marker always
+# reflects the whole transcript and a session that ends abruptly still carries
+# it. Empty for sessions that never touched Cargo.
+MARKER=""
+if [ -x "$SCRIPT_DIR/skill-loads.sh" ]; then
+  MARKER="$(bash "$SCRIPT_DIR/skill-loads.sh" "$TRANSCRIPT_PATH" 2>/dev/null || true)"
+fi
+[ -n "$MARKER" ] && SUMMARY="$SUMMARY $MARKER"
+
 if cargo-ai workspaceManagement session upsert \
   --session-id "$SESSION_ID" \
   --title "$TITLE" \

--- a/hooks/session-end.sh
+++ b/hooks/session-end.sh
@@ -84,11 +84,21 @@ CLAUDE_BIN="$(command -v claude 2>/dev/null || true)"
 #    --finished even if the async refinement below never completes. The hook MUST
 #    return quickly — a blocking `claude -p` here is aborted during session
 #    teardown, which Claude Code reports as "Hook cancelled".
+#
+#    Include the skill marker in the placeholder summary so it persists even when
+#    refine() fails, times out, or is skipped. The marker is fast: no LLM call,
+#    just grep/sed on the transcript.
+PLACEHOLDER_SUMMARY="Session ended."
+if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ] && [ -x "$SCRIPT_DIR/skill-loads.sh" ]; then
+  PLACEHOLDER_MARKER="$(bash "$SCRIPT_DIR/skill-loads.sh" "$TRANSCRIPT_PATH" 2>/dev/null || true)"
+  [ -n "$PLACEHOLDER_MARKER" ] && PLACEHOLDER_SUMMARY="$PLACEHOLDER_SUMMARY $PLACEHOLDER_MARKER"
+fi
+
 if command -v cargo-ai >/dev/null 2>&1; then
   if cargo-ai workspaceManagement session upsert \
     --session-id "$SESSION_ID" \
     --title "Claude Code session ${SESSION_ID}" \
-    --summary "Session ended." \
+    --summary "$PLACEHOLDER_SUMMARY" \
     --finished >>"$LOG" 2>&1; then
     log "finalized $SESSION_ID with placeholder summary"
   else

--- a/hooks/session-end.sh
+++ b/hooks/session-end.sh
@@ -140,6 +140,16 @@ refine() {
     return 0
   fi
 
+  # Which skills the session actually loaded — see hooks/skill-loads.sh for
+  # what is and is not read. Appended to the summary because the session row
+  # has no structured field for it yet; empty for sessions that never touched
+  # Cargo, so non-Cargo sessions are unaffected.
+  MARKER=""
+  if [ -x "$SCRIPT_DIR/skill-loads.sh" ]; then
+    MARKER="$(bash "$SCRIPT_DIR/skill-loads.sh" "$TRANSCRIPT_PATH" 2>/dev/null || true)"
+  fi
+  [ -n "$MARKER" ] && PARSED_SUMMARY="$PARSED_SUMMARY $MARKER"
+
   if cargo-ai workspaceManagement session upsert \
     --session-id "$SESSION_ID" \
     --title "$PARSED_TITLE" \
@@ -152,7 +162,7 @@ refine() {
 }
 
 export -f refine log
-export SESSION_ID TRANSCRIPT_PATH CLAUDE_BIN LOG MODE
+export SESSION_ID TRANSCRIPT_PATH CLAUDE_BIN LOG MODE SCRIPT_DIR
 
 # Detach: prefer setsid, fall back to nohup. Redirect all fds so nothing keeps
 # the hook's stdio open and holds the session teardown.

--- a/hooks/skill-loads.sh
+++ b/hooks/skill-loads.sh
@@ -32,10 +32,14 @@ emit_marker() {
   # Skills invoked through the Skill tool — both model-chosen and user-typed
   # (`/cargo-gtm`). Plugin installs namespace them as `cargo:cargo-gtm`, so
   # strip the prefix and dedupe, or the same skill counts twice by channel.
+  #
+  # IMPORTANT: preserve load order (first occurrence wins) so the first skill
+  # in a multi-skill session is the misroute candidate. `awk '!seen[$0]++'`
+  # dedupes while keeping order, unlike `sort -u`.
   skills="$(
     grep -o '"skill":"\(cargo:\)\?cargo[a-z-]*"' "$transcript" 2>/dev/null |
       sed 's/.*"skill":"//; s/"$//; s/^cargo://' |
-      sort -u | paste -sd, - 2>/dev/null || true
+      awk '!seen[$0]++' | paste -sd, - 2>/dev/null || true
   )"
 
   # Reference docs opened underneath a skill — the deeper signal, because it
@@ -145,6 +149,16 @@ self_test() {
   check "cap is declared" \
     "[cargo-skills: docs: r01,r02,r03,r04,r05,r06,r07,r08,r09,r10,r11,r12,+2 more]" \
     "$(emit_marker "$tmp/h.jsonl")"
+
+  # 10. Load order is preserved — the first skill is the misroute candidate.
+  #     `cargo-enrich` comes before `cargo-gtm` alphabetically but after in
+  #     transcript order; must stay in load order.
+  {
+    printf '%s\n' '{"name":"Skill","input":{"skill":"cargo-gtm"}}'
+    printf '%s\n' '{"name":"Skill","input":{"skill":"cargo-enrich"}}'
+    printf '%s\n' '{"name":"Skill","input":{"skill":"cargo-gtm"}}'
+  } >"$tmp/i.jsonl"
+  check "skills preserve load order" "[cargo-skills: cargo-gtm,cargo-enrich]" "$(emit_marker "$tmp/i.jsonl")"
 
   [ "$fail" -eq 0 ] && printf '\nskill-loads.sh: all checks passed\n'
   return "$fail"

--- a/hooks/skill-loads.sh
+++ b/hooks/skill-loads.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Which Cargo skills did this session actually load?
+#
+# Routing — whether an agent picks the right skill for a request — is the thing
+# the whole bundle turns on, and until now it was argued rather than measured.
+# `evals/routing.jsonl` tests it against prompts we wrote ourselves, which
+# stops catching regressions once it saturates. Real sessions are the only
+# source of prompts nobody wrote to pass.
+#
+# This reads a Claude Code transcript and emits a one-line marker naming the
+# skills and reference docs that were loaded, which the session hooks append to
+# the row's summary.
+#
+# WHAT IT READS: tool-use records only. Skill invocations appear as
+#   {"name":"Skill","input":{"skill":"cargo-gtm"}}
+# and reference reads as file paths ending in SKILL.md, recipes/*.md, or
+# provider-playbooks/*.md.
+#
+# WHAT IT NEVER EMITS: prompts, file contents, record data, arguments, or
+# anything a user typed. Only names that already exist in this public repo.
+#
+# Usage:  skill-loads.sh <transcript-path>     # prints the marker, or nothing
+#         skill-loads.sh --self-test           # fixture check, used by CI
+set -u
+
+MARKER_PREFIX="cargo-skills:"
+
+emit_marker() {
+  transcript="$1"
+  [ -n "$transcript" ] && [ -f "$transcript" ] || return 0
+
+  # Skills invoked through the Skill tool — both model-chosen and user-typed
+  # (`/cargo-gtm`). Plugin installs namespace them as `cargo:cargo-gtm`, so
+  # strip the prefix and dedupe, or the same skill counts twice by channel.
+  skills="$(
+    grep -o '"skill":"\(cargo:\)\?cargo[a-z-]*"' "$transcript" 2>/dev/null |
+      sed 's/.*"skill":"//; s/"$//; s/^cargo://' |
+      sort -u | paste -sd, - 2>/dev/null || true
+  )"
+
+  # Reference docs opened underneath a skill — the deeper signal, because it
+  # says which recipe or playbook the routing actually landed on.
+  #
+  # This MUST be anchored to a `"file_path":` tool input. Matching the bare
+  # path anywhere in the transcript looks equivalent and is not: a skill's own
+  # catalog table lists every recipe and playbook by name, so loading cargo-gtm
+  # once would report all 43 playbooks as "read" and the signal would be noise.
+  docs_all="$(
+    grep -oE '"file_path":"[^"]*/(recipes|provider-playbooks|guides)/[a-zA-Z0-9._-]+\.md"' "$transcript" 2>/dev/null |
+      sed 's#.*/##; s#\.md"$##' |
+      sort -u || true
+  )"
+  # `grep -c` exits 1 on no matches, so a `|| echo 0` fallback would append a
+  # second count rather than replace it. Count non-empty lines directly.
+  if [ -n "$docs_all" ]; then
+    docs_count="$(printf '%s\n' "$docs_all" | wc -l | tr -d ' ')"
+  else
+    docs_count=0
+  fi
+  docs="$(printf '%s' "$docs_all" | head -12 | paste -sd, - 2>/dev/null || true)"
+  # Never truncate silently — a capped list that looks complete is worse than
+  # one that admits it was capped.
+  [ "$docs_count" -gt 12 ] && docs="$docs,+$((docs_count - 12)) more"
+
+  [ -n "$skills" ] || [ -n "$docs" ] || return 0
+
+  # Each half is optional: a session can read a recipe without a Skill call
+  # (following a link), or invoke a skill without opening a sub-doc.
+  if [ -n "$skills" ] && [ -n "$docs" ]; then
+    printf '[%s %s | docs: %s]' "$MARKER_PREFIX" "$skills" "$docs"
+  elif [ -n "$skills" ]; then
+    printf '[%s %s]' "$MARKER_PREFIX" "$skills"
+  else
+    printf '[%s docs: %s]' "$MARKER_PREFIX" "$docs"
+  fi
+}
+
+self_test() {
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' EXIT
+  fail=0
+
+  check() {
+    label="$1"; want="$2"; got="$3"
+    if [ "$got" = "$want" ]; then
+      printf 'ok    %s\n' "$label"
+    else
+      printf 'FAIL  %s\n        want: %s\n        got:  %s\n' "$label" "$want" "$got"
+      fail=1
+    fi
+  }
+
+  # 1. A plain skill invocation.
+  printf '%s\n' '{"name":"Skill","input":{"skill":"cargo-gtm"}}' >"$tmp/a.jsonl"
+  check "single skill" "[cargo-skills: cargo-gtm]" "$(emit_marker "$tmp/a.jsonl")"
+
+  # 2. Plugin namespacing must collapse onto the bare name, not double-count.
+  {
+    printf '%s\n' '{"name":"Skill","input":{"skill":"cargo:cargo-gtm"}}'
+    printf '%s\n' '{"name":"Skill","input":{"skill":"cargo-gtm"}}'
+  } >"$tmp/b.jsonl"
+  check "plugin namespace dedupes" "[cargo-skills: cargo-gtm]" "$(emit_marker "$tmp/b.jsonl")"
+
+  # 3. Reference docs are reported alongside, sorted and deduped.
+  {
+    printf '%s\n' '{"name":"Skill","input":{"skill":"cargo-gtm"}}'
+    printf '%s\n' '{"file_path":"/x/cargo-gtm/recipes/build-tam.md"}'
+    printf '%s\n' '{"file_path":"/x/cargo-gtm/provider-playbooks/waterfall.md"}'
+    printf '%s\n' '{"file_path":"/x/cargo-gtm/recipes/build-tam.md"}'
+  } >"$tmp/c.jsonl"
+  check "skills + docs" "[cargo-skills: cargo-gtm | docs: build-tam,waterfall]" "$(emit_marker "$tmp/c.jsonl")"
+
+  # 4. A session that never touched Cargo emits nothing at all — no marker,
+  #    no empty brackets polluting the summary.
+  printf '%s\n' '{"name":"Bash","input":{"command":"ls"}}' >"$tmp/d.jsonl"
+  check "no cargo usage → empty" "" "$(emit_marker "$tmp/d.jsonl")"
+
+  # 5. Non-cargo skills are not ours to report.
+  printf '%s\n' '{"name":"Skill","input":{"skill":"code-review"}}' >"$tmp/e.jsonl"
+  check "foreign skill ignored" "" "$(emit_marker "$tmp/e.jsonl")"
+
+  # 6. A missing transcript must not error — hooks never block a session.
+  check "missing file → empty" "" "$(emit_marker "$tmp/does-not-exist.jsonl")"
+
+  # 7. THE ONE REAL DATA CAUGHT AND FIXTURES DID NOT. A skill's catalog table
+  #    names every recipe and playbook in prose. Those mentions are not reads,
+  #    and counting them reported all 43 playbooks for a single skill load.
+  {
+    printf '%s\n' '{"name":"Skill","input":{"skill":"cargo-gtm"}}'
+    printf '%s\n' '{"text":"| [recipes/build-tam.md](recipes/build-tam.md) | Building a TAM list |"}'
+    printf '%s\n' '{"text":"see provider-playbooks/waterfall.md for the fallback chain"}'
+  } >"$tmp/f.jsonl"
+  check "prose mentions are not reads" "[cargo-skills: cargo-gtm]" "$(emit_marker "$tmp/f.jsonl")"
+
+  # 8. Docs without a Skill call — following a link straight to a recipe —
+  #    must not leave a dangling "cargo-skills:" with nothing after it.
+  printf '%s\n' '{"file_path":"/x/cargo-gtm/recipes/build-tam.md"}' >"$tmp/g.jsonl"
+  check "docs only, no dangling prefix" "[cargo-skills: docs: build-tam]" "$(emit_marker "$tmp/g.jsonl")"
+
+  # 9. Over the cap, the marker says so rather than looking complete.
+  : >"$tmp/h.jsonl"
+  for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14; do
+    printf '{"file_path":"/x/cargo-gtm/recipes/r%02d.md"}\n' "$i" >>"$tmp/h.jsonl"
+  done
+  check "cap is declared" \
+    "[cargo-skills: docs: r01,r02,r03,r04,r05,r06,r07,r08,r09,r10,r11,r12,+2 more]" \
+    "$(emit_marker "$tmp/h.jsonl")"
+
+  [ "$fail" -eq 0 ] && printf '\nskill-loads.sh: all checks passed\n'
+  return "$fail"
+}
+
+case "${1:-}" in
+  --self-test) self_test ;;
+  "") exit 0 ;;
+  *) emit_marker "$1" ;;
+esac


### PR DESCRIPTION
Routing is the thing this bundle turns on, and it has been **argued rather than measured**.

`evals/routing.jsonl` now scores 100% on the real-model tier. That's a ceiling effect, not a victory — every prompt in it was written by someone looking at the descriptions they were grading, and several were added to pin behavior that had just been implemented. A suite that always passes has stopped discovering anything.

Prompts nobody wrote to pass have to come from real sessions. This makes those observable.

## What it does

`hooks/skill-loads.sh` reads a Claude Code transcript and emits a marker naming what the session actually loaded:

```
[cargo-skills: cargo-gtm | docs: build-tam,waterfall]
```

Both session hooks append it to the row's summary, so it's queryable **today** over `workspace_management.sessions` with no schema change:

```sql
SELECT title, summary FROM workspace_management.sessions
WHERE summary LIKE '%cargo-skills:%' ORDER BY created_at DESC
```

`evals/README.md` documents the three questions that data answers, each of which produces eval cases:

1. **Which skills never load?** Zero loads with real usage elsewhere is a description problem, not a capability problem — the absence *is* the finding.
2. **Which sessions loaded two skills before settling?** The first is a candidate misroute, and the title tells you the prompt. That's a `hard` case with a known-correct answer.
3. **Which skills load with no doc read after?** Either the skill answered alone, or the agent bounced.

## Two bugs the fixtures passed and real transcripts caught

I ran this against real transcripts before trusting it, which was the right call:

- **Prose mentions counted as reads.** The doc regex matched a bare path anywhere in the transcript — and a skill's own catalog table names every recipe and playbook. One `cargo-gtm` load reported **all 43 playbooks** as opened. Now anchored to a `"file_path":` tool input; fixture 7 is that exact case.
- **Dangling prefix** when docs were read without a Skill call: `[cargo-skills: | docs: …]`. Both halves are now independently optional.

The doc list also caps at 12 and says `+N more` rather than looking complete.

## Privacy

**Skill and document names only** — all of them already public in this repository. Never a prompt, file contents, an argument, a record, or anything a user typed. Sessions that never touch Cargo emit nothing at all. The exact matching rules are in the script header.

## On the shape

Packing structured data into a free-text `summary` is deliberately an interim: the session row has no field for it, and I'd rather earn a column with evidence than ask for one on a hunch. If the data proves useful, the proper fix is `session upsert --skills-loaded` backed by a real column, and this becomes its migration source.

Self-test wired into `skills-lint` — a regression here would corrupt telemetry silently rather than fail loudly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session summary content on every Cargo checkpoint/end path; marker parsing bugs would corrupt queryable telemetry silently, though CI self-tests and fail-open hook behavior limit blast radius.
> 
> **Overview**
> Adds **`hooks/skill-loads.sh`**, which parses Claude Code transcripts for Skill tool invocations and real `"file_path"` reads under recipes/playbooks/guides, then emits a compact marker like `[cargo-skills: cargo-gtm | docs: build-tam,waterfall]` (public skill/doc names only, load order preserved, doc list capped with `+N more`).
> 
> **`session-checkpoint.sh`** and **`session-end.sh`** append that marker to each `workspace_management.sessions` summary on checkpoint and on both the fast placeholder finalize and the async LLM refine, so routing telemetry survives refine failures without a schema change.
> 
> The detector avoids false positives by requiring `"file_path":` for doc reads (not prose mentions in skill catalogs) and handles plugin namespacing, docs-only sessions, and non-Cargo sessions (no marker). **`skills-lint`** CI runs `skill-loads.sh --self-test`; **`evals/README.md`** documents querying markers and turning real sessions into routing eval cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0509f8beda91ea880f3c1015c99f6dbd1ea88cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->