### PR TITLE
Describe what the marketplaces actually ship

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,12 +1,12 @@
 {
   "name": "cargo",
   "interface": { "displayName": "Cargo" },
-  "metadata": { "description": "Official Cargo plugin for Codex" },
+  "metadata": { "description": "The Cargo pack for Codex — 17 GTM skills, plus what a plain skills install doesn't carry: prompt-free approval for safe cargo-ai calls." },
   "plugins": [
     {
       "name": "cargo",
       "source": { "source": "local", "path": "./" },
-      "description": "Cargo GTM agent skills — sourcing, enrichment, orchestration, workspace-as-code (CDK), diagnostics, and analytics via the cargo-ai CLI.",
+      "description": "17 skills over the cargo-ai CLI — build target account and contact lists, enrich and verify them against licensed data providers, score and qualify leads, sync your CRM, monitor buying signals, run workflows, and manage the whole workspace as code.",
       "policy": { "installation": "AVAILABLE", "authentication": "ON_INSTALL" }
     }
   ]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,13 +1,13 @@
 {
   "name": "cargo",
   "owner": { "name": "Cargo", "url": "https://getcargo.ai" },
-  "metadata": { "description": "Official Cargo plugin for Claude Code" },
+  "metadata": { "description": "The Cargo pack for Claude Code — 17 GTM skills, plus what a plain skills install doesn't carry: prompt-free approval for safe cargo-ai calls, and session-lifecycle hooks that keep the CLI pinned and record each session." },
   "plugins": [
     {
       "name": "cargo",
       "displayName": "Cargo",
       "source": "./",
-      "description": "Cargo GTM agent skills — sourcing, enrichment, orchestration, workspace-as-code (CDK), diagnostics, and analytics via the cargo-ai CLI."
+      "description": "17 skills over the cargo-ai CLI — build target account and contact lists, enrich and verify them against licensed data providers, score and qualify leads, sync your CRM, monitor buying signals, run workflows, and manage the whole workspace as code."
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -1,12 +1,12 @@
 {
   "name": "cargo",
   "owner": { "name": "Cargo", "url": "https://getcargo.ai" },
-  "metadata": { "description": "Official Cargo plugin for Cursor" },
+  "metadata": { "description": "The Cargo pack for Cursor — 17 GTM skills, plus what a plain skills install doesn't carry: prompt-free approval for safe cargo-ai calls." },
   "plugins": [
     {
       "name": "cargo",
       "source": "./",
-      "description": "Cargo GTM agent skills — sourcing, enrichment, orchestration, workspace-as-code (CDK), diagnostics, and analytics via the cargo-ai CLI."
+      "description": "17 skills over the cargo-ai CLI — build target account and contact lists, enrich and verify them against licensed data providers, score and qualify leads, sync your CRM, monitor buying signals, run workflows, and manage the whole workspace as code."
     }
   ]
 }


### PR DESCRIPTION
All three manifests carried placeholder copy: `"Official Cargo plugin for <target>"` as the marketplace description, and a plugin blurb that listed subsystems ("sourcing, enrichment, orchestration, workspace-as-code (CDK), diagnostics, and analytics") rather than what a user gets.

**Plugin description** now leads with the count and the actual work, and says contact data comes from **licensed data providers** — "sourcing, enrichment" reads as scraping to anyone who hasn't used the product, which is the wrong first impression in a plugin browser.

**Marketplace description** now names what each channel adds over a plain `skills add`, and that genuinely differs per target: Claude Code gets the approval hook *and* session-lifecycle hooks, Codex and Cursor get the approval hook only.

Deliberately unchanged: `name`, `plugins[].name`, `displayName` ("Cargo" stays — in-product, where `cargo@cargo` disambiguates), `source`, and the Codex `policy` block. Done as string replacement rather than a JSON round-trip, so the diff is six lines instead of a whole-file reformat.

Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only JSON string updates in marketplace manifests; no runtime or security behavior changes.
> 
> **Overview**
> Updates **marketplace** and **plugin** description strings in `.agents`, `.claude-plugin`, and `.cursor-plugin` `marketplace.json` files so plugin browsers show what users actually get instead of generic “Official Cargo plugin” copy.
> 
> **Plugin descriptions** now lead with **17 skills** and concrete GTM outcomes (lists, enrichment via **licensed data providers**, CRM sync, signals, workflows, workspace-as-code), replacing subsystem jargon that could read like scraping.
> 
> **Marketplace descriptions** are **per channel**: Claude Code highlights prompt-free safe `cargo-ai` approval plus session-lifecycle hooks; Codex and Cursor highlight approval-only extras over a plain skills install. Names, sources, and Codex `policy` are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5893256cf298306777862b1917d97e96f2f2dacc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->