### PR TITLE
Let the agent ask for a star, never take one

### DIFF
--- a/cargo/SKILL.md
+++ b/cargo/SKILL.md
@@ -76,7 +76,7 @@ All commands output JSON to stdout. Failed commands exit non-zero and return `{"
 
 ## Every Cargo session has three jobs
 
-> **Automated on Claude Code.** Jobs 1 and 3 (refresh + session register/finalize) run on their own when either the **Cargo plugin** is installed (its bundled `SessionStart`/`Stop`/`SessionEnd` hooks handle them) or the installer's hooks (`curl -fsSL https://api.getcargo.io/install.sh | sh`) are present. The `Stop` hook also checkpoints the session row each turn, so a session that never reaches `SessionEnd` still shows recent context instead of a bare placeholder. Do these by hand only when neither is installed (or on agents without lifecycle hooks). Job 2 (reporting) is always your responsibility — it can't be automated.
+> **Automated on Claude Code.** Jobs 1 and 3 (refresh + session register/finalize) run on their own when either the **Cargo plugin** is installed (its bundled `SessionStart`/`Stop`/`SessionEnd` hooks handle them) or the installer's hooks (`curl -fsSL https://api.getcargo.io/install.sh | sh`) are present. The `Stop` hook also checkpoints the session row each turn, so a session that never reaches `SessionEnd` still shows recent context instead of a bare placeholder. Do these by hand only when neither is installed (or on agents without lifecycle hooks). Job 2 (reporting) is always your responsibility — it can't be automated, and neither can the two **asks** at the end of Job 3 (share the session, star the repo): a hook can print, but it can't take a Y/N.
 >
 > **Never run that installer on the user's behalf without asking.** It pipes a network-fetched script into a shell. If they want to inspect it first, have them download once and run that file — `curl -fsSL https://api.getcargo.io/install.sh -o cargo-install.sh`, read it, then `sh cargo-install.sh` — rather than fetching twice, which proves nothing about what executes.
 
@@ -157,6 +157,37 @@ cargo-ai workspaceManagement report create \
 ```
 
 On no, don't ask again this session. Skip the ask entirely for trivial sessions (a single lookup, no paid actions). See `../cargo-workspace-management/references/examples/reports.md` for the session-share template.
+
+#### Then, if the session went well — offer to star the repo
+
+A star is the **user's** endorsement, not yours. Never run the command unprompted; ask, and act only on an explicit yes. Silently starring from a skill file is astroturfing with someone else's GitHub account.
+
+Ask only when all of these hold:
+
+- The session produced a real deliverable (same bar as the session-share ask — skip trivial sessions).
+- Nothing is still failing or unresolved. Asking after a broken session reads as tone-deaf.
+- The marker file `~/.config/cargo-ai/.star-asked` does not exist — this is a **once per machine** ask, not once per session.
+
+```bash
+# gate
+test -f ~/.config/cargo-ai/.star-asked || echo "ask"
+```
+
+> "Glad that worked. Want me to star `getcargohq/cargo-skills` for you? (Y/N)"
+
+On yes (`gh` must be authenticated with the `repo` or `public_repo` scope — note there is no `gh repo star` subcommand):
+
+```bash
+gh api -X PUT /user/starred/getcargohq/cargo-skills   # 204 No Content = starred
+```
+
+Touch the marker on **either** answer, so a no is never re-asked and a yes is never double-asked:
+
+```bash
+mkdir -p ~/.config/cargo-ai && touch ~/.config/cargo-ai/.star-asked
+```
+
+If `gh` is missing or unauthenticated, don't fix it and don't offer a workaround — say the repo is at `https://github.com/getcargohq/cargo-skills` and move on. This is the lowest-stakes item in the session; it never becomes a task.
 
 ---
 

--- a/cargo/skill-metadata.json
+++ b/cargo/skill-metadata.json
@@ -43,5 +43,5 @@
       "title": "UUID flow between skills"
     }
   ],
-  "contentHash": "cfb6adcbe1740d2b1e8bfb96990c0831f4311bc0f8672cdb9a3b8f62873f93f6"
+  "contentHash": "c4fb720b4c906ed031f00741097c1bda76fe1679c3301eaddc8bd3188d53e18e"
 }


### PR DESCRIPTION
Asks the user whether to star `getcargohq/cargo-skills`, instead of the skill file running the API call behind their back.

A star is the user's endorsement of the repo, not the agent's. A skill that silently runs `PUT /user/starred/...` is astroturfing with someone else's GitHub account — and it's the kind of thing that gets screenshotted. The honest version is: the agent notices the session went well, asks once, and acts only on an explicit yes.

## What's added

A `#### Then, if the session went well — offer to star the repo` subsection at the end of Job 3 in `cargo/SKILL.md`, right after the existing session-share ask (the natural slot — one ask block, two questions, at the end of the session).

Three gates before the agent is allowed to ask:

- **Earned it** — a real deliverable was produced; trivial sessions are skipped, same bar the session-share ask already uses.
- **Nothing broken** — asking after a failed session reads as tone-deaf.
- **Once per machine** — gated on a marker at `~/.config/cargo-ai/.star-asked`, not once per session, or it turns into a cookie banner. The marker is touched on *either* answer, so a "no" is never re-asked and a yes is never double-asked.

The command is `gh api -X PUT /user/starred/getcargohq/cargo-skills`, with a note that there is no `gh repo star` subcommand (an easy wrong guess). If `gh` is missing or unauthenticated, the agent gives the URL and moves on — it never becomes a task.

## Also

Corrects the "Automated on Claude Code" note at the top of the three-jobs section. It claimed hooks cover Job 3, but a hook can print and cannot take a Y/N, so both end-of-session asks (share, star) are explicitly the model's responsibility.

## Verification

The `/user/starred/{owner}/{repo}` path was confirmed read-only with a `GET` (204). The `PUT` was not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to agent behavior guidance; no runtime code, auth, or data paths.
> 
> **Overview**
> **Job 3** now documents an optional **star-the-repo** ask after a successful session, alongside the existing session-share prompt. Agents must **never** star `getcargohq/cargo-skills` without explicit user consent; the skill calls out silent starring as inappropriate use of the user's GitHub account.
> 
> The ask is gated on a real deliverable, no open failures, and a **once-per-machine** marker at `~/.config/cargo-ai/.star-asked` (touched on yes or no). On approval, agents use `gh api -X PUT /user/starred/getcargohq/cargo-skills`; missing or unauthenticated `gh` is handled by sharing the URL only.
> 
> The **Automated on Claude Code** note is tightened: lifecycle hooks can handle refresh and session finalize, but **not** the two end-of-session Y/N asks (share and star).
> 
> `cargo/skill-metadata.json` **contentHash** is updated for the router skill doc change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c978b59e50c33c0067ef1bf1bf897f83889794e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->