### PR TITLE
Name the pack Cargo Skills in the README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Cargo Agent Skills — GTM engineering for AI coding agents
+# Cargo Skills — GTM engineering for AI coding agents
 
 [![cargo-ai cli](https://img.shields.io/npm/v/@cargo-ai/cli?label=cargo-ai%20cli&color=black)](https://www.npmjs.com/package/@cargo-ai/cli)
 [![skills.sh](https://img.shields.io/badge/skills.sh-17%20skills-black)](https://www.skills.sh)


### PR DESCRIPTION
We ship **three** names today:

| Name | Where |
|---|---|
| Cargo | every plugin manifest `displayName`, `marketplace.json`, the Gemini manifest |
| Cargo Skills | the CLI's npm README |
| Cargo Agent Skills | this README's H1 |

Three names build recall for none. This settles on **two, deliberately**:

- **"Cargo"** in-product — the plugin list, `displayName`, `/plugin install cargo@cargo`. Already consistent, and context disambiguates there.
- **"Cargo Skills"** everywhere external — this title, directories, listings.

Why not the short name externally: in a developer-tool catalog, "Cargo" is Rust's package manager. Searching the 2,281-plugin Anthropic community registry for "cargo" returns *only* Rust tooling — `cargo-deny`, `Cargo.toml` parsing, "npm, pip, Cargo, NuGet", even one plugin warning against "cargo-culting". None of them us. "Cargo Skills" also matches the repo slug that renders right beside the name in every listing.

Why not "Agent Skills": it's the proper noun of the open standard and carries some category weight, but matching our own URL wins, and it reads redundant inside a directory category already called Skills.

Already applied to the pending awesome-ai-plugins entry (hashgraph-online/awesome-ai-plugins#72) before review.

One line. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only heading change with no impact on code, installs, or runtime behavior.
> 
> **Overview**
> Renames the README **H1** from **Cargo Agent Skills** to **Cargo Skills** so external-facing branding matches the repo slug and listings, while in-product naming stays **Cargo**.
> 
> No functional, install, or skill content changes—title line only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76aef2e5c354b9497dc82d1c94b41df705600986. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->