### PR TITLE
Document Hermes Agent support and add skills.sh groupings

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,33 @@ The agent runs the whole setup itself: installs the CLI at the bundle's pinned v
 npx skills add getcargohq/cargo-skills
 ```
 
-Works with Claude Code, Cursor, Windsurf, GitHub Copilot, and any agent that supports the [skills.sh](https://skills.sh) standard. These skills have been installed **54,885 times** across the bundle on skills.sh (August 2026).
+Works with Claude Code, Codex, Cursor, Windsurf, GitHub Copilot, [Hermes Agent](#hermes-agent), and any agent that supports the [skills.sh](https://skills.sh) standard. These skills have been installed **54,885 times** across the bundle on skills.sh (August 2026).
+
+### Hermes Agent
+
+[Hermes](https://github.com/NousResearch/hermes-agent) reads the same `SKILL.md` standard, so all seventeen skills work there with no Cargo-side changes. Install them whichever way suits you:
+
+```bash
+# From inside Hermes, via the skills.sh source
+hermes skills install skills-sh/getcargohq/cargo-skills/cargo-gtm
+
+# Or straight from GitHub, one skill at a time
+hermes skills install getcargohq/cargo-skills/cargo-gtm
+
+# Or the whole bundle from outside Hermes
+npx skills add getcargohq/cargo-skills --agent hermes-agent
+```
+
+The last one writes all seventeen to `.hermes/skills/` (or `~/.hermes/skills/` with `-g`). Cross-skill references resolve because the skills land as siblings — the same layout every other channel uses.
+
+To subscribe to the whole repo as a [tap](https://hermes-agent.nousresearch.com/docs), add it and then point it at the repo root, since these skills live at the top level rather than under `skills/`:
+
+```bash
+hermes skills tap add getcargohq/cargo-skills
+# then set "path": "." for this entry in ~/.hermes/skills/.hub/taps.json
+```
+
+**Two things differ on Hermes.** The plugin channel below is Claude Code / Codex / Cursor only, so its approval hook doesn't apply — Hermes gates tool calls with its own approval policy, and its `pre_tool_call` hooks can only *block* a call, never pre-approve one. Expect `cargo-ai` commands to prompt. And with no bundled session-lifecycle hooks, [the session's three jobs](cargo/SKILL.md) (refresh, register, finalize) are the agent's to run by hand — the router skill already accounts for agents without lifecycle hooks.
 
 ### Just one job — `gtm-skills`
 

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://skills.sh/schemas/skills.sh.schema.json",
+  "notGrouped": "bottom",
+  "groupings": [
+    {
+      "title": "Start here — router",
+      "description": "Load first for anything Cargo, and whenever a task spans two domains.",
+      "skills": ["cargo"]
+    },
+    {
+      "title": "Onboarding",
+      "description": "Guided first run: one persona question to 25 real leads with a cost receipt, in under two minutes.",
+      "skills": ["cargo-quickstart"]
+    },
+    {
+      "title": "Outcome — go-to-market",
+      "description": "The front door for any GTM job: sourcing, enrichment, verification, scoring, outreach, CRM sync, signal monitoring.",
+      "skills": ["cargo-gtm"]
+    },
+    {
+      "title": "Run and build",
+      "description": "Execute actions, workflows, and batches; watch them; explain them when they misbehave.",
+      "skills": [
+        "cargo-orchestration",
+        "cargo-diagnostics",
+        "cargo-observability",
+        "cargo-analytics",
+        "cargo-billing"
+      ]
+    },
+    {
+      "title": "Data",
+      "description": "Models, columns, records, SQL over workspace storage, and the saved filters that name an audience.",
+      "skills": ["cargo-storage", "cargo-segmentation", "cargo-connection"]
+    },
+    {
+      "title": "AI and knowledge",
+      "description": "Agents, retrieval, MCP servers, memories, and the workspace's git-backed GTM context.",
+      "skills": ["cargo-ai", "cargo-content", "cargo-context"]
+    },
+    {
+      "title": "Ship and administer",
+      "description": "Hosted apps and edge workers, workspace-as-code, members, tokens, and folders.",
+      "skills": ["cargo-hosting", "cargo-cdk", "cargo-workspace-management"]
+    }
+  ]
+}


### PR DESCRIPTION
`should we support hermes too` — turns out we already do, and nothing said so.

## Verified, not assumed

`npx skills add getcargohq/cargo-skills --agent hermes-agent` installs **17/17** skills into `.hermes/skills/` with **0 broken cross-references** (the `../cargo-*/` paths resolve because the skills land as siblings). skills.sh lists Hermes Agent as a first-class target, and Hermes installs from skills.sh and ClawHub — both channels we already publish to. Hermes Agent is at 229k stars and shipping daily.

## What's here

**README** — a Hermes section with the three install paths that work today (skills-sh source, direct GitHub, `skills add`), plus the tap route with its caveat: `hermes skills tap add` defaults to `path: "skills/"` and our skills live at the repo root, so the entry needs `"path": "."` in `taps.json`. Restructuring into `skills/` would break every other channel, so documenting the one-line fix is the right trade.

**skills.sh.json** — groupings per the [skills.sh schema](https://skills.sh/schemas/skills.sh.schema.json). Two payoffs from one file: it sections our repo page on skills.sh, and Hermes reads the same file for Skills Hub categorization rather than guessing from tags. All 17 skills grouped exactly once (asserted in the commit).

## What does *not* port, and why the README says so

I'd planned to port `hooks/approve-cli.sh` as a fourth dialect. It can't be done. Hermes' `pre_tool_call` shell-hook protocol accepts only `{"decision": "block"}` / `{"action": "block"}`, and the Python `approve` directive *escalates* to the human gate rather than bypassing it. There is no auto-allow anywhere in the API — which is the entire purpose of our hook. So Hermes users will see approval prompts for `cargo-ai` calls, and the README now says that plainly instead of letting them discover it.

Session-lifecycle hooks (`on_session_start`/`on_session_end`) *do* exist and could carry jobs 1 and 3 later, but our current scripts are Claude-Code-shaped (the `claude -p` summarizer, `~/.claude/hooks/` mode detection). Not worth shipping untested against a live Hermes. The router skill already handles hookless agents, so the fallback is correct today.

Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and skills.sh metadata only; no runtime, auth, or CLI behavior changes.
> 
> **Overview**
> Documents **Hermes Agent** as a supported install target and adds **skills.sh** catalog metadata so the bundle is easier to browse on skills.sh and in Hermes Skills Hub.
> 
> The README now links Hermes in the manual install blurb and adds a dedicated section with three install paths (`hermes skills install` via skills.sh or GitHub, and `npx skills add … --agent hermes-agent`), plus tap setup with the **`"path": "."`** caveat for repo-root skills. It also calls out Hermes-specific behavior: no plugin auto-approve hook (expect `cargo-ai` prompts) and no bundled session-lifecycle hooks (session refresh/register/finalize are manual; the router skill already covers hookless agents).
> 
> A new **`skills.sh.json`** defines seven groupings that place all 17 skills exactly once (router, onboarding, GTM outcome, run/build, data, AI/knowledge, ship/admin), with unlisted skills falling to the bottom per schema.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ced2b878ec6f4217f4a319f82944046c90fa254. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->