### PR TITLE
Document relationships and unification, which the CLI has always had

### DIFF
--- a/cargo-storage/SKILL.md
+++ b/cargo-storage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cargo-storage
-description: "Work with the data inside a Cargo workspace — models (Companies, Contacts, Deals…), datasets, columns, relationships, records, and SQL over workspace storage. Triggers: \"what models do I have\", \"show me the schema\", \"add a column for\", \"how many contacts do I have\", \"SELECT … FROM\", \"query my companies table\", \"join contacts to companies\", \"what is the DDL\", \"set up a webhook-fed model\", \"where does this field live\", \"import this into a model\". Skip when: querying run or batch telemetry rather than business data — use cargo-orchestration; naming a reusable filtered audience — use cargo-segmentation."
+description: "Work with the data inside a Cargo workspace — models (Companies, Contacts, Deals…), datasets, columns, relationships, records, and SQL over workspace storage. Triggers: \"what models do I have\", \"show me the schema\", \"add a column for\", \"how many contacts do I have\", \"SELECT … FROM\", \"query my companies table\", \"join contacts to companies\", \"what is the DDL\", \"set up a webhook-fed model\", \"where does this field live\", \"import this into a model\", \"unify these models\", \"merge duplicate accounts\", \"link contacts to companies\", \"set up a relationship between\". Skip when: querying run or batch telemetry rather than business data — use cargo-orchestration; naming a reusable filtered audience — use cargo-segmentation."
 version: "1.2.1"
 compatibility: Requires @cargo-ai/cli (npm). Sign in or create an account with `cargo-ai login --email` (emailed code, no browser), `--oauth`, or an API token
 homepage: https://github.com/getcargohq/cargo-skills
@@ -20,7 +20,7 @@ metadata:
 
 # Cargo CLI — Storage
 
-Data layer management: inspecting and modifying models, datasets, columns, relationships, and records, and running SQL queries against workspace storage.
+Data layer management: inspecting and modifying models, datasets, columns, relationships, unification, and records, and running SQL queries against workspace storage.
 
 > See `references/response-shapes.md` for full JSON response structures.
 > See `references/troubleshooting.md` for common errors and how to fix them.
@@ -63,7 +63,7 @@ cargo-ai storage model get <model-uuid>
 cargo-ai storage model get-ddl <model-uuid>
 cargo-ai storage dataset list
 cargo-ai storage column list --model-uuid <uuid>
-cargo-ai storage relationship list --model-uuid <uuid>
+cargo-ai storage relationship list
 cargo-ai storage record list --model-uuid <uuid>
 cargo-ai storage query execute "SELECT * FROM default.companies LIMIT 10"
 cargo-ai storage query download --query "SELECT * FROM default.companies"
@@ -187,17 +187,88 @@ If the preview comes back empty or all-null when it shouldn't, that's a finding 
 
 ## Relationships
 
-Relationships link models together (e.g. Contacts belong to Companies).
+Relationships link models together (e.g. Contacts belong to Companies). They are
+authored from the CLI, not just the UI.
+
+`relationship list` takes **no flags** — it returns every relationship in the
+workspace. Filter client-side on `fromModelUuid` / `toModelUuid`.
 
 ```bash
-# List relationships for a model
-cargo-ai storage relationship list --model-uuid <uuid>
-
-# Set a relationship between two models
-cargo-ai storage relationship set \
-  --from-model-uuid <uuid> \
-  --to-model-uuid <uuid>
+cargo-ai storage relationship list
 ```
+
+**`relationship set` replaces the dataset's whole relationship set.** It takes a
+dataset and the complete list that should exist within it: entries carrying a
+`uuid` are updated, entries without one are created, and **any existing
+relationship whose `uuid` is absent from the payload is deleted**. Sending one
+relationship to a dataset that has five removes the other four. Always `list`
+first, then send back the full array with your addition:
+
+```bash
+cargo-ai storage relationship set \
+  --dataset-uuid <dataset-uuid> \
+  --relationships '[
+    {"uuid":"<existing-uuid>","fromModelUuid":"<contacts-uuid>","fromColumnSlug":"account_id","toModelUuid":"<companies-uuid>","toColumnSlug":"id","relation":"manyToOne"},
+    {"fromModelUuid":"<deals-uuid>","fromColumnSlug":"company_id","toModelUuid":"<companies-uuid>","toColumnSlug":"id","relation":"manyToOne"}
+  ]'
+```
+
+`relation` is `oneToOne`, `manyToOne`, or `oneToMany`. Both models must live in
+the dataset you pass — relationships never span datasets, so `fromDatasetUuid`
+and `toDatasetUuid` on the response always equal `--dataset-uuid`.
+
+Failure reasons: `datasetNotFound`; `invalidRelationships` (a column slug or
+model UUID that doesn't resolve, or a duplicate — including the same pair stated
+in reverse); `modelNotCompatible` (see below).
+
+**Unify models refuse manual relationships.** In the native dataset, a unify
+model's relationships are generated during sync, so naming one as `fromModelUuid`
+or `toModelUuid` returns `modelNotCompatible`. Those auto-generated rows are also
+excluded from the replace above, so a `set` call cannot delete them.
+
+## Unification
+
+Unification is what merges records from several source models into one canonical
+account/contact — and it is **configurable from the CLI**, via `--unification` on
+`model update`. Pass `null` to clear it.
+
+```bash
+# Connector-driven: the integration decides how records unify
+cargo-ai storage model update --uuid <model-uuid> --unification '{"source":"integration"}'
+
+# Custom: you name the type, the matching keys, and optionally a parent
+cargo-ai storage model update --uuid <model-uuid> --unification '{
+  "source": "custom",
+  "type": "account",
+  "uniqueColumns": [{"slug":"domain","reference":"domain"}],
+  "selectedColumnSlugs": ["name","industry","employee_count"],
+  "parent": {"kind":"model","columnSlug":"account_id","parentModelUuid":"<accounts-uuid>"}
+}'
+```
+
+| Field | Applies to | Meaning |
+|---|---|---|
+| `source` | both | `integration` (connector-defined) or `custom` |
+| `type` | custom | `account`, `contact`, `accountEvent`, `contactEvent` |
+| `uniqueColumns` | custom | Match keys — `{slug, reference}` per column. This is what decides which rows are the same entity |
+| `selectedColumnSlugs` | custom | Columns carried into the unified model. Omit for all |
+| `timeColumnSlug` | custom | Event timestamp — for the two `*Event` types |
+| `parent` | custom | Links contacts/events to their account: `{"kind":"model","columnSlug":…,"parentModelUuid":…}` or `{"kind":"reference","columnSlug":…,"reference":…}` |
+| `filter` | custom | Segmentation filter restricting which rows unify — same `conjonction` shape as segments |
+
+**Writing the config does not recompute anything.** The unified rows are rebuilt
+by the model's sync run, so follow the update with a run and poll it:
+
+```bash
+cargo-ai storage run create --model-uuid <model-uuid>
+cargo-ai storage run list --model-uuid <model-uuid>
+```
+
+Get the current config from `storage model get <uuid>` → `unification` (`null`
+when the model doesn't unify). Once the run finishes, check the row count with
+`storage query execute` before treating the change as done — a too-narrow
+`uniqueColumns` under-merges and a too-broad one collapses distinct entities, and
+both look like a successful run.
 
 ## Records
 

--- a/cargo-storage/references/response-shapes.md
+++ b/cargo-storage/references/response-shapes.md
@@ -25,6 +25,7 @@ JSON response structures returned by Cargo CLI commands used in the `cargo-stora
         { "slug": "full_name", "type": "string", "label": "Full Name", "kind": "computed", "expression": { "kind": "jsExpression", "expression": "..." }, "columnsUsed": ["first_name", "last_name"] },
         { "slug": "total_deals", "type": "number", "label": "Total Deals", "kind": "metric", "relationshipUuid": "...", "aggregation": { "function": "count", "columnSlug": "uuid" } }
       ],
+      "unification": null,
       "playsCount": 2,
       "segmentsCount": 1,
       "isPaused": false,
@@ -43,6 +44,11 @@ JSON response structures returned by Cargo CLI commands used in the `cargo-stora
 ```
 
 **Key fields:** `uuid`, `slug`, `name`, `datasetUuid`, `idColumnSlug`, `columns` (original columns), `additionalColumns` (custom/computed/metric/lookup columns).
+
+`unification` is `null` unless the model unifies. When set it is either
+`{"source":"integration"}` or the `custom` shape (`type`, `uniqueColumns`,
+optionally `selectedColumnSlugs` / `timeColumnSlug` / `parent` / `filter`) —
+see the Unification section of `SKILL.md`.
 
 Columns have no `uuid` — they are identified by `slug` within the model.
 
@@ -176,15 +182,26 @@ Kind-specific fields are included alongside the base fields:
   "relationships": [
     {
       "uuid": "relationship-uuid",
+      "workspaceUuid": "workspace-uuid",
+      "fromDatasetUuid": "dataset-uuid",
       "fromModelUuid": "contacts-model-uuid",
+      "fromColumnSlug": "account_id",
+      "fromPropertySlug": "hubspot___contacts[0]",
+      "toDatasetUuid": "dataset-uuid",
       "toModelUuid": "companies-model-uuid",
-      "fromColumnSlug": "company_uuid",
-      "toColumnSlug": "uuid",
+      "toColumnSlug": "id",
       "relation": "manyToOne"
     }
   ]
 }
 ```
+
+Workspace-wide — the command takes no flags. `fromDatasetUuid` always equals
+`toDatasetUuid`. `fromPropertySlug` / `toPropertySlug` appear only where the
+relationship keys off a nested property of a connector column.
+
+`relationship set` returns the same shape, holding the dataset's full set after
+the replace.
 
 ## cargo-ai storage record list
 

--- a/cargo-storage/references/troubleshooting.md
+++ b/cargo-storage/references/troubleshooting.md
@@ -31,8 +31,20 @@ Common errors and recovery steps for `cargo-storage` commands.
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| `relationship set` fails | One or both model UUIDs are wrong | Verify both model UUIDs with `model list` |
-| `relationship list` returns empty | No relationships defined for that model | This is expected if relationships haven't been configured yet |
+| Relationships disappeared after a `set` | `relationship set` replaces the dataset's whole set — anything whose `uuid` is missing from the payload is deleted | `relationship list` first, then send the full array back with your addition, keeping each existing `uuid` |
+| `invalidRelationships` | A model UUID or column slug doesn't resolve, or the payload duplicates a pair (including stated in reverse) | Verify UUIDs with `model list` and slugs with `column list --model-uuid <uuid>` |
+| `modelNotCompatible` | A unify model was named as `fromModelUuid` or `toModelUuid` | Unify-model relationships are generated during sync and can't be authored by hand |
+| `datasetNotFound` | `--dataset-uuid` is wrong, or the two models live in different datasets | Relationships never span datasets; confirm with `model list` → `datasetUuid` |
+| `relationship list` returns everything | It takes no flags and is workspace-wide by design | Filter client-side on `fromModelUuid` / `toModelUuid` |
+
+## Unification
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `model update --unification` succeeded but nothing merged | Writing the config doesn't recompute; unified rows are rebuilt by the sync run | `storage run create --model-uuid <uuid>`, then poll `storage run list --model-uuid <uuid>` |
+| Duplicates survive unification | `uniqueColumns` is too narrow, or the match key is dirty (mixed case, `www.` prefixes) | Widen or normalize the key, then re-run |
+| Distinct entities merged into one | `uniqueColumns` is too broad (e.g. matching on a shared generic domain) | Add a second key column, or scope with `filter` |
+| Contacts not attached to accounts | `parent` is unset on a `contact` unification | Set `parent` to the account model and the joining column slug |
 
 ## Records
 

--- a/cargo/SKILL.md
+++ b/cargo/SKILL.md
@@ -467,6 +467,7 @@ The non-obvious rules for each skill — the things that fail silently or cost m
 - Query via `cargo-ai storage query execute "<sql>"` (or `storage query download --query "<sql>"` for full exports) using `<datasetSlug>.<modelSlug>` table names (e.g. `default.companies`). `model get-ddl` is optional — useful for column types and SQL dialect.
 - For SQL against orchestration runtime tables (`runs`/`batches`/`spans`/`records`), use `cargo-ai orchestration query execute "<sql>"` — documented in `cargo-orchestration`.
 - For advanced record queries (filtering, sorting, pagination), use `segmentation segment fetch` — documented in `cargo-segmentation`.
+- **Relationships and unification are CLI-authorable, not UI-only.** `storage relationship set` and `storage model update --unification` both exist. Two traps: `relationship set` **replaces** the dataset's whole set (anything absent from the payload is deleted — `list` first, send the full array back), and `--unification` only writes config, so the merge does not happen until a `storage run create --model-uuid <uuid>`.
 
 ### cargo-segmentation
 

--- a/cargo/SKILL.md
+++ b/cargo/SKILL.md
@@ -467,7 +467,7 @@ The non-obvious rules for each skill — the things that fail silently or cost m
 - Query via `cargo-ai storage query execute "<sql>"` (or `storage query download --query "<sql>"` for full exports) using `<datasetSlug>.<modelSlug>` table names (e.g. `default.companies`). `model get-ddl` is optional — useful for column types and SQL dialect.
 - For SQL against orchestration runtime tables (`runs`/`batches`/`spans`/`records`), use `cargo-ai orchestration query execute "<sql>"` — documented in `cargo-orchestration`.
 - For advanced record queries (filtering, sorting, pagination), use `segmentation segment fetch` — documented in `cargo-segmentation`.
-- **Relationships and unification are CLI-authorable, not UI-only.** `storage relationship set` and `storage model update --unification` both exist. Two traps: `relationship set` **replaces** the dataset's whole set (anything absent from the payload is deleted — `list` first, send the full array back), and `--unification` only writes config, so the merge does not happen until a `storage run create --model-uuid <uuid>`.
+- `storage relationship set` **replaces** the dataset's whole relationship set — anything absent from the payload is deleted. `list` first, send the full array back.
 
 ### cargo-segmentation
 


### PR DESCRIPTION
## Why

A customer conversation landed on "you can't do unification and relationships between models in CLI". Both have been in the CLI for a long time — `relationship set` since #4327, `model update --unification` since before that. The claim came from our own docs being wrong.

`cargo-storage/SKILL.md` documented three flags that do not exist:

```bash
cargo-ai storage relationship list --model-uuid <uuid>      # list takes no flags
cargo-ai storage relationship set --from-model-uuid <uuid> \
                                  --to-model-uuid <uuid>    # invented
```

The real surface is `relationship list` (no flags, workspace-wide) and `relationship set --dataset-uuid --relationships <json array>`. Unification appeared **nowhere** in the pack — zero hits across `cargo-storage` and `cargo-cdk`.

So an agent reads the skill, runs the documented command, gets rejected on an unknown flag, finds nothing about unification at all, and concludes UI-only. Which is exactly what happened.

## What changed

- **Relationships** — corrected flags, plus the two things that aren't guessable: `set` is a **full replace scoped to the dataset** (anything whose `uuid` is absent from the payload is deleted — sending one relationship to a dataset holding five removes four), and unify models refuse manual relationships with `modelNotCompatible`.
- **Unification** — new section: both `source` variants, a field table for the `custom` shape (`type`, `uniqueColumns`, `selectedColumnSlugs`, `timeColumnSlug`, `parent`, `filter`), and the fact that **writing the config recomputes nothing** — the merge happens on the model's sync run, so it needs a `storage run create`.
- **Troubleshooting** — replaced two vague relationship rows with the real failure reasons (`datasetNotFound`, `invalidRelationships`, `modelNotCompatible`, the silent-delete symptom), and added a unification table covering under-merge and over-merge.
- **Response shapes** — real `relationship list` output (`workspaceUuid`, `fromDatasetUuid`/`toDatasetUuid`, `fromPropertySlug`), and `unification` on the model shape.
- **Router recap** — one line in `cargo/SKILL.md` for the only rule here that fails silently: `relationship set` deletes anything absent from the payload. Sits next to the `conjonction` rule, same class.
- **Routing triggers** — "unify these models", "merge duplicate accounts", "link contacts to companies", "set up a relationship between".

## Verification

Every command and shape checked against the installed CLI (1.0.61, matching the published version) and against `origin/master` in `getcargohq/cargo` — `packages/cli/src/commands/storage/{relationship,model}.ts`, the v1 routes under `http/routes/v1/storage/relationship/`, `storage/validation.ts` for the `modelUnification` union and the `relation` enum, and `services/relationship/set.ts` for the replace semantics. `relationship list` was run live to capture the response shape.

## Not in scope

`packages/cdk` exports several builders the `cargo-cdk` skill never mentions — `defineRelationship`, `defineDomain`, `defineMailbox`, `defineCapacity`, `defineCustomIntegration`. Same class of gap, bigger surface; worth its own pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JU1NTvKaBEiLDaAAnFW2ho

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only skill pack updates; no runtime, API, or CLI code changes. The main residual risk is agents following the new replace semantics incorrectly if they skip `list` first — which the docs now warn about.
> 
> **Overview**
> Corrects `cargo-storage` skill docs so agents can author **relationships** and **unification** from the CLI instead of treating them as UI-only.
> 
> `relationship list` is now documented as workspace-wide (no `--model-uuid`). `relationship set` is a **full replace** on `--dataset-uuid` + a JSON array — missing `uuid`s are deleted. Unify models cannot take manual relationships (`modelNotCompatible`).
> 
> Adds a **Unification** section for `model update --unification` (`integration` vs `custom` fields). Writing config does not merge rows; a sync run is required. Routing triggers, response shapes, troubleshooting, and the router recap call out the replace trap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8ea16207c8dbe7d5d3079dc00335a737f79f47f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

