### PR TITLE
Add README badges and surface the skills.sh install count

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Cargo Agent Skills — GTM engineering for AI coding agents
 
+[![cargo-ai cli](https://img.shields.io/npm/v/@cargo-ai/cli?label=cargo-ai%20cli&color=black)](https://www.npmjs.com/package/@cargo-ai/cli)
+[![skills.sh](https://img.shields.io/badge/skills.sh-17%20skills-black)](https://www.skills.sh)
+[![License](https://img.shields.io/github/license/getcargohq/cargo-skills?color=black)](LICENSE)
+
 Seventeen agent skills that turn Claude Code, Codex, Cursor, and any [skills.sh](https://skills.sh)-compatible agent into a go-to-market engineering workstation: **build lead lists, find and verify emails and phone numbers, enrich companies and contacts through provider waterfalls, score and qualify leads, write outreach, sync to your CRM, and monitor buying signals** (job changes, funding rounds, tech-stack and hiring intent) — then make any of it a scheduled, always-on workflow.
 
 They run on the [Cargo CLI](https://www.npmjs.com/package/@cargo-ai/cli) against [Cargo](https://getcargo.ai), the AI-native revenue infrastructure: **138 integrations** (HubSpot, Salesforce, Attio, Pipedrive, Outreach, Salesloft, Lemlist, Smartlead, Instantly, Snowflake, BigQuery, Slack, Google Ads, Meta and LinkedIn audiences, and more), **50 credits-based data providers** with per-action costs documented up front, models and SQL over workspace storage, AI agents with RAG, alerting, hosted apps, and a full workspace-as-code CDK.
@@ -42,7 +46,7 @@ The agent runs the whole setup itself: installs the CLI at the bundle's pinned v
 npx skills add getcargohq/cargo-skills
 ```
 
-Works with Claude Code, Cursor, Windsurf, GitHub Copilot, and any agent that supports the [skills.sh](https://skills.sh) standard.
+Works with Claude Code, Cursor, Windsurf, GitHub Copilot, and any agent that supports the [skills.sh](https://skills.sh) standard. These skills have been installed **54,885 times** across the bundle on skills.sh (August 2026).
 
 ### Just one job — `gtm-skills`
 


### PR DESCRIPTION
The repo has 54,885 skills.sh installs and 15 stars. Every registry gatekeeper reads stars as the trust proxy — awesome-claude-code says so explicitly — so the adoption number is worth making visible.

- **Badges** (none existed): live npm version for `@cargo-ai/cli`, a skills.sh link, and the MIT license. All three verified rendering.
- **Install count** stated in the manual-install section, dated.

Deliberately *not* a badge for the install total: shields' dynamic-JSON endpoint against the skills.sh API can only read a single skill's count, not the sum across 17, and it returned `inaccessible` on a repeat call during testing. A badge that intermittently renders an error is worse than none, so the number is prose that we update on purpose.

If we want it live later, a small edge worker on `cargo.app` could sum the API and serve the shields endpoint schema — dogfooding `cargo-hosting` for our own badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README edits with no runtime, auth, or data-handling impact.
> 
> **Overview**
> The README now surfaces **trust signals** at the top and in the manual install path.
> 
> Three **shields.io badges** were added under the title: live **npm** version for `@cargo-ai/cli`, a **skills.sh** link labeled with the 17-skill bundle size, and the **MIT license**. In **Manual — skills.sh**, the compatibility blurb now states the bundle has been installed **54,885 times** on skills.sh, with an **August 2026** date for manual refresh instead of a dynamic install-count badge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0575149a9aa6674db3d41fb219660312c40cbac9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->