### PR TITLE
Publish every skill to ClawHub, not the fifteen someone remembered

### DIFF
--- a/.github/workflows/clawhub-publish.yml
+++ b/.github/workflows/clawhub-publish.yml
@@ -50,9 +50,13 @@ jobs:
           skipped=0
           failed=0
 
-          for dir in cargo cargo-quickstart cargo-gtm cargo-cdk cargo-orchestration cargo-storage \
-                     cargo-connection cargo-ai cargo-content cargo-context cargo-analytics \
-                     cargo-billing cargo-diagnostics cargo-hosting cargo-workspace-management; do
+          # Discovered from the tree rather than hand-listed. The previous list
+          # silently omitted cargo-segmentation and cargo-observability, so two
+          # shipped skills never reached the registry at all.
+          for dir in */; do
+            dir="${dir%/}"
+            [ -f "$dir/SKILL.md" ] || continue
+
             version=$(awk -F'"' '/^version:/ {print $2; exit}' "$dir/SKILL.md")
             if [ -z "$version" ]; then
               echo "::error::No version: in $dir/SKILL.md"


### PR DESCRIPTION
`clawhub-publish.yml` hand-listed the directories it publishes, and the list had fallen two behind the tree.

**`cargo-segmentation` and `cargo-observability` have never been published to the registry.** Both ship in the bundle, both are in `llms.txt`, neither is installable from ClawHub.

## The fix

Discover the set from `*/SKILL.md` instead of naming it. Adding a skill now publishes it — no second place to remember.

Verified locally against the real tree; the loop resolves all 17 with versions, including the two that were missing:

```
cargo@1.18.1  cargo-ai@2.2.1  cargo-analytics@1.4.3  cargo-billing@1.0.3
cargo-cdk@1.2.1  cargo-connection@1.2.1  cargo-content@1.0.1  cargo-context@1.2.1
cargo-diagnostics@1.0.2  cargo-gtm@1.12.0  cargo-hosting@1.0.1
cargo-observability@1.0.1  cargo-orchestration@1.6.1  cargo-quickstart@1.0.1
cargo-segmentation@1.0.0  cargo-storage@1.2.1  cargo-workspace-management@1.2.1
```

Already-published versions are skipped by the existing `already exists` branch, so the first run after merge publishes exactly the two that are missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only discovery change with no auth or runtime impact; first run may publish two previously missing skill versions, with existing versions still skipped as duplicates.
> 
> **Overview**
> The **ClawHub publish** workflow no longer loops over a fixed list of skill folder names. It now walks top-level `*/` directories and publishes any that contain a `SKILL.md`, using the same version parsing and publish/skip logic as before.
> 
> This fixes **`cargo-segmentation`** and **`cargo-observability`** never being published because they were missing from the hand-maintained list. New skills in the repo are picked up automatically without updating the workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f351c55a7b07fe04987f83968c0f2a370b62af8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->