### PR TITLE
Add a well-known front door so skills add getcargo.ai installs the bundle

### DIFF
--- a/.github/scripts/build-well-known.mjs
+++ b/.github/scripts/build-well-known.mjs
@@ -1,0 +1,73 @@
+// Build (or check) .well-known/agent-skills/index.json.
+//
+// WHY THIS EXISTS
+//
+// getcargo.ai proxies /.well-known/agent-skills/* to this directory on raw
+// GitHub, so `npx skills add getcargo.ai` resolves through RFC 8615 discovery
+// and lands on the front-door skill here, which then installs the real bundle.
+//
+// The index carries a sha256 digest per entry, and the skills CLI VERIFIES it:
+// providers/wellknown.ts rejects an entry whose bytes do not hash to the
+// declared digest, and it does so by returning nothing rather than by raising.
+// So an index that drifts from its skill.md does not fail loudly, it makes the
+// install quietly find no skill. That is why this is generated and checked in
+// CI rather than hand-maintained.
+import { createHash } from "node:crypto";
+import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const DIR = join(ROOT, ".well-known", "agent-skills");
+const INDEX = join(DIR, "index.json");
+const SCHEMA = "https://schemas.agentskills.io/discovery/0.2.0/schema.json";
+
+/** Frontmatter is a flat block here by construction; no YAML dependency. */
+function frontmatterField(text, field) {
+  if (!text.startsWith("---\n")) throw new Error("missing frontmatter");
+  const block = text.slice(4, text.indexOf("\n---", 3));
+  for (const line of block.split("\n")) {
+    const match = line.match(new RegExp(`^${field}:\\s*(.+)$`));
+    if (match) return match[1].trim().replace(/^["']|["']$/g, "");
+  }
+  throw new Error(`missing \`${field}\` in frontmatter`);
+}
+
+function build() {
+  const skills = readdirSync(DIR, { withFileTypes: true })
+    .filter((e) => e.isDirectory() && existsSync(join(DIR, e.name, "skill.md")))
+    .map((e) => e.name)
+    .sort()
+    .map((name) => {
+      const bytes = readFileSync(join(DIR, name, "skill.md"));
+      return {
+        name,
+        type: "skill-md",
+        description: frontmatterField(bytes.toString("utf8"), "description"),
+        // Relative, so it resolves against whichever host served the index.
+        url: `${name}/skill.md`,
+        digest: `sha256:${createHash("sha256").update(bytes).digest("hex")}`,
+      };
+    });
+  if (skills.length === 0) throw new Error(`no skill.md found under ${DIR}`);
+  return `${JSON.stringify({ $schema: SCHEMA, skills }, null, 2)}\n`;
+}
+
+const built = build();
+
+if (process.argv.includes("--check")) {
+  const current = existsSync(INDEX) ? readFileSync(INDEX, "utf8") : "";
+  if (current !== built) {
+    console.error(
+      "error .well-known/agent-skills/index.json is stale.\n" +
+        "      Run `node .github/scripts/build-well-known.mjs` and commit the result.\n" +
+        "      Left as is, the digest will not match the skill and `skills add\n" +
+        "      getcargo.ai` will install nothing at all, without an error.",
+    );
+    process.exit(1);
+  }
+  console.log(`well-known index: in sync (${JSON.parse(built).skills.length} skill(s))`);
+} else {
+  writeFileSync(INDEX, built);
+  console.log(`well-known index: wrote ${JSON.parse(built).skills.length} skill(s)`);
+}

--- a/.github/workflows/skills-lint.yml
+++ b/.github/workflows/skills-lint.yml
@@ -60,6 +60,15 @@ jobs:
       - name: Run the skill-load detector's self-test
         run: bash hooks/skill-loads.sh --self-test
 
+      # The well-known index declares a sha256 per skill and the skills CLI
+      # verifies it, returning no skill rather than an error when it does not
+      # match. So a stale index does not break loudly, it makes
+      # `npx skills add getcargo.ai` install nothing at all. Verified both ways
+      # against the real CLI: correct digest installs, corrupted digest fails
+      # with zero files written.
+      - name: Check the well-known index matches its skills
+        run: node .github/scripts/build-well-known.mjs --check
+
   routing-evals:
     name: Route prompts to the right skill
     runs-on: ubuntu-latest

--- a/.well-known/agent-skills/cargo-install/skill.md
+++ b/.well-known/agent-skills/cargo-install/skill.md
@@ -1,0 +1,75 @@
+---
+name: cargo-install
+description: Install the Cargo skill bundle and sign in, so the full set of Cargo capabilities becomes available. Use when someone reaches Cargo by its domain rather than by its repository, when a Cargo command is wanted but `cargo-ai` is not installed, or when a Cargo skill is referenced and not present. Triggers, "set up Cargo", "install Cargo", "I want to use Cargo", "cargo-ai is not found". Skip when the bundle is already installed, in which case load the `cargo` router instead.
+version: "1.0.0"
+homepage: https://github.com/getcargohq/cargo-skills
+metadata:
+  author: getcargo
+---
+
+# Installing Cargo
+
+Cargo is a go-to-market platform you drive from the terminal or from a coding
+agent: source and enrich B2B contact data, run workflows and AI agents against
+your own data models, and declare an entire workspace as version-controlled
+TypeScript.
+
+**This skill is the front door, not the product.** It exists because
+`getcargo.ai` is the address people type, while the skills live in a
+repository. Everything below installs the real bundle. Run it once, then use
+the `cargo` router it installs.
+
+## 1. Install the CLI
+
+```sh
+npm install -g @cargo-ai/cli
+```
+
+Verify with `cargo-ai --version`. If the binary is not on `PATH`, check
+`"${CARGO_NPM_USER_PREFIX:-$HOME/.local}/bin/cargo-ai"`, or substitute
+`npx @cargo-ai/cli` for `cargo-ai` in every command below.
+
+## 2. Install the bundle, on one channel only
+
+Pick the channel for the agent you are, and use exactly one. Installing both
+the plugin and the standalone skills gives every skill twice.
+
+| Agent | Command |
+| --- | --- |
+| Claude Code | `/plugin install cargo@cargo` |
+| Codex, Cursor, others | `npx skills add getcargohq/cargo-skills --all` |
+
+The plugin carries the same skills plus an approval hook and session hooks that
+`skills add` cannot deliver, which is why it is preferred where it is
+available.
+
+Job-shaped skills for one task at a time, rather than the whole platform, live
+separately: `npx skills add getcargohq/gtm-skills --all`, or a single one with
+`npx skills add getcargohq/gtm-skills/find-work-email`.
+
+## 3. Sign in
+
+```sh
+cargo-ai login --email      # emailed code, no browser, works headless
+cargo-ai login --oauth      # device flow, opens a browser
+```
+
+Either creates an account when the user has none, so there is no signup step to
+do first and no purchase gate before a real result. New workspaces start with
+free credits.
+
+## 4. Confirm it worked
+
+```sh
+cargo-ai storage model list
+```
+
+A list of data models means the CLI is installed, authenticated, and pointed at
+a workspace. Then load the `cargo` skill, which routes to the right one of the
+bundle for whatever comes next.
+
+## If any step fails
+
+`https://api.getcargo.io/agent-install.txt` is the full sequence written for an
+agent to execute, with a verification step after each one and the per-platform
+branches spelled out. Fetch it and follow it rather than guessing.

--- a/.well-known/agent-skills/index.json
+++ b/.well-known/agent-skills/index.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
+  "skills": [
+    {
+      "name": "cargo-install",
+      "type": "skill-md",
+      "description": "Install the Cargo skill bundle and sign in, so the full set of Cargo capabilities becomes available. Use when someone reaches Cargo by its domain rather than by its repository, when a Cargo command is wanted but `cargo-ai` is not installed, or when a Cargo skill is referenced and not present. Triggers, \"set up Cargo\", \"install Cargo\", \"I want to use Cargo\", \"cargo-ai is not found\". Skip when the bundle is already installed, in which case load the `cargo` router instead.",
+      "url": "cargo-install/skill.md",
+      "digest": "sha256:6a9b0d14ac093ebea2e4d12bc68f55e2b5b51eec5b7d690c14899aa3024649bd"
+    }
+  ]
+}


### PR DESCRIPTION
`npx skills add getcargo.ai` 404s today. Every marketing host redirects to `www.getcargo.ai`, which serves neither well-known path, so the address people actually type does nothing.

## Why not just point the domain at docs

That was the first attempt ([`getcargohq/cargo#5593`](https://github.com/getcargohq/cargo/pull/5593), closed). `docs.getcargo.ai` already answers both well-known paths, so proxying looked free. It is not: **the skill served there is not this repo.**

| | served at `docs.getcargo.ai` | `cargo/SKILL.md` here |
| --- | --- | --- |
| size | 13,482 bytes | **53,591 bytes** |
| version | `1.0` | **`1.20.1`** |
| description | "Use when building GTM automation workflows, defining data models and connectors…" | "Router for the Cargo CLI skill bundle, load first for anything Cargo…" |

It carries `metadata: mintlify-proj: cargo`, `apps/documentation` has no `.well-known` directory, and `docs.json` has no skills key. Mintlify generates it, switched on outside the repo. `npx skills add docs.getcargo.ai` installs it right now.

## What this does instead

Serves a **front door** that installs the pack from its real address, rather than serving the pack from a second address.

That keeps the install counter whole, which was the main objection to a domain source: the pack install still reports `source=getcargohq/cargo-skills`, and only the one front-door skill counts against the domain.

It is a real front door, not a bare redirect: what Cargo is, the CLI prerequisite, the one channel per agent (plugin on Claude Code, `skills add` elsewhere, never both), sign-in, and a verification command. A skill whose entire body is "install this other thing" is the doorway pattern OpenAI cited when it rejected `cargo-gtm` for spam in August, and this repo should not ship one.

## Why the index is generated and gated

`providers/wellknown.ts` requires a `sha256:` digest per entry and **verifies** it, returning no skill rather than raising when it mismatches (`:347` validates, `:482` rejects). A stale index does not fail loudly, it makes the install find nothing at all. So `build-well-known.mjs` generates the index from the skill files, and `--check` gates it in `skills-lint`.

## Verified against the real CLI

Served this directory over localhost and ran `npx skills@latest add`:

| | Result |
| --- | --- |
| `--list` | discovers the source, lists `cargo-install` with its description |
| `--all` | installs it, frontmatter and body intact |
| `--all`, digest corrupted to `sha256:000…` | "Installation failed", **zero files written** |

That last row is why the CI check exists.

The existing linters are unaffected and both still exit 0: `skills-lint.mjs` skips dot-directories, and `generate-llms-txt.ts` looks for `<dir>/SKILL.md` at the root, so nothing here enters the bundle or `llms.txt`.

## What this does not do

- **It is not reachable until the website proxies to it.** That is the companion PR on `getcargohq/cargo`. Merging this alone changes nothing that is served.
- **It will not get `getcargo.ai` listed on skills.sh.** `docs.getcargo.ai` has served a valid index the whole time and is not a source there, so serving the file is demonstrably not what decides listing.
- **It does not turn off the Mintlify one.** That is a dashboard setting, and until it is off, `docs.getcargo.ai` and `getcargo.ai` answer with two different skills.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New discovery assets and a CI sync check only; no runtime app, auth, or data-path changes until the website proxy lands.
> 
> **Overview**
> Adds **`.well-known/agent-skills/`** so domain-based skills discovery can resolve `getcargo.ai` to a single **`cargo-install`** skill that walks agents through CLI install, one install channel per agent, sign-in, and verification—then points them at the real **`getcargohq/cargo-skills`** bundle instead of serving the full pack from the marketing domain.
> 
> **`build-well-known.mjs`** scans skill directories, builds **`index.json`** with descriptions and **`sha256:`** digests from each **`skill.md`**, and supports **`--check`** so CI fails when the committed index drifts (the skills CLI silently skips mismatched digests). **`skills-lint.yml`** runs that check in the QA job.
> 
> **Note:** Nothing is user-visible until the site proxies **`/.well-known/agent-skills/*`** to this repo (companion change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 507c5904ee77ac172bf72db4cb789be57ee91f03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->