### PR TITLE
Let the routing evals grade any skill set

### DIFF
--- a/.github/scripts/routing-eval.ts
+++ b/.github/scripts/routing-eval.ts
@@ -12,6 +12,11 @@
  *                                                     (needs ANTHROPIC_API_KEY)
  *   node .github/scripts/routing-eval.ts --llm --llm-min=90   # gate on a floor
  *
+ * Grade a different skill set — any directory of `<name>/SKILL.md`, with its
+ * cases at `<root>/evals/routing.jsonl` unless `--cases` says otherwise:
+ *
+ *   node .github/scripts/routing-eval.ts --skills-root ../gtm-skills
+ *
  * Three tiers:
  *
  *  1. STRUCTURAL — every description obeys the four-part template documented in
@@ -39,10 +44,22 @@ import { join, dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
-const casesPath = join(repoRoot, "evals/routing.jsonl");
 const verbose = process.argv.includes("--verbose");
 const withLlm = process.argv.includes("--llm");
 const strict = process.argv.includes("--strict");
+
+function argValue(flag: string): string | undefined {
+  const i = process.argv.indexOf(flag);
+  return i !== -1 ? process.argv[i + 1] : undefined;
+}
+
+/**
+ * Which skill set to grade. Defaults to this repo, but any directory of
+ * `<name>/SKILL.md` works — the standalone gtm-skills repo competes for the
+ * same prompts from the same descriptions, and deserves the same test.
+ */
+const skillsRoot = resolve(argValue("--skills-root") ?? repoRoot);
+const casesPath = resolve(argValue("--cases") ?? join(skillsRoot, "evals/routing.jsonl"));
 
 /** Cheapest capable model — this is a routing judgement, not a reasoning task. */
 const LLM_MODEL = process.env.ROUTING_EVAL_MODEL ?? "claude-haiku-4-5-20251001";
@@ -100,9 +117,9 @@ function tokenize(text: string): string[] {
 
 function loadSkills(): Skill[] {
   const skills: Skill[] = [];
-  for (const entry of readdirSync(repoRoot)) {
-    const skillMd = join(repoRoot, entry, "SKILL.md");
-    if (!statSync(join(repoRoot, entry), { throwIfNoEntry: false })?.isDirectory()) continue;
+  for (const entry of readdirSync(skillsRoot)) {
+    const skillMd = join(skillsRoot, entry, "SKILL.md");
+    if (!statSync(join(skillsRoot, entry), { throwIfNoEntry: false })?.isDirectory()) continue;
     if (!existsSync(skillMd)) continue;
     const lines = readFileSync(skillMd, "utf8").split("\n");
     let name = "";
@@ -188,7 +205,7 @@ function loadCases(): Case[] {
       try {
         return JSON.parse(l) as Case;
       } catch (e) {
-        throw new Error(`evals/routing.jsonl line ${i + 1} is not valid JSON: ${(e as Error).message}`);
+        throw new Error(`${casesPath} line ${i + 1} is not valid JSON: ${(e as Error).message}`);
       }
     });
 }


### PR DESCRIPTION
`getcargohq/gtm-skills` ships 12 standalone, single-job skills as an acquisition surface — job-named (`find-work-email`, `find-stakeholders`) so they are found by people searching a registry for the job rather than for Cargo. They route from the same four-part descriptions this repo's evals were built to protect, and they had no test, because the ranker was hardwired to this repo's layout.

They are also the set most likely to need one. `find-work-email`, `enrich-linkedin-profile`, and `find-linkedin-url` are deliberately adjacent — that is what makes them findable, and what makes them liable to drift into each other.

## What changed

`--skills-root <dir>` grades any directory of `<name>/SKILL.md`. Cases default to `<root>/evals/routing.jsonl`; `--cases` overrides. Three call sites moved from `repoRoot` to `skillsRoot`, and the JSON parse error now names the file it actually read.

```bash
node .github/scripts/routing-eval.ts                              # 17 skills, 81/81 core
node .github/scripts/routing-eval.ts --skills-root ../gtm-skills  # 12 skills, 56/56 core
```

Default behaviour is unchanged — same 17 skills, same 81/81, same hard tier.

## On that 56/56

It is a ceiling effect, exactly as `evals/README.md` describes: every case was generated from the trigger phrases it grades. It proves the triggers do not collide. It does not prove the descriptions route. The `hard` cases have to come from real sessions — which is what the `[gtm-skills: <name>]` session marker (same grammar as #78) is there to make harvestable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev/CI tooling only; default paths and gating behavior are unchanged, so merge risk is minimal.
> 
> **Overview**
> The routing eval harness was tied to this repository’s layout; it can now **grade any skill bundle** that follows the same `<name>/SKILL.md` structure.
> 
> New CLI flags **`--skills-root <dir>`** (where skills are discovered) and **`--cases <path>`** (JSONL cases; default `<skills-root>/evals/routing.jsonl`). A small **`argValue`** helper parses argv. **`loadSkills`** and case loading use these roots instead of always using `repoRoot`, and JSON parse errors cite the **actual cases file** path.
> 
> **Default behavior is unchanged** — omitting the flags still runs the same 17 skills and `evals/routing.jsonl` in CI. Example: `node .github/scripts/routing-eval.ts --skills-root ../gtm-skills` for the standalone gtm-skills repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a96192f429acd8c6f062a4a9eec794ab91d643d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->